### PR TITLE
WIP: Widget component

### DIFF
--- a/glue_jupyter/bqplot/view.py
+++ b/glue_jupyter/bqplot/view.py
@@ -8,6 +8,7 @@ from glue.core.subset import roi_to_subset_state
 from glue.core.roi import RectangularROI, RangeROI
 from glue.core.command import ApplySubsetState
 
+import glue_jupyter.widgets.component
 from ..view import IPyWidgetView
 from ..link import link, dlink, calculation, link_component_id_to_select_widget, on_change
 from ..utils import float_or_none
@@ -324,10 +325,10 @@ class BqplotScatterView(BqplotBaseView):
         self.widgets_axis = []
         for i, axis_name in enumerate('xy'):
             if hasattr(self.state, axis_name + '_att_helper'):
-                helper = getattr(self.state, axis_name + '_att_helper')
-                widget_axis = widgets.Dropdown(description=axis_name + ' axis')
+                widget_axis = glue_jupyter.widgets.component.Component(
+                    self.state, axis_name + '_att', label=axis_name + ' axis'
+                )
                 self.widgets_axis.append(widget_axis)
-                link_component_id_to_select_widget(self.state, axis_name + '_att', widget_axis)
         self.tab_general.children += tuple(self.widgets_axis)
 
 
@@ -357,10 +358,10 @@ class BqplotHistogramView(BqplotBaseView):
         self.widgets_axis = []
         for i, axis_name in enumerate('x'):
             if hasattr(self.state, axis_name + '_att_helper'):
-                helper = getattr(self.state, axis_name + '_att_helper')
-                widget_axis = widgets.Dropdown(description=axis_name + ' axis')
+                widget_axis = glue_jupyter.widgets.component.Component(
+                    self.state, axis_name + '_att', label=axis_name + ' axis'
+                )
                 self.widgets_axis.append(widget_axis)
-                link_component_id_to_select_widget(self.state, axis_name + '_att', widget_axis)
         # @on_change([(self.state, 'hist_n_bin')])
         # def trigger():
 

--- a/glue_jupyter/ipyvolume/scatter.py
+++ b/glue_jupyter/ipyvolume/scatter.py
@@ -18,7 +18,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawCallbackProperty as DDCProperty,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 
-from ..link import link, dlink, calculation, link_component_id_to_select_widget, on_change
+from ..link import link, dlink, calculation, on_change
 import glue_jupyter.widgets
 
 class Scatter3dLayerState(ScatterLayerState):
@@ -162,17 +162,15 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
         # vector/quivers
         self.widget_vector = widgets.Checkbox(description='show vectors', value=self.state.vector_visible)
 
-        helper = self.state.vx_att_helper
-        self.widget_vector_x = widgets.Dropdown(options=[k.label for k in helper.choices], value=self.state.vx_att, description='vx')
-        link_component_id_to_select_widget(self.state, 'vx_att', self.widget_vector_x)
-
-        helper = self.state.vy_att_helper
-        self.widget_vector_y = widgets.Dropdown(options=[k.label for k in helper.choices], value=self.state.vy_att, description='vy')
-        link_component_id_to_select_widget(self.state, 'vy_att', self.widget_vector_y)
-
-        helper = self.state.vz_att_helper
-        self.widget_vector_z = widgets.Dropdown(options=[k.label for k in helper.choices], value=self.state.vz_att, description='vz')
-        link_component_id_to_select_widget(self.state, 'vz_att', self.widget_vector_z)
+        self.widget_vector_x = glue_jupyter.widgets.Component(
+            self.state, 'vx_att', label='vx'
+        )
+        self.widget_vector_y = glue_jupyter.widgets.Component(
+            self.state, 'vy_att', label='vy'
+        )
+        self.widget_vector_z = glue_jupyter.widgets.Component(
+            self.state, 'vz_att', label='vz'
+        )
 
         on_change([(self.state, 'vector_visible', 'vx_att', 'vy_att', 'vz_att')])(self._update_quiver)
         link((self.state, 'vector_visible'), (self.widget_vector, 'value'))

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -49,9 +49,6 @@ def test_scatter3d(app, dataxyz, dataxz):
     assert s.layers[1].scatter.z.tolist() == [1, 2, 3]
     assert s.layers[1].scatter.selected == [2]
 
-    assert s.widgets_axis[0].label == 'y'
-    assert s.widgets_axis[1].label == 'z'
-    assert s.widgets_axis[2].label == 'x'
 
     size_previous = s.layers[0].scatter.size
     s.layers[0].state.size_mode = 'Linear'

--- a/glue_jupyter/ipyvolume/view.py
+++ b/glue_jupyter/ipyvolume/view.py
@@ -11,9 +11,10 @@ from glue.core.subset import RoiSubsetState3d
 from glue.core.command import ApplySubsetState
 
 from ..view import IPyWidgetView
-from ..link import link, dlink, link_component_id_to_select_widget
+from ..link import link, dlink
 from .scatter import IpyvolumeScatterLayerArtist
 from .volume import IpyvolumeVolumeLayerArtist
+import glue_jupyter.widgets
 
 
 class IpyvolumeBaseView(IPyWidgetView):
@@ -114,15 +115,13 @@ class IpyvolumeBaseView(IPyWidgetView):
                     ipv.style.box_off()
         self.widget_show_axes.observe(change, 'value')
 
-
         self.widgets_axis = []
         for i, axis_name in enumerate('xyz'):
             if hasattr(self.state, axis_name + '_att_helper'):
-                helper = getattr(self.state, axis_name + '_att_helper')
-                widget_axis = widgets.Dropdown(options=[k.label for k in helper.choices],
-                                               value=getattr(self.state, axis_name + '_att'), description=axis_name + ' axis')
+                widget_axis = glue_jupyter.widgets.Component(
+                    self.state, axis_name + '_att', label=axis_name + ' axis'
+                )
                 self.widgets_axis.append(widget_axis)
-                link_component_id_to_select_widget(self.state, axis_name + '_att', widget_axis)
 
         selectors = ['lasso', 'circle', 'rectangle']
         self.button_action = widgets.ToggleButtons(description='Mode: ', options=[(selector, selector) for selector in selectors],

--- a/glue_jupyter/widgets/__init__.py
+++ b/glue_jupyter/widgets/__init__.py
@@ -1,2 +1,4 @@
 from .color import Color
 from .size import Size
+from .component import Component
+__all__ = ['Color', 'Size', 'Component']

--- a/glue_jupyter/widgets/color.py
+++ b/glue_jupyter/widgets/color.py
@@ -4,6 +4,8 @@ import ipywidgets as widgets
 from glue.config import colormaps
 
 from ..link import link, dlink, calculation, link_component_id_to_select_widget, on_change
+import glue_jupyter.widgets
+
 
 class Color(widgets.VBox):
 
@@ -18,11 +20,7 @@ class Color(widgets.VBox):
         self.widget_cmap_mode = widgets.RadioButtons(options=cmap_mode_options, description='cmap mode')
         link((self.state, 'cmap_mode'), (self.widget_cmap_mode, 'value'))
 
-        helper = self.state.cmap_att_helper
-        self.widget_cmap_att = widgets.Dropdown(options=[k.label for k in helper.choices],
-                                       value=self.state.cmap_att, description='color attr.')
-        link_component_id_to_select_widget(self.state, 'cmap_att', self.widget_cmap_att)
-        # on_change([(self.state, 'cmap', 'cmap_mode', 'cmap_vmin', 'cmap_vmax')])(self._update_cmap)
+        self.widget_cmap_att = glue_jupyter.widgets.Component(self.state, 'cmap_att', ui_name='color attribute')
 
         self.widget_cmap_vmin = widgets.FloatText(description='color min')
         self.widget_cmap_vmax = widgets.FloatText(description='color max')

--- a/glue_jupyter/widgets/component.py
+++ b/glue_jupyter/widgets/component.py
@@ -1,0 +1,76 @@
+import ipymaterialui as mui
+import glue.external.echo.selection
+
+# TODO: we probably want to listen to new components being added
+# from glue.core import message as msg
+# from glue.core.hub import HubListener
+
+
+class Component(mui.Div):
+    """Widget responsible for selecting a component, sync state between UI and a (View)State attribute.
+
+    * On glue's side the state is in state.<attribute_name> and the options are in state.<attribute_name_helper>.
+    * On the UI the state is in widget_select.value which holds the index of the selected component.
+    * Indices are (for the moment) calculated from a list of components (ignoring separators)
+    """
+
+    def __init__(self, state, attribute_name, attribute_name_helper=None, ui_name=None, label=None):
+        super(Component, self).__init__()
+        self.state = state
+        self.attribute_name = attribute_name
+        self.attribute_name_helper = attribute_name_helper or self.attribute_name + '_helper'
+
+        self.menu_items = self._create_menu_items()
+        self.widget_select = mui.Select(
+            value=self._get_glue_selected_component_index(), children=self.menu_items, multiple=False
+        )
+        label = label or getattr(type(self.state), self.attribute_name).__doc__
+        self.widget_input_label = mui.InputLabel(description=label, placeholder='No component')
+        # style is a dict with css key/values
+        self.widget_form_control = mui.FormControl(
+            children=[self.widget_input_label, self.widget_select], style={'width': '205px'}
+        )
+
+        self.child = self.widget_form_control
+
+        getattr(type(self.state), self.attribute_name).add_callback(self.state, self._update_ui_from_glue_state)
+        self.widget_select.observe(self._update_glue_state_from_ui, 'value')
+        # initial state
+        self._update_ui_from_glue_state()
+
+    def _update_glue_state_from_ui(self, change):
+        component = self._get_components()[self.widget_select.value]
+        setattr(self.state, self.attribute_name, component)
+
+    def _update_ui_from_glue_state(self, *ignore_args):
+        index = self._get_glue_selected_component_index()
+        self.widget_select.value = index
+
+    def _get_components(self):
+        return [
+            k
+            for k in getattr(type(self.state), self.attribute_name).get_choices(self.state)
+            if not isinstance(k, glue.external.echo.selection.ChoiceSeparator)
+        ]
+
+    def _create_menu_items(self):
+        components = self._get_components()
+        # we don't use choice_labels, but display_func manually, since we ignore separators for the moment
+        display_func = getattr(type(self.state), self.attribute_name).get_display_func(self.state)
+        labels = [display_func(components[k]) for k in range(len(components))]
+        return [mui.MenuItem(description=label, value=index) for index, label in enumerate(labels)]
+
+    def _get_glue_selected_component_index(self):
+        components = self._get_components()
+        component = getattr(self.state, self.attribute_name)
+        # A users can set a component to a string, and
+        # comparing a component to a string always returns a truthy
+        if isinstance(component, str):  # WARNING: this will not work for py27
+            matches = [k for k in range(len(components)) if component == str(components[k])]
+            if len(matches):
+                return matches[0]
+        try:
+            return components.index(component)
+        except ValueError:
+            # No selection in materialui is equivalent to '' (idea: use None for Python and undefined in js)
+            return ''

--- a/glue_jupyter/widgets/component_test.py
+++ b/glue_jupyter/widgets/component_test.py
@@ -1,0 +1,51 @@
+from glue.core.state_objects import State
+from glue.core.data_combo_helper import ComponentIDComboHelper
+from glue.external.echo import SelectionCallbackProperty
+from .component import Component
+
+
+class DummyState(State):
+    """Mock state class for testing only."""
+
+    x_att = SelectionCallbackProperty(docstring='x test attribute')
+
+
+def test_component(app, dataxz, dataxyz):
+    # setup
+    state = DummyState()
+    helper = ComponentIDComboHelper(state, 'x_att', app.data_collection)
+    helper.append_data(dataxz)
+    state.helper = helper
+
+    # main object we test
+    component = Component(state, 'x_att', 'helper')
+
+    # simple sanity tests
+    assert component.widget_input_label.description == 'x test attribute'
+    items = getattr(type(state), 'x_att').get_choice_labels(state)
+    assert len(component.widget_select.children) == len(items)
+    assert [item.description for item in component.widget_select.children] == ['x', 'z']
+
+    # initial state
+    assert str(state.x_att) == 'x'
+    assert component.widget_select.value == 0
+
+    # glue state -> ui
+    state.x_att = dataxz.id['z']
+    assert component.widget_select.value == 1
+
+    # ui -> glue state
+    assert str(state.x_att) == 'z'
+    assert component.widget_select.value == 1
+    component.widget_select.value = 0
+    assert str(state.x_att) == 'x'
+
+    # same, but now be ok with strings
+    assert component.widget_select.value == 0
+    assert str(state.x_att) == 'x'
+
+    state.x_att = 'z'
+    assert component.widget_select.value == 1
+
+    state.x_att = 'x'
+    assert component.widget_select.value == 0


### PR DESCRIPTION
Similar to #43 a widget takes the responsibility for managing ui state and glue state, makes testing and reusing much easier.
Also using ipymaterialui for a more consistent look

TODO: remove all use of link_component_id_to_select_widget