### PR TITLE
Move selection buttons in bqplot into toolbar above viewer

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -81,7 +81,6 @@ class BqplotBaseView(IPyWidgetView):
         )
         self.widget_button_interact.observe(self.change_action, "value")
 
-        self.widget_toolbar = self.widget_button_interact
         self.change_action()  # 'fire' manually for intial value
 
         link((self.state, 'x_min'), (self.scale_x, 'min'), float_or_none)
@@ -94,6 +93,7 @@ class BqplotBaseView(IPyWidgetView):
         self.create_tab()
         self.output_widget = widgets.Output()
         self.widget_toolbar = widgets.HBox([
+                        self.widget_button_interact,
                         self.session.application.widget_subset_select,
                         self.session.application.widget_subset_mode]
              )
@@ -107,14 +107,16 @@ class BqplotBaseView(IPyWidgetView):
         display(self.main_widget)
 
     def create_tab(self):
+
         self.widget_show_axes = widgets.Checkbox(value=True, description="Show axes")
-        self.tab_general = widgets.VBox([self.widget_toolbar, self.widget_show_axes])
-        children = [self.tab_general]
+        link((self.state, 'show_axes'), (self.widget_show_axes, 'value'))
+
+        self.tab_general = widgets.VBox([self.widget_show_axes])
         self.tab_general.children += self._options_cls(self.state).children
+        children = [self.tab_general]
+
         self.tab = widgets.Tab(children)
         self.tab.set_title(0, "General")
-        self.tab.set_title(1, "Axes")
-        link((self.state, 'show_axes'), (self.widget_show_axes, 'value'))
 
     def _sync_show_axes(self):
         # TODO: if moved to state, this would not rely on the widget


### PR DESCRIPTION
Just a minor UI change, I think it would make more sense for the selection tools to be next to the rest of the selection toolbar:

<img width="677" alt="Screenshot 2019-04-14 at 17 15 40" src="https://user-images.githubusercontent.com/314716/56095871-02d5f000-5ed9-11e9-92db-83eb4390170f.png">
