### PR TITLE
Using ipyvolume 0.5, enabled Jupyter Lab, and merge two rebased branches of bqplot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - (cd ipyvolume; pip install -v .)
   - pip uninstall bqplot -y
   - git clone https://github.com/maartenbreddels/bqplot
-  - (cd bqplot; git checkout scatter_webgl; pip install -v .)
+  - (cd bqplot; git checkout scatter_webgl; git merge image_colormap_frontend; pip install -v .)
   - conda info -a
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - (cd ipyvolume; pip install -v .)
   - pip uninstall bqplot -y
   - git clone https://github.com/maartenbreddels/bqplot
-  - (cd bqplot; git checkout scatter_webgl; git merge image_colormap_frontend; pip install -v .)
+  - (cd bqplot; git checkout scatter_webgl; git merge --no-edit origin/image_colormap_frontend; pip install -v .)
   - conda info -a
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - source ci-helpers/travis/setup_conda.sh
 
   - export MPLBACKEND='Agg';
-
+  - conda install -c conda-forge nodejs
   - conda env update -n test -f environment.yml
   - pip install -v pytest pytest-cov runipy
 #  - bash postBuild

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,5 +9,6 @@ dependencies:
     - ipywidgets
     - ipympl
     - pythreejs
+    - ipyvolume >=0.5.1
     - https://github.com/glue-viz/glue/archive/master.zip
     - https://github.com/glue-viz/glue-vispy-viewers/archive/master.zip

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,29 +2,34 @@
 
 set -ex
 
+# keep git happy
+git config --global user.email "bin@der.com"
+git config --global user.name "Bin Der"
 
 pip install .
 
-git clone https://github.com/glue-viz/glue
-(cd glue; pip install .)
+# git clone https://github.com/glue-viz/glue
+# (cd glue; pip install .)
 
-# jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-threejs ipyvolume@^0.5.0-beta.1 --no-build
 
-pip uninstall ipyvolume -y
-git clone https://github.com/maartenbreddels/ipyvolume/
-pushd ipyvolume
-
-pip install -v .
+# pip uninstall ipyvolume -y
+# git clone https://github.com/maartenbreddels/ipyvolume/
+# pushd ipyvolume
+# pip install -v .
 # jupyter labextension install js --no-build
 # jupyter labextension install jupyter-threejs --no-build
-popd
+# popd
+
+
 
 pip uninstall bqplot -y
 git clone https://github.com/maartenbreddels/bqplot/
 pushd bqplot
 git checkout scatter_webgl
+git merge origin/image_colormap_frontend
 pip install .
-# jupyter labextension install js
+jupyter labextension install js --no-build
 popd
 
-# jupyter labextension build
+jupyter lab build


### PR DESCRIPTION
I've restructured the branches in bqplot, and we can now rely on ipyvolume ^0.5.0-beta.1. I guess we need to do the same for https://github.com/glue-viz/glue-example-data/tree/jupyter. Or we make add a postBuild in that repo, that pulls this repo, and executes this postBuild.