### PR TITLE
Include dataset label in tab labels, resolves #11

### DIFF
--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -51,7 +51,7 @@ def example_data_xyz(seed=42, N=500, loc=0, scale=1):
     vy = y - y.mean()
     vz = z - z.mean()
     speed = np.sqrt(vx**2 + vy**2 + vz**2)
-    data_xyz = Data(x=x, y=y, z=z, vx=vx, vy=vy, vz=vz, speed=speed, label="xyz data")
+    data_xyz = Data(x=x, y=y, z=z, vx=vx, vy=vy, vz=vz, speed=speed, label="xyz")
     return data_xyz
 
 def example_volume(shape=64, limits=[-4, 4]):
@@ -391,4 +391,8 @@ class IPyWidgetView(Viewer):
     def _add_layer_tab(self, layer):
         layer_tab = layer.create_widgets()
         self.tab.children = self.tab.children + (layer_tab, )
-        self.tab.set_title(len(self.tab.children)-1, layer.layer.label)
+        if isinstance(layer.layer, Subset):
+            label = '{data_label}:{subset_label}'.format(data_label=layer.layer.data.label, subset_label=layer.layer.label)
+        else:
+            label = layer.layer.label
+        self.tab.set_title(len(self.tab.children)-1, label)


### PR DESCRIPTION
I've used the <dataset>:<subset> format, instead of putting dataset behind the subset, which to me feel more natural.
<img width="836" alt="screen shot 2018-10-10 at 11 11 14" src="https://user-images.githubusercontent.com/1765949/46726035-c0a7c980-cc7d-11e8-9428-3e72fc4c56bd.png">
