### PR TITLE
Move to using ipyastroimage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - (cd ipyvolume; pip install -v .)
   - pip uninstall bqplot -y
   - git clone https://github.com/maartenbreddels/bqplot
-  - (cd bqplot; git checkout scatter_webgl; git merge --no-edit origin/image_colormap_frontend; pip install -v .)
+  - (cd bqplot; git checkout scatter_webgl; pip install -v .)
   - conda info -a
 
 install:

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -27,7 +27,12 @@ pip uninstall bqplot -y
 git clone https://github.com/maartenbreddels/bqplot/
 pushd bqplot
 git checkout scatter_webgl
-git merge origin/image_colormap_frontend
+pip install .
+jupyter labextension install js --no-build
+popd
+
+git clone https://github.com/glue-viz/ipyastroimage/
+pushd ipyastroimage
 pip install .
 jupyter labextension install js --no-build
 popd

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - https://github.com/glue-viz/glue-vispy-viewers/archive/master.zip
     - https://github.com/maartenbreddels/ipyvolume/archive/master.zip
     - https://github.com/maartenbreddels/bqplot/archive/scatter_webgl.zip
+    - https://github.com/glue-viz/ipyastroimage/archive/master.zip

--- a/glue_jupyter/bqplot/image.py
+++ b/glue_jupyter/bqplot/image.py
@@ -2,6 +2,7 @@ import uuid
 
 import numpy as np
 import bqplot
+from ipyastroimage.astroimage import AstroImage
 import ipywidgets as widgets
 import ipywidgets.widgets.trait_types as tt
 from IPython.display import display
@@ -53,7 +54,7 @@ class BqplotImageLayerArtist(LayerArtistBase):
 
         self.scale_image = bqplot.ColorScale()
         self.scales = {'x': self.view.scale_x, 'y': self.view.scale_y, 'image': self.scale_image}
-        self.image_mark = bqplot.Image(image=[[1, 2], [3,4]], scales=self.scales)
+        self.image_mark = AstroImage(image=[[1, 2], [3,4]], scales=self.scales)
         self.color_axis = bqplot.ColorAxis(side='right', scale=self.scale_image, orientation='vertical')
         self.view.figure.axes = list(self.view.figure.axes) + [self.color_axis]
 

--- a/glue_jupyter/bqplot/scatter.py
+++ b/glue_jupyter/bqplot/scatter.py
@@ -1,5 +1,6 @@
 import numpy as np
 import bqplot
+from ipyastroimage.astroimage import AstroImage
 import ipywidgets as widgets
 import ipywidgets.widgets.trait_types as tt
 from IPython.display import display
@@ -46,7 +47,7 @@ class BqplotScatterLayerArtist(LayerArtistBase):
         self.quiver = bqplot.ScatterGL(scales=self.scales_quiver, x=[0, 1], y=[0, 1], visible=False, marker='arrow')
 
         self.counts = None
-        self.image = bqplot.Image(scales=self.scales_image)
+        self.image = AstroImage(scales=self.scales_image)
         on_change([(self.state, 'density_map')])(self._on_change_density_map)
         on_change([(self.state, 'bins')])(self._update_scatter)
         self._viewer_state.add_global_callback(self._update_scatter)


### PR DESCRIPTION
Use https://github.com/glue-viz/ipyastroimage for the bqplot Image mark, instead of trying to get all we want in bqplot.

Since we want astronomy related parts in the image mark, and want to move fast, it makes more sense to continue development outside of bqplot.
