### PR TITLE
Fix issue with image viewer when data is not floating-point

### DIFF
--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -81,8 +81,8 @@ class BqplotImageLayerArtist(LayerArtist):
             min = (min - bias * width)*contrast + 0.5 * width
             max = (max - bias * width)*contrast + 0.5 * width
             with self.scale_image.hold_sync():
-                self.scale_image.min = min
-                self.scale_image.max = max
+                self.scale_image.min = float(min)
+                self.scale_image.max = float(max)
 
     def _update_cmap(self):
         if isinstance(self.layer, Subset):
@@ -122,8 +122,8 @@ class BqplotImageLayerArtist(LayerArtist):
             # data /= (self.state.v_max - self.state.v_min)
             # print(np.nanmin(data), np.nanmax(data))
             # png_data = _scalar_to_png_data(data)
-            self.scale_image.min = self.state.v_min
-            self.scale_image.max = self.state.v_max
+            self.scale_image.min = float(self.state.v_min)
+            self.scale_image.max = float(self.state.v_max)
             self.image_mark.image = data
         # force the image mark to update the image data
         # self.image_mark.send_state(key='image')

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -1,5 +1,6 @@
 import os
 import nbformat
+import numpy as np
 from nbconvert.preprocessors import ExecutePreprocessor
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
@@ -259,6 +260,11 @@ def test_imshow_equal_aspect(app, data_image):
     assert v.widgets_aspect.value
     assert v.figure.min_aspect_ratio == 1
     assert v.figure.max_aspect_ratio == 1
+
+
+def test_imshow_nonfloat(app):
+    data = app.add_data(data_int=np.array([[1, 2], [2, 3]], dtype=np.uint16))[0]
+    app.imshow(data=data)
 
 
 def test_show_axes(app, dataxyz):


### PR DESCRIPTION
This should be rebased once #68 is merged.

Fixes https://github.com/glue-viz/glue-jupyter/issues/54