### PR TITLE
Refactor tools to use glue infrastructure

### DIFF
--- a/glue_jupyter/bqplot/common/__init__.py
+++ b/glue_jupyter/bqplot/common/__init__.py
@@ -1,1 +1,2 @@
 from .viewer import *  # noqa
+from .tools import *  # noqa

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -2,7 +2,7 @@ from bqplot import PanZoom
 from bqplot.interacts import BrushSelector, BrushIntervalSelector
 from glue.core.roi import RectangularROI, RangeROI
 from glue.config import viewer_tool
-from glue.viewers.common.qt.tool import CheckableTool
+from glue.viewers.common.tool import CheckableTool
 
 __all__ = []
 

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -1,0 +1,117 @@
+from bqplot import PanZoom
+from bqplot.interacts import BrushSelector, BrushIntervalSelector
+from glue.core.roi import RectangularROI, RangeROI
+from glue.config import viewer_tool
+from glue.viewers.common.qt.tool import CheckableTool
+
+__all__ = []
+
+ICON_WIDTH = 20
+
+
+class InteractCheckableTool(CheckableTool):
+
+    def __init__(self, viewer):
+        self.viewer = viewer
+
+    def activate(self):
+        self.viewer.figure.interaction = self.interact
+
+    def deactivate(self):
+        self.viewer.figure.interaction = None
+
+
+@viewer_tool
+class BqplotPanZoomMode(InteractCheckableTool):
+
+    icon = 'glue_move'
+    tool_id = 'bqplot:panzoom'
+    action_text = 'Pan and Zoom'
+    tool_tip = 'Interactively pan and zoom around'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = PanZoom(scales={'x': [self.viewer.scale_x],
+                                        'y': [self.viewer.scale_y]})
+
+
+@viewer_tool
+class BqplotRectangleMode(InteractCheckableTool):
+
+    icon = 'glue_square'
+    tool_id = 'bqplot:rectangle'
+    action_text = 'Rectangular ROI'
+    tool_tip = 'Define a rectangular region of interest'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = BrushSelector(x_scale=self.viewer.scale_x,
+                                      y_scale=self.viewer.scale_y,
+                                      color="green")
+
+        self.interact.observe(self.update_selection, "brushing")
+
+    def update_selection(self, *args):
+        with self.viewer.output_widget:
+            if self.interact.selected_x is not None and self.interact.selected_y is not None:
+                x = self.interact.selected_x
+                y = self.interact.selected_y
+                roi = RectangularROI(xmin=min(x), xmax=max(x), ymin=min(y), ymax=max(y))
+                self.viewer.apply_roi(roi)
+
+
+@viewer_tool
+class BqplotXRangeMode(InteractCheckableTool):
+
+    icon = 'glue_xrange_select'
+    tool_id = 'bqplot:xrange'
+    action_text = 'X range ROI'
+    tool_tip = 'Select a range of x values'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = BrushIntervalSelector(scale=self.viewer.scale_x,
+                                              color="green")
+
+        self.interact.observe(self.update_selection, "brushing")
+
+    def update_selection(self, *args):
+        with self.viewer.output_widget:
+            if self.interact.selected is not None:
+                x = self.interact.selected
+                if x is not None and len(x):
+                    roi = RangeROI(min=min(x), max=max(x), orientation='x')
+                    self.viewer.apply_roi(roi)
+
+
+@viewer_tool
+class BqplotYRangeMode(InteractCheckableTool):
+
+    icon = 'glue_yrange_select'
+    tool_id = 'bqplot:yrange'
+    action_text = 'Y range ROI'
+    tool_tip = 'Select a range of y values'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = BrushIntervalSelector(scale=self.viewer.scale_y,
+                                              orientation='vertical',
+                                              color="green")
+
+        self.interact.observe(self.update_selection, "brushing")
+
+    def update_selection(self, *args):
+        with self.viewer.output_widget:
+            if self.interact.selected is not None:
+                y = self.interact.selected
+                if y is not None and len(x):
+                    roi = RangeROI(min=min(y), max=max(y), orientation='y')
+                    self.viewer.apply_roi(roi)

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -1,21 +1,13 @@
 import bqplot
 import ipywidgets as widgets
-import ipymaterialui as mui
 from IPython.display import display
 
-from bqplot.interacts import BrushSelector
-import glue.icons
 from glue.core.subset import roi_to_subset_state
-from glue.core.roi import RectangularROI, RangeROI
 from glue.core.command import ApplySubsetState
-from glue.config import viewer_tool
 
 from ...view import IPyWidgetView
 from ...link import link, on_change
 from ...utils import float_or_none
-
-# Need to import this here to register viewer tools
-from . import tools  # noqa
 
 __all__ = ['BqplotBaseView']
 

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -65,11 +65,7 @@ class BqplotBaseView(IPyWidgetView):
 
         self.create_tab()
         self.output_widget = widgets.Output()
-        self.widget_toolbar = widgets.HBox([
-                        self.toolbar,
-                        self.session.application.widget_subset_select,
-                        self.session.application.widget_subset_mode]
-             )
+
         self.main_widget = widgets.VBox([
                 self.widget_toolbar,
                 widgets.HBox([self.figure, self.tab]),
@@ -99,14 +95,6 @@ class BqplotBaseView(IPyWidgetView):
     @staticmethod
     def update_viewer_state(rec, context):
         print('update viewer state', rec, context)
-
-    def change_action(self, *ignore):
-        index = self.widget_button_interact.value
-        self.figure.interaction = self.widget_button_interact.value #self.interact_map[self.button_action.value]
-        if self.is2d:
-            self.interact_brush.selected_x = []
-            self.interact_brush_y.selected = []
-        self.interact_brush_x.selected = []
 
     def apply_roi(self, roi, use_current=False):
         # TODO: partial copy paste from glue/viewers/matplotlib/qt/data_viewer.py

--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -24,6 +24,9 @@ class BqplotHistogramView(BqplotBaseView):
     _subset_artist_cls = BqplotHistogramLayerArtist
     _layer_style_widget_cls = HistogramLayerStateWidget
 
+    tools = ['bqplot:panzoom', 'bqplot:xrange']
+
+
     def _roi_to_subset_state(self, roi):
         # TODO: copy paste from glue/viewers/histogram/qt/data_viewer.py
         # TODO Does subset get applied to all data or just visible data?

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -30,6 +30,8 @@ class BqplotImageView(BqplotBaseView):
     _state_cls = ImageViewerState
     _options_cls = ImageViewerStateWidget
 
+    tools = ['bqplot:panzoom', 'bqplot:rectangle', 'bqplot:xrange', 'bqplot:yrange']
+
     def __init__(self, session):
 
         super(BqplotImageView, self).__init__(session)

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -26,6 +26,8 @@ class BqplotProfileView(BqplotBaseView):
     _subset_artist_cls = BqplotProfileLayerArtist
     _layer_style_widget_cls = ProfileLayerStateWidget
 
+    tools = ['bqplot:panzoom', 'bqplot:xrange']
+
     def _roi_to_subset_state(self, roi):
 
         x = roi.to_polygon()[0]

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -21,3 +21,5 @@ class BqplotScatterView(BqplotBaseView):
     _data_artist_cls = BqplotScatterLayerArtist
     _subset_artist_cls = BqplotScatterLayerArtist
     _layer_style_widget_cls = ScatterLayerStateWidget
+
+    tools = ['bqplot:panzoom', 'bqplot:rectangle', 'bqplot:xrange', 'bqplot:yrange']

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -24,9 +24,11 @@ def test_histogram1d(app, dataxyz):
     assert s.layers[1].bins.tolist() == [1.5, 2.5, 3.5, 4.5]
     assert s.layers[1].hist.tolist() == [0, 1, 1]
 
-    s.interact_brush_x.brushing = True
-    s.interact_brush_x.selected = [2.5, 3.5]
-    s.interact_brush_x.brushing = False
+    tool = s.toolbar.tools['bqplot:xrange']
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [2.5, 3.5]
+    tool.interact.brushing = False
 
     assert len(s.layers) == 3
     assert s.layers[2].bins.tolist() == [1.5, 2.5, 3.5, 4.5]
@@ -51,8 +53,9 @@ def test_interact(app, dataxyz):
     s = app.scatter2d('x', 'y', data=dataxyz)
     # s.widget_menu_select_x.value = True
     # s.widget_menu_select_x.click()# = True
-    s.widget_button_interact.value = s.interact_brush_x
-    assert s.figure.interaction == s.interact_brush_x
+    tool = s.toolbar.tools['bqplot:xrange']
+    s.toolbar.value = tool.tool_id
+    assert s.figure.interaction == tool.interact
 
 
 def test_scatter2d(app, dataxyz, dataxz):
@@ -128,10 +131,12 @@ def test_scatter2d_brush(app, dataxyz, dataxz):
     s = app.scatter2d('x', 'y', data=dataxyz)
 
     # 1d x brushing
-    #s.button_action.value = 'brush x'
-    s.interact_brush_x.brushing = True
-    s.interact_brush_x.selected = [1.5, 3.5]
-    s.interact_brush_x.brushing = False
+    tool1d = s.toolbar.tools['bqplot:xrange']
+    tool1d.activate()
+    tool1d.interact.brushing = True
+    tool1d.interact.selected = [1.5, 3.5]
+    tool1d.interact.brushing = False
+
     assert len(s.layers) == 2
     assert s.layers[1].layer['x'].tolist() == [2, 3]
     assert s.layers[1].layer['y'].tolist() == [3, 4]
@@ -157,9 +162,12 @@ def test_scatter2d_brush(app, dataxyz, dataxz):
 
     # 2d brushing
     # format of 'selected' (x1, y1), (x2, y2)
-    s.interact_brush.brushing = True
-    s.interact_brush.selected = [(2.5, 2.5), (3.5, 4.5)]
-    s.interact_brush.brushing = False
+    tool2d = s.toolbar.tools['bqplot:rectangle']
+    tool2d.activate()
+    tool2d.interact.brushing = True
+    tool2d.interact.selected = [(2.5, 2.5), (3.5, 4.5)]
+    tool2d.interact.brushing = False
+
     assert len(s.layers) == 2
     assert s.layers[1].layer['x'].tolist() == [3]
     assert s.layers[1].layer['y'].tolist() == [4]
@@ -170,9 +178,9 @@ def test_scatter2d_brush(app, dataxyz, dataxz):
     assert s.layers[1].scatter.selected == [2]
 
     # nothing should change when we change modes
-    s.widget_button_interact.value = s.interact_brush_x
+    s.toolbar.value = tool1d.tool_id
     assert s.layers[1].scatter.selected == [2]
-    s.widget_button_interact.value = s.interact_brush_y
+    s.toolbar.value = tool2d.tool_id
     assert s.layers[1].scatter.selected == [2]
 
 
@@ -201,9 +209,11 @@ def test_scatter2d_cmap_mode(app, dataxyz):
 def test_scatter2d_and_histogram(app, dataxyz):
     s = app.scatter2d('x', 'y', data=dataxyz)
     h = app.histogram1d('x', data=dataxyz)
-    s.interact_brush.brushing = True
-    s.interact_brush.selected = [(1.5, 3.5), (3.5, 5)]
-    s.interact_brush.brushing = False
+    tool = s.toolbar.tools['bqplot:rectangle']
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [(1.5, 3.5), (3.5, 5)]
+    tool.interact.brushing = False
     assert len(s.layers) == 2
     import glue.core.subset
     assert isinstance(s.layers[1].layer.subset_state,
@@ -217,9 +227,12 @@ def test_imshow(app, data_image, dataxyz):
     v.add_data(dataxyz)
 
     assert len(v.layers) == 2
-    v.interact_brush.brushing = True
-    v.interact_brush.selected = [(1.5, 3.5), (300.5, 550)]
-    v.interact_brush.brushing = False
+
+    tool = v.toolbar.tools['bqplot:rectangle']
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [(1.5, 3.5), (300.5, 550)]
+    tool.interact.brushing = False
 
     assert len(v.layers) == 4
 

--- a/glue_jupyter/common/toolbar.py
+++ b/glue_jupyter/common/toolbar.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function
+
+from ipywidgets import Image
+from ipymaterialui import ToggleButtonGroup, ToggleButton
+
+from glue.icons import icon_path
+
+__all__ = ['BasicJupyterToolbar']
+
+ICON_WIDTH = 20
+
+
+class BasicJupyterToolbar(ToggleButtonGroup):
+
+    def __init__(self):
+        super().__init__(exclusive=True, style={'margin': '4px'}, value=None)
+        self.tools = {}
+        self.observe(self._change_tool, "value")
+
+    def _change_tool(self, event):
+
+        if event['old'] is not None:
+            self.tools[event['old']].deactivate()
+
+        if event['new'] is not None:
+            self.tools[event['new']].activate()
+
+    def add_tool(self, tool):
+        self.tools[tool.tool_id] = tool
+        icon = Image.from_file(icon_path(tool.icon, icon_format='svg'),
+                               width=ICON_WIDTH)
+        button = ToggleButton(children=[icon], value=tool.tool_id)
+        self.children += (button,)

--- a/glue_jupyter/ipyvolume/common/__init__.py
+++ b/glue_jupyter/ipyvolume/common/__init__.py
@@ -1,2 +1,3 @@
 from .viewer_options_widget import *  # noqa
 from .viewer import *  # noqa
+from .tools import *

--- a/glue_jupyter/ipyvolume/common/tools.py
+++ b/glue_jupyter/ipyvolume/common/tools.py
@@ -1,0 +1,106 @@
+import numpy as np
+
+from glue.core.roi import PolygonalROI, CircularROI, RectangularROI, Projected3dROI
+
+from glue.config import viewer_tool
+from glue.viewers.common.qt.tool import CheckableTool
+
+__all__ = []
+
+
+class IPyVolumeCheckableTool(CheckableTool):
+
+    def __init__(self, viewer):
+        self.viewer = viewer
+        self.viewer.figure.on_selection(self.on_selection)
+
+    def activate(self):
+        self.viewer.figure.selector = self.selector
+
+    def deactivate(self):
+        self.viewer.figure.selector = ''
+
+    @property
+    def projection_matrix(self):
+        W = np.matrix(self.viewer.figure.matrix_world).reshape((4, 4))     .T
+        P = np.matrix(self.viewer.figure.matrix_projection).reshape((4, 4)).T
+        M = np.dot(P, W)
+        return M
+
+
+@viewer_tool
+class IpyvolumeLassoMode(IPyVolumeCheckableTool):
+
+    icon = 'glue_lasso'
+    tool_id = 'ipyvolume:lasso'
+    action_text = 'Polygon ROI'
+    tool_tip = 'Define a polygonal region of interest'
+
+    selector = 'lasso'
+
+    def on_selection(self, data, other=None):
+
+        if data['type'] != self.selector:
+            return
+
+        if data['device']:
+            with self.viewer.output_widget:
+                region = data['device']
+                vx, vy = zip(*region)
+                roi_2d = PolygonalROI(vx=vx, vy=vy)
+                roi = Projected3dROI(roi_2d, self.projection_matrix)
+                self.viewer.apply_roi(roi)
+
+
+@viewer_tool
+class IpyvolumeCircleMode(IPyVolumeCheckableTool):
+
+    icon = 'glue_circle'
+    tool_id = 'ipyvolume:circle'
+    action_text = 'Circular ROI'
+    tool_tip = 'Define a circular region of interest'
+
+    selector = 'circle'
+
+    def on_selection(self, data, other=None):
+
+        if data['type'] != self.selector:
+            return
+
+        if data['device']:
+            with self.viewer.output_widget:
+                x1, y1 = data['device']['begin']
+                x2, y2 = data['device']['end']
+                dx = x2 - x1
+                dy = y2 - y1
+                r = (dx**2 + dy**2)**0.5
+                roi_2d = CircularROI(xc=x1, yc=y1, radius=r)
+                roi = Projected3dROI(roi_2d, self.projection_matrix)
+                self.viewer.apply_roi(roi)
+
+
+@viewer_tool
+class IpyvolumeRectanglewMode(IPyVolumeCheckableTool):
+
+    icon = 'glue_square'
+    tool_id = 'ipyvolume:rectangle'
+    action_text = 'Rectangular ROI'
+    tool_tip = 'Define a rectangular region of interest'
+
+    selector = 'rectangle'
+
+    def on_selection(self, data, other=None):
+
+        if data['type'] != self.selector:
+            return
+
+        if data['device']:
+            with self.viewer.output_widget:
+                x1, y1 = data['device']['begin']
+                x2, y2 = data['device']['end']
+                x = [x1, x2]
+                y = [y1, y2]
+                roi_2d = RectangularROI(
+                    xmin=min(x), xmax=max(x), ymin=min(y), ymax=max(y))
+                roi = Projected3dROI(roi_2d, self.projection_matrix)
+                self.viewer.apply_roi(roi)

--- a/glue_jupyter/ipyvolume/common/tools.py
+++ b/glue_jupyter/ipyvolume/common/tools.py
@@ -3,7 +3,7 @@ import numpy as np
 from glue.core.roi import PolygonalROI, CircularROI, RectangularROI, Projected3dROI
 
 from glue.config import viewer_tool
-from glue.viewers.common.qt.tool import CheckableTool
+from glue.viewers.common.tool import CheckableTool
 
 __all__ = []
 

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -3,16 +3,12 @@ from __future__ import absolute_import, division, print_function
 from ipywidgets import HTML, Tab, HBox, VBox, Output
 from IPython.display import display
 
-# from matplotlib.backends.backend_nbagg import FigureCanvasNbAgg, FigureManager
 from ipympl.backend_nbagg import FigureCanvasNbAgg, FigureManagerNbAgg
 from matplotlib.figure import Figure
 
 from glue.viewers.matplotlib.mpl_axes import init_mpl
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
 from glue.viewers.matplotlib.viewer import MatplotlibViewerMixin
-
-# Make sure Matplotlib-based tools are registered
-from glue.viewers.common.qt import toolbar_mode
 
 from glue.utils.matplotlib import DEFER_DRAW_BACKENDS
 
@@ -41,10 +37,8 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
         self.canvas.manager = FigureManagerNbAgg(self.canvas, 0)
         self.figure, self.axes = init_mpl(self.figure, wcs=wcs)
 
-        # FIXME: for the tools to work
+        # FIXME: The following is required for now for the tools to work
         self.central_widget = self.figure
-        from mock import MagicMock
-        self.window_closed = MagicMock()
         self._axes = self.axes
 
         super(MatplotlibJupyterViewer, self).__init__(session, state=state)

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -10,6 +10,10 @@ from matplotlib.figure import Figure
 from glue.viewers.matplotlib.mpl_axes import init_mpl
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
 from glue.viewers.matplotlib.viewer import MatplotlibViewerMixin
+
+# Make sure Matplotlib-based tools are registered
+from glue.viewers.common.qt import toolbar_mode
+
 from glue.utils.matplotlib import DEFER_DRAW_BACKENDS
 
 from glue_jupyter.view import IPyWidgetView
@@ -32,13 +36,18 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
 
     def __init__(self, session, parent=None, wcs=None, state=None):
 
-        super(MatplotlibJupyterViewer, self).__init__(session, state=state)
-
         self.figure = Figure()
         self.canvas = FigureCanvasNbAgg(self.figure)
         self.canvas.manager = FigureManagerNbAgg(self.canvas, 0)
-
         self.figure, self.axes = init_mpl(self.figure, wcs=wcs)
+
+        # FIXME: for the tools to work
+        self.central_widget = self.figure
+        from mock import MagicMock
+        self.window_closed = MagicMock()
+        self._axes = self.axes
+
+        super(MatplotlibJupyterViewer, self).__init__(session, state=state)
 
         MatplotlibViewerMixin.setup_callbacks(self)
 
@@ -49,6 +58,7 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
 
         self.main_widget = VBox([
                 self.css_widget,
+                self.widget_toolbar,
                 HBox([self.canvas, self.tab]),
                 self.output_widget
             ])

--- a/glue_jupyter/matplotlib/histogram.py
+++ b/glue_jupyter/matplotlib/histogram.py
@@ -24,6 +24,8 @@ class HistogramJupyterViewer(MatplotlibHistogramMixin, MatplotlibJupyterViewer):
     _options_cls = HistogramViewerStateWidget
     _layer_style_widget_cls = HistogramLayerStateWidget
 
+    tools = ['select:xrange']
+
     def __init__(self, session, parent=None, state=None):
         super(HistogramJupyterViewer, self).__init__(session, parent=parent, state=state)
         MatplotlibHistogramMixin.setup_callbacks(self)

--- a/glue_jupyter/matplotlib/image.py
+++ b/glue_jupyter/matplotlib/image.py
@@ -28,6 +28,10 @@ class ImageJupyterViewer(MatplotlibImageMixin, MatplotlibJupyterViewer):
                                ImageSubsetLayerArtist: ImageSubsetLayerStateWidget,
                                ScatterLayerArtist: ScatterLayerStateWidget}
 
+    tools = ['select:rectangle', 'select:xrange',
+             'select:yrange', 'select:circle',
+             'select:polygon']
+
     def __init__(self, session, parent=None, state=None):
         super(ImageJupyterViewer, self).__init__(session, wcs=True, parent=parent, state=state)
         MatplotlibImageMixin.setup_callbacks(self)

--- a/glue_jupyter/matplotlib/scatter.py
+++ b/glue_jupyter/matplotlib/scatter.py
@@ -24,6 +24,10 @@ class ScatterJupyterViewer(MatplotlibScatterMixin, MatplotlibJupyterViewer):
     _options_cls = ScatterViewerStateWidget
     _layer_style_widget_cls = ScatterLayerStateWidget
 
+    tools = ['select:rectangle', 'select:xrange',
+             'select:yrange', 'select:circle',
+             'select:polygon']
+
     def __init__(self, session, parent=None, state=None):
         super(ScatterJupyterViewer, self).__init__(session, parent=parent, state=state)
         MatplotlibScatterMixin.setup_callbacks(self)

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -1,9 +1,11 @@
 from ipywidgets import HBox
 
 from glue.viewers.common.viewer import Viewer
+from glue.viewers.common.utils import get_viewer_tools
 from glue.core.layer_artist import LayerArtistContainer
 from glue.core import message as msg
 from glue.core.subset import Subset
+
 
 from glue_jupyter.utils import _update_not_none
 
@@ -12,49 +14,11 @@ from glue_jupyter.common.toolbar import BasicJupyterToolbar
 __all__ = ['IPyWidgetView', 'IPyWidgetLayerArtistContainer']
 
 
-def get_viewer_tools(cls, tools=None, subtools=None):
-    """
-    Given a viewer class, find all the tools and subtools to include in the
-    viewer.
-
-    Parameters
-    ----------
-    cls : type
-        The viewer class for which to look for tools.
-    tools : list
-        The list to add the tools to - this is modified in-place.
-    subtools : dict
-        The dictionary to add the subtools to - this is modified in-place.
-    """
-
-    # TODO: mege with version in glue-core
-
-    if not issubclass(cls, IPyWidgetView):
-        return
-    if tools is None:
-        tools = []
-    if subtools is None:
-        subtools = {}
-    if cls.inherit_tools and cls is not IPyWidgetView:
-        for parent_cls in cls.__bases__:
-            get_viewer_tools(parent_cls, tools, subtools)
-    for tool_id in cls.tools:
-        if tool_id not in tools:
-            tools.append(tool_id)
-    for tool_id in cls.subtools:
-        if tool_id not in subtools:
-            subtools[tool_id] = []
-        for subtool_id in cls.subtools[tool_id]:
-            if subtool_id not in subtools[tool_id]:
-                subtools[tool_id].append(subtool_id)
-    return tools, subtools
-
-
 class IPyWidgetLayerArtistContainer(LayerArtistContainer):
 
     def __init__(self):
         super(IPyWidgetLayerArtistContainer, self).__init__()
-        pass  #print('layer artist created')
+        pass
 
 
 class IPyWidgetView(Viewer):

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -1,3 +1,4 @@
+from ipywidgets import HBox
 from ipymaterialui import ToggleButtonGroup, ToggleButton
 
 from glue.viewers.common.viewer import Viewer
@@ -67,6 +68,10 @@ class IPyWidgetView(Viewer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.initialize_toolbar()
+        self.widget_toolbar = HBox([
+                        self.toolbar,
+                        self.session.application.widget_subset_select,
+                        self.session.application.widget_subset_mode])
 
     def add_data(self, data, color=None, alpha=None, **layer_state):
 

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -1,5 +1,4 @@
 from ipywidgets import HBox
-from ipymaterialui import ToggleButtonGroup, ToggleButton
 
 from glue.viewers.common.viewer import Viewer
 from glue.core.layer_artist import LayerArtistContainer
@@ -49,6 +48,7 @@ def get_viewer_tools(cls, tools=None, subtools=None):
             if subtool_id not in subtools[tool_id]:
                 subtools[tool_id].append(subtool_id)
     return tools, subtools
+
 
 class IPyWidgetLayerArtistContainer(LayerArtistContainer):
 


### PR DESCRIPTION
This refactors all code related to selection tools to use the glue CheckableTool infrastructure, and define a general toolbar class. This also enables the use of all the default Matplotlib tools (thanks to https://github.com/glue-viz/glue/pull/1983 and https://github.com/glue-viz/glue/pull/1984).