### PR TITLE
Tidy up how layout is defined for viewers and provide a way to customize

### DIFF
--- a/docs/developer_notes.rst
+++ b/docs/developer_notes.rst
@@ -39,6 +39,52 @@ bi-directional link, where the two properties are kept in sync::
     from glue_jupyter.link import link
     dlink((state, 'color'), (widget, 'color'))
 
+Accessing individual parts of viewers
+-------------------------------------
+
+By default, the data viewers will be shown using a pre-configured layout, with
+the figure on the left, and the viewer and layer options on the right in tabs.
+The selection tools, active subset, and selection mode are shown above.
+However, developers can choose to override this layout. The main individual
+widgets that make up a data viewer can be accessed using the following
+properties on a viewer object:
+
+* `~glue_jupyter.view.IPyWidgetView.toolbar_selection_tools`: the basic
+  selection tools (e.g. the rectangular, circular, or lasso selection tools).
+
+* `~glue_jupyter.view.IPyWidgetView.toolbar_active_subset`: the drop-down
+  menu with the current active subset.
+
+* `~glue_jupyter.view.IPyWidgetView.toolbar_selection_mode`: the toolbar to
+  select the logical subset selection mode.
+
+* `~glue_jupyter.view.IPyWidgetView.figure_widget`: the main widget containing
+  the figure.
+
+* `~glue_jupyter.view.IPyWidgetView.viewer_options`: the collection of
+  widgets used to control the general viewer options.
+
+* `~glue_jupyter.view.IPyWidgetView.layer_options`: a widget that combines
+  a way to select the current layer being edited, and the widgets to control
+  the options for that layer.
+
+* `~glue_jupyter.view.IPyWidgetView.output_widget`: a widget containing textual
+  output such as errors, etc.
+
+To override the layout, define a function that takes a viewer and returns
+a widget containing the layout that you want, for example::
+
+    from ipywidgets import VBox
+
+    def simple_viewer_layout(viewer):
+        return VBox([viewer.toolbar_selection_tools, viewer.figure_widget])
+
+then register it using::
+
+    from glue_jupyter import set_layout_factory
+
+    set_layout_factory(simple_viewer_layout)
+
 Interacting with other glue objects
 -----------------------------------
 

--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -4,7 +4,26 @@ from ._version import __version__  # noqa
 from .app import JupyterApplication  # noqa
 
 __all__ = ['jglue', 'example_data_xyz', 'example_image', 'example_volume',
-           'JupyterApplication']
+           'JupyterApplication', 'set_layout_factory', 'get_layout_factory']
+
+LAYOUT_FACTORY = None
+
+
+def set_layout_factory(func):
+    """
+    Set the function to use to generate the viewer layout. This should take a
+    viewer class and return a widget containing the viewer widgets laid out
+    in the desired way.
+    """
+    global LAYOUT_FACTORY
+    LAYOUT_FACTORY = func
+
+
+def get_layout_factory():
+    """
+    Get the current layout factory. Returns `None` if using the default.
+    """
+    return LAYOUT_FACTORY
 
 
 def jglue(*args, **kwargs):

--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -32,7 +32,7 @@ def jglue(*args, **kwargs):
 
     It is typically easiest to call this function without arguments and load
     data and add links separately in subsequent calls. However, this function
-    can also take the same inputs as the `~glue.qglue.qglue` function.
+    can also take the same inputs as the `~glue.qglue` function.
 
     Once this function is called, it will return a
     `~glue_jupyter.JupyterApplication` object, which can then be used to

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -39,7 +39,7 @@ class JupyterApplication(Application):
         created.
     """
 
-    def __init__(self, data_collection=None, session=None):
+    def __init__(self, data_collection=None, session=None, layout_factory=None):
         super(JupyterApplication, self).__init__(data_collection=data_collection, session=session)
         self.output = widgets.Output()
         self.widget_data_collection = widgets.SelectMultiple()

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -39,7 +39,7 @@ class JupyterApplication(Application):
         created.
     """
 
-    def __init__(self, data_collection=None, session=None, layout_factory=None):
+    def __init__(self, data_collection=None, session=None):
         super(JupyterApplication, self).__init__(data_collection=data_collection, session=session)
         self.output = widgets.Output()
         self.widget_data_collection = widgets.SelectMultiple()

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -56,7 +56,7 @@ class BqplotRectangleMode(InteractCheckableTool):
         self.interact.observe(self.update_selection, "brushing")
 
     def update_selection(self, *args):
-        with self.viewer.output_widget:
+        with self.viewer._output_widget:
             if self.interact.selected_x is not None and self.interact.selected_y is not None:
                 x = self.interact.selected_x
                 y = self.interact.selected_y
@@ -82,7 +82,7 @@ class BqplotXRangeMode(InteractCheckableTool):
         self.interact.observe(self.update_selection, "brushing")
 
     def update_selection(self, *args):
-        with self.viewer.output_widget:
+        with self.viewer._output_widget:
             if self.interact.selected is not None:
                 x = self.interact.selected
                 if x is not None and len(x):
@@ -109,7 +109,7 @@ class BqplotYRangeMode(InteractCheckableTool):
         self.interact.observe(self.update_selection, "brushing")
 
     def update_selection(self, *args):
-        with self.viewer.output_widget:
+        with self.viewer._output_widget:
             if self.interact.selected is not None:
                 y = self.interact.selected
                 if y is not None and len(y):

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -105,11 +105,6 @@ class BqplotBaseView(IPyWidgetView):
             self.scale_y.min = float(self.state.y_min)
             self.scale_y.max = float(self.state.y_max)
 
-    def get_layer_artist(self, cls, layer=None, layer_state=None):
-        layer = super().get_layer_artist(cls, layer=layer, layer_state=layer_state)
-        self._add_layer_tab(layer)
-        return layer
-
     def receive_message(self, message):
         print("Message received:")
         print("{0}".format(message))

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -1,6 +1,5 @@
 import bqplot
 import ipywidgets as widgets
-from IPython.display import display
 
 from glue.core.subset import roi_to_subset_state
 from glue.core.command import ApplySubsetState
@@ -56,29 +55,11 @@ class BqplotBaseView(IPyWidgetView):
 
         on_change([(self.state, 'show_axes')])(self._sync_show_axes)
 
-        self.create_tab()
-        self.output_widget = widgets.Output()
+        self.create_layout()
 
-        self.main_widget = widgets.VBox([
-                self.widget_toolbar,
-                widgets.HBox([self.figure, self.tab]),
-                self.output_widget
-            ])
-
-    def show(self):
-        display(self.main_widget)
-
-    def create_tab(self):
-
-        self.widget_show_axes = widgets.Checkbox(value=True, description="Show axes")
-        link((self.state, 'show_axes'), (self.widget_show_axes, 'value'))
-
-        self.tab_general = widgets.VBox([self.widget_show_axes])
-        self.tab_general.children += self._options_cls(self.state).children
-        children = [self.tab_general]
-
-        self.tab = widgets.Tab(children)
-        self.tab.set_title(0, "General")
+    @property
+    def figure_widget(self):
+        return self.figure
 
     def _sync_show_axes(self):
         # TODO: if moved to state, this would not rely on the widget
@@ -91,7 +72,7 @@ class BqplotBaseView(IPyWidgetView):
 
     def apply_roi(self, roi, use_current=False):
         # TODO: partial copy paste from glue/viewers/matplotlib/qt/data_viewer.py
-        with self.output_widget:
+        with self._output_widget:
             if len(self.layers) > 0:
                 subset_state = self._roi_to_subset_state(roi)
                 cmd = ApplySubsetState(data_collection=self._data,

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -11,7 +11,6 @@ def test_histogram1d(app, dataxyz):
     assert s.state.x_att == 'y'
     assert len(s.layers) == 1
     assert s.layers[0].layer['y'].tolist() == [2, 3, 4]
-    print('updating histogram state')
     s.state.hist_x_min = 1.5
     s.state.hist_x_max = 4.5
     s.state.hist_n_bin = 3
@@ -258,12 +257,12 @@ def test_imshow_nonfloat(app):
 def test_show_axes(app, dataxyz):
     s = app.scatter2d('x', 'y', data=dataxyz)
     assert s.state.show_axes
-    assert s.widget_show_axes.value
+    assert s.viewer_options.widget_show_axes.value
     margin_initial = s.figure.fig_margin
     s.state.show_axes = False
-    assert not s.widget_show_axes.value
+    assert not s.viewer_options.widget_show_axes.value
     assert s.figure.fig_margin != margin_initial
-    s.widget_show_axes.value = True
+    s.viewer_options.widget_show_axes.value = True
     assert s.state.show_axes
     assert s.figure.fig_margin == margin_initial
 

--- a/glue_jupyter/common/state_widgets/viewer_histogram.py
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.py
@@ -1,4 +1,4 @@
-from ipywidgets import VBox, ToggleButton
+from ipywidgets import VBox, ToggleButton, Checkbox
 
 from ...widgets.linked_dropdown import LinkedDropdown
 from ...link import link
@@ -12,15 +12,18 @@ class HistogramViewerStateWidget(VBox):
 
         self.state = viewer_state
 
+        self.widget_show_axes = Checkbox(value=True, description="Show axes")
+        link((self.widget_show_axes, 'value'), (self.state, 'show_axes'))
+
         self.button_normalize = ToggleButton(value=False, description='normalize',
                                              tooltip='Normalize histogram')
         link((self.button_normalize, 'value'), (self.state, 'normalize'))
 
         self.button_cumulative = ToggleButton(value=False, description='cumulative',
-                                             tooltip='Cumulative histogram')
+                                              tooltip='Cumulative histogram')
         link((self.button_cumulative, 'value'), (self.state, 'cumulative'))
 
         self.widget_x_axis = LinkedDropdown(self.state, 'x_att', label='x axis')
 
-        super().__init__([self.widget_x_axis,
-                          self.button_normalize, self.button_cumulative])
+        super().__init__([self.widget_x_axis, self.button_normalize,
+                          self.button_cumulative, self.widget_show_axes])

--- a/glue_jupyter/common/state_widgets/viewer_image.py
+++ b/glue_jupyter/common/state_widgets/viewer_image.py
@@ -13,6 +13,11 @@ class ImageViewerStateWidget(VBox):
 
         self.state = viewer_state
 
+        # Set checkbox for showing/hiding axes
+
+        self.widget_show_axes = Checkbox(value=True, description="Show axes")
+        link((self.widget_show_axes, 'value'), (self.state, 'show_axes'))
+
         # Set up dropdown for color mode
 
         self.widget_color_mode = LinkedDropdown(self.state, 'color_mode', label='mode')
@@ -41,4 +46,4 @@ class ImageViewerStateWidget(VBox):
 
         super().__init__([self.widget_color_mode, self.widget_reference_data,
                           self.widgets_aspect, self.widget_axis_x,
-                          self.widget_axis_y, self.sliders])
+                          self.widget_axis_y, self.sliders, self.widget_show_axes])

--- a/glue_jupyter/common/state_widgets/viewer_profile.py
+++ b/glue_jupyter/common/state_widgets/viewer_profile.py
@@ -1,4 +1,4 @@
-from ipywidgets import VBox, ToggleButton
+from ipywidgets import VBox, ToggleButton, Checkbox
 
 from ...widgets.linked_dropdown import LinkedDropdown
 from ...link import link
@@ -12,6 +12,9 @@ class ProfileViewerStateWidget(VBox):
 
         self.state = viewer_state
 
+        self.widget_show_axes = Checkbox(value=True, description="Show axes")
+        link((self.widget_show_axes, 'value'), (self.state, 'show_axes'))
+
         self.widget_reference_data = LinkedDropdown(self.state, 'reference_data', label='reference')
         self.widget_axis_x = LinkedDropdown(self.state, 'x_att', label='x axis')
         self.widget_function = LinkedDropdown(self.state, 'function', label='function')
@@ -20,5 +23,6 @@ class ProfileViewerStateWidget(VBox):
                                              tooltip='Normalize profiles')
         link((self.button_normalize, 'value'), (self.state, 'normalize'))
 
-        super().__init__([self.widget_reference_data, self.widget_axis_x,
-                          self.widget_function, self.button_normalize])
+        super().__init__([self.widget_reference_data,
+                          self.widget_axis_x, self.widget_function,
+                          self.button_normalize, self.widget_show_axes])

--- a/glue_jupyter/common/state_widgets/viewer_scatter.py
+++ b/glue_jupyter/common/state_widgets/viewer_scatter.py
@@ -1,6 +1,7 @@
-from ipywidgets import VBox
+from ipywidgets import VBox, Checkbox
 
 from ...widgets.linked_dropdown import LinkedDropdown
+from ...link import link
 
 __all__ = ['ScatterViewerStateWidget']
 
@@ -11,7 +12,10 @@ class ScatterViewerStateWidget(VBox):
 
         self.state = viewer_state
 
+        self.widget_show_axes = Checkbox(value=True, description="Show axes")
+        link((self.widget_show_axes, 'value'), (self.state, 'show_axes'))
+
         self.widget_x_axis = LinkedDropdown(self.state, 'x_att', label='x axis')
         self.widget_y_axis = LinkedDropdown(self.state, 'y_att', label='y axis')
 
-        super().__init__([self.widget_x_axis, self.widget_y_axis])
+        super().__init__([self.widget_x_axis, self.widget_y_axis, self.widget_show_axes])

--- a/glue_jupyter/ipyvolume/common/tools.py
+++ b/glue_jupyter/ipyvolume/common/tools.py
@@ -44,7 +44,7 @@ class IpyvolumeLassoMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer.output_widget:
+            with self.viewer._output_widget:
                 region = data['device']
                 vx, vy = zip(*region)
                 roi_2d = PolygonalROI(vx=vx, vy=vy)
@@ -68,7 +68,7 @@ class IpyvolumeCircleMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer.output_widget:
+            with self.viewer._output_widget:
                 x1, y1 = data['device']['begin']
                 x2, y2 = data['device']['end']
                 dx = x2 - x1
@@ -95,7 +95,7 @@ class IpyvolumeRectanglewMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer.output_widget:
+            with self.viewer._output_widget:
                 x1, y1 = data['device']['begin']
                 x2, y2 = data['device']['end']
                 x = [x1, x2]

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -27,11 +27,13 @@ class IpyvolumeBaseView(IPyWidgetView):
 
     def __init__(self, *args, **kwargs):
 
-        self.state = self._state_cls()
         self.figure = ipv.figure(animation_exponent=1.)
         self.figure.selector = ''
 
         super(IpyvolumeBaseView, self).__init__(*args, **kwargs)
+
+        # FIXME: hack for the movie maker to have access to the figure
+        self.state.figure = self.figure
 
         self.state.add_callback('x_min', self.limits_to_scales)
         self.state.add_callback('x_max', self.limits_to_scales)
@@ -41,9 +43,20 @@ class IpyvolumeBaseView(IPyWidgetView):
             self.state.add_callback('z_min', self.limits_to_scales)
             self.state.add_callback('z_max', self.limits_to_scales)
 
+        self.state.add_callback('visible_axes', self._update_axes_visibility)
+
         self._figure_widget = ipv.gcc()
 
         self.create_layout()
+
+    def _update_axes_visibility(self, *args):
+        with self.figure:
+            if self.state.visible_axes:
+                ipv.style.axes_on()
+                ipv.style.box_on()
+            else:
+                ipv.style.axes_off()
+                ipv.style.box_off()
 
     @property
     def figure_widget(self):

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -33,8 +33,6 @@ class IpyvolumeBaseView(IPyWidgetView):
 
         super(IpyvolumeBaseView, self).__init__(*args, **kwargs)
 
-        self.create_tab()
-
         self.state.add_callback('x_min', self.limits_to_scales)
         self.state.add_callback('x_max', self.limits_to_scales)
         self.state.add_callback('y_min', self.limits_to_scales)
@@ -42,12 +40,14 @@ class IpyvolumeBaseView(IPyWidgetView):
         if hasattr(self.state, 'z_min'):
             self.state.add_callback('z_min', self.limits_to_scales)
             self.state.add_callback('z_max', self.limits_to_scales)
-        self.output_widget = widgets.Output()
-        self.main_widget = widgets.VBox(
-            children=[self.widget_toolbar, widgets.HBox([ipv.gcc(), self.tab])])
 
-    def show(self):
-        display(self.main_widget)
+        self._figure_widget = ipv.gcc()
+
+        self.create_layout()
+
+    @property
+    def figure_widget(self):
+        return self._figure_widget
 
     def apply_roi(self, roi, use_current=False):
         if len(self.layers) > 0:
@@ -76,27 +76,3 @@ class IpyvolumeBaseView(IPyWidgetView):
 
     def redraw(self):
         pass
-
-    def create_tab(self):
-
-        def change(visible):
-            with self.figure:
-                if visible:
-                    ipv.style.axes_on()
-                    ipv.style.box_on()
-                else:
-                    ipv.style.axes_off()
-                    ipv.style.box_off()
-        self.state.add_callback('visible_axes', change)
-
-        self.widget_show_movie_maker = ToggleButton(value=False, description="Show movie maker")
-        self.movie_maker = ipv.moviemaker.MovieMaker(self.figure, self.figure.camera)
-        dlink((self.widget_show_movie_maker, 'value'), (self.movie_maker.widget_main.layout, 'display'), lambda value: None if value else 'none')
-
-        self.tab_general = VBox([])
-        self.tab_general.children += self._options_cls(self.state).children
-        self.tab_general.children += (self.widget_show_movie_maker, self.movie_maker.widget_main)
-        children = [self.tab_general]
-        self.tab = Tab(children)
-        self.tab.set_title(0, "General")
-        self.tab.set_title(1, "Axes")

--- a/glue_jupyter/ipyvolume/common/viewer_options_widget.py
+++ b/glue_jupyter/ipyvolume/common/viewer_options_widget.py
@@ -1,6 +1,8 @@
-from ipywidgets import Checkbox, VBox
+from ipywidgets import Checkbox, VBox, ToggleButton
 
-from ...link import link
+import ipyvolume as ipv
+
+from ...link import link, dlink
 from ...widgets import LinkedDropdown
 
 
@@ -18,7 +20,13 @@ class Viewer3DStateWidget(VBox):
 
         self.widgets_axis = []
         for i, axis_name in enumerate('xyz'):
-            widget_axis = LinkedDropdown(self.state, axis_name + '_att', label=axis_name + ' axis')
+            widget_axis = LinkedDropdown(self.state, axis_name + '_att',
+                                         label=axis_name + ' axis')
             self.widgets_axis.append(widget_axis)
 
-        super().__init__([self.widget_show_axes] + self.widgets_axis)
+        self.widget_show_movie_maker = ToggleButton(value=False, description="Show movie maker")
+        self.movie_maker = ipv.moviemaker.MovieMaker(self.state.figure, self.state.figure.camera)
+        dlink((self.widget_show_movie_maker, 'value'),
+              (self.movie_maker.widget_main.layout, 'display'), lambda value: None if value else 'none')
+
+        super().__init__([self.widget_show_axes] + self.widgets_axis + [self.widget_show_movie_maker, self.movie_maker.widget_main])

--- a/glue_jupyter/ipyvolume/common/viewer_options_widget.py
+++ b/glue_jupyter/ipyvolume/common/viewer_options_widget.py
@@ -24,9 +24,11 @@ class Viewer3DStateWidget(VBox):
                                          label=axis_name + ' axis')
             self.widgets_axis.append(widget_axis)
 
-        self.widget_show_movie_maker = ToggleButton(value=False, description="Show movie maker")
-        self.movie_maker = ipv.moviemaker.MovieMaker(self.state.figure, self.state.figure.camera)
-        dlink((self.widget_show_movie_maker, 'value'),
-              (self.movie_maker.widget_main.layout, 'display'), lambda value: None if value else 'none')
+        super().__init__([self.widget_show_axes] + self.widgets_axis)
 
-        super().__init__([self.widget_show_axes] + self.widgets_axis + [self.widget_show_movie_maker, self.movie_maker.widget_main])
+        if hasattr(self.state, 'figure'):
+            self.widget_show_movie_maker = ToggleButton(value=False, description="Show movie maker")
+            self.movie_maker = ipv.moviemaker.MovieMaker(self.state.figure, self.state.figure.camera)
+            dlink((self.widget_show_movie_maker, 'value'),
+                  (self.movie_maker.widget_main.layout, 'display'), lambda value: None if value else 'none')
+            self.children += (self.widget_show_movie_maker, self.movie_maker.widget_main)

--- a/glue_jupyter/ipyvolume/scatter/viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/viewer.py
@@ -21,11 +21,7 @@ class IpyvolumeScatterView(IpyvolumeBaseView):
 
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
-        layer = self.get_layer_artist(self._data_artist_cls, layer=layer, layer_state=layer_state)
-        self._add_layer_tab(layer)
-        return layer
+        return self.get_layer_artist(self._data_artist_cls, layer=layer, layer_state=layer_state)
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):
-        layer = self.get_layer_artist(self._subset_artist_cls, layer=layer, layer_state=layer_state)
-        self._add_layer_tab(layer)
-        return layer
+        return self.get_layer_artist(self._subset_artist_cls, layer=layer, layer_state=layer_state)

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -28,10 +28,10 @@ def test_scatter3d(app, dataxyz, dataxz):
     assert s.state.z_min == 5
     assert s.state.z_max == 7
 
-    assert len(s.tab.children) == 2
+    assert len(s.layer_options._layer_dropdown.options) == 1
     app.subset('test', dataxyz.id['x'] > 2)
     assert len(s.layers) == 2
-    assert len(s.tab.children) == 3
+    assert len(s.layer_options._layer_dropdown.options) == 2
     assert s.layers[1].layer['x'].tolist() == [3]
     assert s.layers[1].layer['y'].tolist() == [4]
     assert s.layers[1].layer['z'].tolist() == [7]
@@ -71,12 +71,12 @@ def test_scatter3d(app, dataxyz, dataxz):
     assert layer.quiver.visible
 
 
-def test_scatter3d_cmap_mode(app,dataxyz):
+def test_scatter3d_cmap_mode(app, dataxyz):
 
     s = app.scatter3d('x', 'y', data=dataxyz)
     l1 = s.layers[0]
 
-    layer_widget = s.tab.children[-1]
+    layer_widget = s.layer_options.children[-1]
 
     assert l1.state.cmap_mode == 'Fixed', 'expected default value'
     assert l1.state.cmap_name == 'Gray'

--- a/glue_jupyter/ipyvolume/volume/viewer.py
+++ b/glue_jupyter/ipyvolume/volume/viewer.py
@@ -28,9 +28,7 @@ class IpyvolumeVolumeView(IpyvolumeBaseView):
             cls = IpyvolumeScatterLayerArtist
         else:
             cls = IpyvolumeVolumeLayerArtist
-        layer = self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
-        self._add_layer_tab(layer)
-        return layer
+        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):
         return self.get_data_layer_artist(layer, layer_state)

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -53,9 +53,3 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
     @property
     def figure_widget(self):
         return self.canvas
-
-    def get_layer_artist(self, cls, layer=None, layer_state=None):
-        # TODO: this method should be defined on the base viewer class
-        layer = super().get_layer_artist(cls, layer=layer, layer_state=layer_state)
-        self._add_layer_tab(layer)
-        return layer

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -45,27 +45,17 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
 
         MatplotlibViewerMixin.setup_callbacks(self)
 
-        self.create_tab()
-        self.output_widget = Output()
-
+        # FIXME - include in figure widget?
         self.css_widget = HTML(REMOVE_TITLE_CSS)
 
-        self.main_widget = VBox([
-                self.css_widget,
-                self.widget_toolbar,
-                HBox([self.canvas, self.tab]),
-                self.output_widget
-            ])
+        self.create_layout()
 
-    def show(self):
-        display(self.main_widget)
+    @property
+    def figure_widget(self):
+        return self.canvas
 
     def get_layer_artist(self, cls, layer=None, layer_state=None):
         # TODO: this method should be defined on the base viewer class
         layer = super().get_layer_artist(cls, layer=layer, layer_state=layer_state)
         self._add_layer_tab(layer)
         return layer
-
-    def create_tab(self):
-        self.tab = Tab([self._options_cls(self.state)])
-        self.tab.set_title(0, "General")

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -45,11 +45,10 @@ class MatplotlibJupyterViewer(MatplotlibViewerMixin, IPyWidgetView):
 
         MatplotlibViewerMixin.setup_callbacks(self)
 
-        # FIXME - include in figure widget?
         self.css_widget = HTML(REMOVE_TITLE_CSS)
 
         self.create_layout()
 
     @property
     def figure_widget(self):
-        return self.canvas
+        return VBox([self.css_widget, self.canvas])

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -12,6 +12,7 @@ from glue.core.subset import Subset
 from glue_jupyter.utils import _update_not_none
 
 from glue_jupyter.common.toolbar import BasicJupyterToolbar
+from glue_jupyter.widgets.layer_options import LayerOptionsWidget
 
 __all__ = ['IPyWidgetView', 'IPyWidgetLayerArtistContainer']
 
@@ -33,6 +34,7 @@ class IPyWidgetView(Viewer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.initialize_layer_options()
         self.initialize_toolbar()
 
     @property
@@ -72,6 +74,21 @@ class IPyWidgetView(Viewer):
         return self._output_widget
 
     @property
+    def viewer_options(self):
+        """
+        A widget containing the options for the current viewer.
+        """
+        return self._layout_viewer_options
+
+    @property
+    def layer_options(self):
+        """
+        A widget containing a layer selector and the options for the selected
+        layer.
+        """
+        return self._layout_layer_options
+
+    @property
     def layout(self):
         """
         The widget containing the final layout of the individual figure widgets.
@@ -90,7 +107,8 @@ class IPyWidgetView(Viewer):
 
         self._layout_viewer_options = self._options_cls(self.state)
 
-        self._layout_tab = Tab([self._layout_viewer_options])
+        self._layout_tab = Tab([self._layout_viewer_options,
+                                self._layout_layer_options])
         self._layout_tab.set_title(0, "General")
         self._layout_tab.set_title(1, "Layers")
 
@@ -131,24 +149,8 @@ class IPyWidgetView(Viewer):
     def get_layer_artist(self, cls, layer=None, layer_state=None):
         return cls(self, self.state, layer=layer, layer_state=layer_state)
 
-    def _add_layer_tab(self, layer):
-        return
-        if isinstance(self._layer_style_widget_cls, dict):
-            layer_tab = self._layer_style_widget_cls[type(layer)](layer.state)
-        else:
-            layer_tab = self._layer_style_widget_cls(layer.state)
-        self.tab.children = self.tab.children + (layer_tab, )
-        if isinstance(layer.layer, Subset):
-            label = '{data_label}:{subset_label}'.format(data_label=layer.layer.data.label, subset_label=layer.layer.label)
-        else:
-            label = layer.layer.label
-
-        # Long tab titles can cause issues
-        # (see https://github.com/jupyter-widgets/ipywidgets/issues/2366)
-        if len(label) > 15:
-            label = label[:15] + '...'
-
-        self.tab.set_title(len(self.tab.children)-1, label)
+    def initialize_layer_options(self):
+        self._layout_layer_options = LayerOptionsWidget(self)
 
     def initialize_toolbar(self):
 

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -9,8 +9,8 @@ from glue.core import message as msg
 from glue.core.subset import Subset
 
 
+from glue_jupyter import get_layout_factory
 from glue_jupyter.utils import _update_not_none
-
 from glue_jupyter.common.toolbar import BasicJupyterToolbar
 from glue_jupyter.widgets.layer_options import LayerOptionsWidget
 
@@ -96,6 +96,12 @@ class IPyWidgetView(Viewer):
         return self._layout
 
     def create_layout(self):
+
+        # Check for a custom layout factory
+        layout_factory = get_layout_factory()
+        if layout_factory is not None:
+            self._layout = layout_factory(self)
+            return
 
         # Take all the different widgets and construct a standard layout
         # for the viewers, based on ipywidgets HBox and VBox. This can be

--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -1,0 +1,62 @@
+from glue.core import Subset
+from ipywidgets import VBox, Dropdown
+
+__all__ = ['LayerOptionsWidget']
+
+
+class LayerOptionsWidget(VBox):
+    """
+    A widget that contains a way to select layers, and will automatically show
+    the options for the selected layer.
+    """
+
+    def __init__(self, viewer):
+
+        self.viewer = viewer
+        self._layer_dropdown = Dropdown(description="Layers")
+
+        self.viewer.state.add_callback('layers', self._update_ui_from_glue_state)
+        self._update_ui_from_glue_state()
+
+        self._layer_dropdown.observe(self._update_layer_options_panel, 'value')
+
+        super(LayerOptionsWidget, self).__init__([self._layer_dropdown])
+
+    def _update_ui_from_glue_state(self, *args):
+
+        layers = self.viewer.layers
+
+        labels = []
+
+        for layer_artist in layers:
+
+            if isinstance(layer_artist.state.layer, Subset):
+                label = layer_artist.state.layer.data.label + ':' + layer_artist.state.layer.label
+            else:
+                label = layer_artist.state.layer.label
+
+            labels.append(label)
+
+        current = self._layer_dropdown.value
+
+        self._layer_dropdown.options = list(zip(labels, layers))
+
+        if len(layers) > 0:
+            if current in layers:
+                self._layer_dropdown.value = current
+            else:
+                self._layer_dropdown.value = layers[0]
+
+    def _update_layer_options_panel(self, *args):
+
+        layer_artist = self._layer_dropdown.value
+
+        if layer_artist is None:
+            return
+
+        if isinstance(self.viewer._layer_style_widget_cls, dict):
+            layer_panel = self.viewer._layer_style_widget_cls[type(layer_artist)](layer_artist.state)
+        else:
+            layer_panel = self.viewer._layer_style_widget_cls(layer_artist.state)
+
+        self.children = self.children[:1] + (layer_panel,)


### PR DESCRIPTION
This tidies up a lot of the code that does the layout for the viewers to be defined in the base class for all Jupyter-based viewers. In addition, this defines a public API for accessing the components for any given viewer, and provides a way to register a custom 'layout factory' that defines a new default layout for viewers, for example:

```python
from ipywidgets import VBox
from glue_jupyter import set_layout_factory

def simple_viewer_layout(viewer):
    return VBox([viewer.toolbar_selection_tools, viewer.figure_widget])

set_layout_factory(simple_viewer_layout)
```

This will make it easier to experiment with ipyvuetify layouts.

Finally, this creates a new widget for editing layer options which consists of a way to select the current layer (for now a dropdown) and shows the options for that specific layer. In future we can improve this, but at least this provides a short-term fix for https://github.com/glue-viz/glue-jupyter/issues/84 by avoiding having many tabs when there are a lot of layers present.