### PR TITLE
Implement show axes for bqplot

### DIFF
--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -219,5 +219,5 @@ def test_show_axes(app, dataxyz):
     assert s.widget_show_axes.value == False
     assert s.figure.fig_margin != margin_initial
     s.widget_show_axes.value = True
-    assert s.state.show_axes == False
+    assert s.state.show_axes == True
     assert s.figure.fig_margin == margin_initial

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -212,9 +212,12 @@ def test_imshow_equal_aspect(app, data_image):
 
 def test_show_axes(app, dataxyz):
     s = app.scatter2d('x', 'y', data=dataxyz)
+    assert s.state.show_axes
     assert s.widget_show_axes.value
     margin_initial = s.figure.fig_margin
-    s.widget_show_axes.value = False
+    s.state.show_axes = False
+    assert s.widget_show_axes.value == False
     assert s.figure.fig_margin != margin_initial
     s.widget_show_axes.value = True
+    assert s.state.show_axes == False
     assert s.figure.fig_margin == margin_initial

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -209,3 +209,12 @@ def test_imshow_equal_aspect(app, data_image):
     assert v.widgets_aspect.value
     assert v.figure.min_aspect_ratio == 1
     assert v.figure.max_aspect_ratio == 1
+
+def test_show_axes(app, dataxyz):
+    s = app.scatter2d('x', 'y', data=dataxyz)
+    assert s.widget_show_axes.value
+    margin_initial = s.figure.fig_margin
+    s.widget_show_axes.value = False
+    assert s.figure.fig_margin != margin_initial
+    s.widget_show_axes.value = True
+    assert s.figure.fig_margin == margin_initial

--- a/glue_jupyter/bqplot/view.py
+++ b/glue_jupyter/bqplot/view.py
@@ -85,6 +85,8 @@ class BqplotBaseView(IPyWidgetView):
         self.state.add_callback('y_min', self.limits_to_scales)
         self.state.add_callback('y_max', self.limits_to_scales)
 
+        on_change([(self.state, 'show_axes')])(self._sync_show_axes)
+
         self.create_tab()
         self.output_widget = widgets.Output()
         self.main_widget = widgets.VBox(
@@ -101,10 +103,7 @@ class BqplotBaseView(IPyWidgetView):
         self.tab = widgets.Tab(children)
         self.tab.set_title(0, "General")
         self.tab.set_title(1, "Axes")
-
-        # TODO: maybe the show_axes should go into MatplotlibDataViewerState
-        # see also https://github.com/glue-viz/glue/issues/1591
-        on_change([self.widget_show_axes])(self._sync_show_axes)
+        link((self.state, 'show_axes'), (self.widget_show_axes, 'value'))
 
     def _sync_show_axes(self):
         # TODO: if moved to state, this would not rely on the widget

--- a/glue_jupyter/bqplot/view.py
+++ b/glue_jupyter/bqplot/view.py
@@ -43,6 +43,10 @@ class BqplotBaseView(IPyWidgetView):
         self.figure = bqplot.Figure(scales=self.scales, animation_duration=0, axes=[
                                     self.axis_x, self.axis_y])
         self.figure.padding_y = 0
+        self._fig_margin_default = self.figure.fig_margin
+        self._fig_margin_zero = dict(self.figure.fig_margin)
+        self._fig_margin_zero['left'] = 0
+        self._fig_margin_zero['bottom'] = 0
 
         actions = ['move']
         self.interact_map = {}
@@ -90,13 +94,22 @@ class BqplotBaseView(IPyWidgetView):
         display(self.main_widget)
 
     def create_tab(self):
-        self.widget_show_axes = widgets.Checkbox(value=False, description="Show axes")
+        self.widget_show_axes = widgets.Checkbox(value=True, description="Show axes")
         self.widgets_axis = []
         self.tab_general = widgets.VBox([self.button_action, self.widget_show_axes] + self.widgets_axis)#, self.widget_y_axis, self.widget_z_axis])
         children = [self.tab_general]
         self.tab = widgets.Tab(children)
         self.tab.set_title(0, "General")
         self.tab.set_title(1, "Axes")
+
+        # TODO: maybe the show_axes should go into MatplotlibDataViewerState
+        # see also https://github.com/glue-viz/glue/issues/1591
+        on_change([self.widget_show_axes])(self._sync_show_axes)
+
+    def _sync_show_axes(self):
+        # TODO: if moved to state, this would not rely on the widget
+        self.axis_x.visible = self.axis_y.visible = self.widget_show_axes.value
+        self.figure.fig_margin = self._fig_margin_default if self.widget_show_axes.value else self._fig_margin_zero
 
 
 

--- a/glue_jupyter/bqplot/view.py
+++ b/glue_jupyter/bqplot/view.py
@@ -107,10 +107,8 @@ class BqplotBaseView(IPyWidgetView):
 
     def _sync_show_axes(self):
         # TODO: if moved to state, this would not rely on the widget
-        self.axis_x.visible = self.axis_y.visible = self.widget_show_axes.value
-        self.figure.fig_margin = self._fig_margin_default if self.widget_show_axes.value else self._fig_margin_zero
-
-
+        self.axis_x.visible = self.axis_y.visible = self.state.show_axes
+        self.figure.fig_margin = self._fig_margin_default if self.state.show_axes else self._fig_margin_zero
 
     @staticmethod
     def update_viewer_state(rec, context):


### PR DESCRIPTION
A feature request in glue (https://github.com/glue-viz/glue/issues/1591) and was already enabled for the ipyvolume viewer, and now enabled for the bqplot viewers as well.
It would be nice to put in the `show_axes` somewhere in the state.

This seems to exposes a bug for the webgl accelerated parts in bqplot (image viewer and scattermega), it seems to work fine for the histogram. So we could merge this, or keep open until that is fixed.

![demo-show-axes](https://user-images.githubusercontent.com/1765949/46725269-1da28000-cc7c-11e8-9389-235432e92684.gif)
