### PR TITLE
Add a mode to debounced to start executing the function while events are still being received

### DIFF
--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -33,7 +33,7 @@ class FRBImage(AstroImage):
         self.viewer.figure.axes[1].scale.observe(self.update, 'min')
         self.viewer.figure.axes[1].scale.observe(self.update, 'max')
 
-    @debounced(method=True)
+    @debounced(method=True, wait_for_end=False, delay_seconds=0.1)
     def update(self, *args, **kwargs):
 
         # Get current limits from the plot

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -50,16 +50,16 @@ class FRBImage(AstroImage):
         # make it a parameter in future. Bqplot does allow us to constrain the
         # aspect ratio though so we could envisage trying to use that info
         # to make sure the ratio of the sizes is sensible..
-        ny, nx = 512, 512
+        ny, nx = 256, 256
 
         # Set up bounds
         bounds = [(ymin, ymax, ny), (xmin, xmax, nx)]
 
         # Get the array and assign it to the artist
+        image = self.array_maker(bounds=bounds)
+        if image is None:
+            image = np.zeros((1, 1, 3))
         with self.hold_sync():
-            image = self.array_maker(bounds=bounds)
-            if image is None:
-                image = np.array([[np.nan]])
             self.image = image
             self.x = (xmin, xmax)
             self.y = (ymin, ymax)


### PR DESCRIPTION
This is an attempt to solve https://github.com/glue-viz/glue-jupyter/issues/82, but not quite there yet. For some background, the debounced decorator works fine in master when panning/zooming - the image only updates if the user stops panning for 0.5 seconds. However, for changing e.g. slices, or bias/contrast, I'd like to start getting feedback on the change while I'm dragging the slider, not just when I stop.

I want the calls to happen as fast as possible but at the same time I don't want the image update calls to build up if they are a bit slow, so I'm trying to use/modify ``debounced`` so that the function is guaranteed to execute at regular intervals. The approach here kind of works but for some reason the updates separated by quite a long delay while dragging the slider, and then when I let go, there is still a backlog of calls, so not quite there yet.

To put this a different way, let's say that the image update takes 1 second, I ideally want to see the image update happen every second, and overall, the last update should happen <=1 second from the last event.

@maartenbreddels - does this make sense? Any ideas on how to make this work properly?