### PR TITLE
Started re-implementing layout with vuetify

### DIFF
--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -23,7 +23,11 @@ def get_layout_factory():
     """
     Get the current layout factory. Returns `None` if using the default.
     """
-    return LAYOUT_FACTORY
+    if LAYOUT_FACTORY is None:
+        from .vuetify_layout import vuetify_layout_factory
+        return vuetify_layout_factory
+    else:   
+        return LAYOUT_FACTORY
 
 
 def jglue(*args, **kwargs):

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -27,9 +27,9 @@ class BqplotBaseView(IPyWidgetView):
 
         self.scales = {'x': self.scale_x, 'y': self.scale_y}
         self.axis_x = bqplot.Axis(
-            scale=self.scale_x, grid_lines='solid', label='x')
+            scale=self.scale_x, grid_lines='none', label='x')
         self.axis_y = bqplot.Axis(scale=self.scale_y, orientation='vertical', tick_format='0.2f',
-                                  grid_lines='solid', label='y')
+                                  grid_lines='none', label='y')
         def update_axes(*ignore):
             self.axis_x.label = str(self.state.x_att)
             if self.is2d:

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -18,7 +18,6 @@ class BasicJupyterToolbar(v.BtnToggle):
         self.output = viewer.output_widget
 
     def _change_tool(self, widget, event, data):
-
         with self.output:
 
             if self.active is not None:
@@ -32,5 +31,6 @@ class BasicJupyterToolbar(v.BtnToggle):
     def add_tool(self, tool):
         self.tools[tool.tool_id] = tool
         icon = Image.from_file(icon_path(tool.icon, icon_format='svg'), width=ICON_WIDTH)
-        button = v.Btn(icon=True, children=[icon], value=tool.tool_id)
-        self.children = list(self.children) + [button]
+        button = v.Btn(slot='activator', icon=True, children=[icon], value=tool.tool_id)
+        annotated = v.Tooltip(bottom=True, children=[button, tool.tool_tip])
+        self.children = list(self.children) + [annotated]

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -1,0 +1,36 @@
+import ipyvuetify as v
+from ipywidgets import Image
+
+from glue.icons import icon_path
+
+__all__ = ['BasicJupyterToolbar']
+
+ICON_WIDTH = 20
+
+
+class BasicJupyterToolbar(v.BtnToggle):
+
+    def __init__(self, viewer):
+        super().__init__(v_model='toggle_exclusive', class_='transparent')
+        self.tools = {}
+        self.on_event('change', self._change_tool)
+        self.active = None
+        self.output = viewer.output_widget
+
+    def _change_tool(self, widget, event, data):
+
+        with self.output:
+
+            if self.active is not None:
+                self.tools[self.active].deactivate()
+                self.active = None
+
+            if data is not None:
+                self.tools[data].activate()
+                self.active = data
+
+    def add_tool(self, tool):
+        self.tools[tool.tool_id] = tool
+        icon = Image.from_file(icon_path(tool.icon, icon_format='svg'), width=ICON_WIDTH)
+        button = v.Btn(icon=True, children=[icon], value=tool.tool_id)
+        self.children = list(self.children) + [button]

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -25,7 +25,7 @@ class BasicJupyterToolbar(v.BtnToggle):
                 self.tools[self.active].deactivate()
                 self.active = None
 
-            if data is not None:
+            if data:
                 self.tools[data].activate()
                 self.active = data
 

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -1,7 +1,9 @@
 import ipyvuetify as v
+import traitlets
 from ipywidgets import Image
 
 from glue.icons import icon_path
+import glue.viewers.common.tool
 
 __all__ = ['BasicJupyterToolbar']
 
@@ -9,24 +11,26 @@ ICON_WIDTH = 20
 
 
 class BasicJupyterToolbar(v.BtnToggle):
+    active_tool = traitlets.Instance(glue.viewers.common.tool.Tool)
 
     def __init__(self, viewer):
-        super().__init__(v_model='toggle_exclusive', class_='transparent')
-        self.tools = {}
-        self.on_event('change', self._change_tool)
-        self.active = None
         self.output = viewer.output_widget
+        self.tools = {}
+        super().__init__(v_model=None, class_='transparent')
 
-    def _change_tool(self, widget, event, data):
+    @traitlets.observe('v_model')
+    def _on_change_v_model(self, change):
         with self.output:
+            if change.new is not None:
+                self.active_tool = self.tools[change.new]
 
-            if self.active is not None:
-                self.tools[self.active].deactivate()
-                self.active = None
-
-            if data:
-                self.tools[data].activate()
-                self.active = data
+    @traitlets.observe('active_tool')
+    def _on_change_active_tool(self, change):
+        with self.output:
+            if change.old:
+                change.old.deactivate()
+            if change.new:
+                change.new.activate()
 
     def add_tool(self, tool):
         self.tools[tool.tool_id] = tool
@@ -34,3 +38,7 @@ class BasicJupyterToolbar(v.BtnToggle):
         button = v.Btn(slot='activator', icon=True, children=[icon], value=tool.tool_id)
         annotated = v.Tooltip(bottom=True, children=[button, tool.tool_tip])
         self.children = list(self.children) + [annotated]
+
+
+# traitlets bug?
+BasicJupyterToolbar.active_tool.default_value = None

--- a/glue_jupyter/ipywidgets_layout.py
+++ b/glue_jupyter/ipywidgets_layout.py
@@ -1,0 +1,31 @@
+# A vuetify layout for the glue data viewers. For now we keep this isolated to
+# a single file, but once we are happy with it we can just replace the original
+# default layout.
+
+from ipywidgets import HBox, Tab, VBox
+
+
+__all__ = ['ipywidgets_layout_factory']
+
+
+def ipywidgets_layout_factory(viewer):
+
+    # Take all the different widgets and construct a standard layout
+    # for the viewers, based on ipywidgets HBox and VBox. This can be
+    # overriden in sub-classes to create alternate layouts.
+
+    layout_toolbar = HBox([viewer.toolbar_selection_tools,
+                           viewer.toolbar_active_subset,
+                           viewer.toolbar_selection_mode])
+
+    layout_tab = Tab([viewer.viewer_options,
+                      viewer.layer_options  ])
+    layout_tab.set_title(0, "General")
+    layout_tab.set_title(1, "Layers")
+
+    layout = VBox([layout_toolbar,
+                   HBox([viewer.figure_widget,
+                         layout_tab]),
+                   viewer.output_widget])
+
+    return layout

--- a/glue_jupyter/matplotlib/base.py
+++ b/glue_jupyter/matplotlib/base.py
@@ -5,8 +5,7 @@ from IPython.display import display
 
 try:
     from ipympl.backend_nbagg import Canvas, FigureManager
-except ImportError:
-    # Prior to June 2019
+except ImportError:  # Prior to June 2019
     from ipympl.backend_nbagg import FigureCanvasNbAgg as Canvas, FigureManagerNbAgg as FigureManager
 
 from matplotlib.figure import Figure

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -1,4 +1,4 @@
-from ipywidgets import HBox, Tab, VBox, Output
+from ipywidgets import Output
 
 from IPython.display import display
 
@@ -6,7 +6,6 @@ from glue.viewers.common.viewer import Viewer
 from glue.viewers.common.utils import get_viewer_tools
 from glue.core.layer_artist import LayerArtistContainer
 from glue.core import message as msg
-from glue.core.subset import Subset
 
 
 from glue_jupyter import get_layout_factory
@@ -102,26 +101,10 @@ class IPyWidgetView(Viewer):
 
         # Check for a custom layout factory
         layout_factory = get_layout_factory()
-        if layout_factory is not None:
+        if layout_factory is None:
+            raise ValueError('layout factory should be set with set_layout_factory')
+        else:
             self._layout = layout_factory(self)
-            return
-
-        # Take all the different widgets and construct a standard layout
-        # for the viewers, based on ipywidgets HBox and VBox. This can be
-        # overriden in sub-classes to create alternate layouts.
-
-        self._layout_toolbar = HBox([self.toolbar_selection_tools,
-                                     self.toolbar_active_subset,
-                                     self.toolbar_selection_mode])
-
-        self._layout_tab = Tab([self._layout_viewer_options,
-                                self._layout_layer_options])
-        self._layout_tab.set_title(0, "General")
-        self._layout_tab.set_title(1, "Layers")
-
-        self._layout = VBox([self._layout_toolbar,
-                             HBox([self.figure_widget, self._layout_tab]),
-                             self._output_widget])
 
     def show(self):
         display(self._layout)

--- a/glue_jupyter/vuetify_layout.py
+++ b/glue_jupyter/vuetify_layout.py
@@ -22,10 +22,15 @@ def vuetify_layout_factory(viewer):
     sidebar_button = v.ToolbarSideIcon()
     sidebar_button.on_event('click', on_click)
 
+    options_panel = v.ExpansionPanel(v_model=[True, True], expand=True,
+                                     children=[v.ExpansionPanelContent(children=[v.Html(tag='b', slot='header', children=['Viewer Options']),
+                                                                                 v.Card(children=[viewer.viewer_options])]),
+                                               v.ExpansionPanelContent(children=[v.Html(tag='b', slot='header', children=['Layer Options']),
+                                                                                 v.Card(children=[viewer.layer_options])])])
+
     drawer = v.NavigationDrawer(v_model=False, absolute=True, right=True,
                                 children=[sidebar_button,
-                                          viewer.viewer_options,
-                                          viewer.layer_options])
+                                          options_panel], width=350)
 
     toolbar_selection_tools = BasicJupyterToolbar(viewer)
 

--- a/glue_jupyter/vuetify_layout.py
+++ b/glue_jupyter/vuetify_layout.py
@@ -1,63 +1,18 @@
-# A vuetify layout for the glue data viewers
+# A vuetify layout for the glue data viewers. For now we keep this isolated to
+# a single file, but once we are happy with it we can just replace the original
+# default layout.
 
 import ipyvuetify as v
-from ipywidgets import HBox
+from ipywidgets import Output
 
-import glue.core.message as msg
-from glue.core.hub import HubListener
+from glue.config import viewer_tool
 
+from glue_jupyter.view import get_viewer_tools
+from glue_jupyter.common.toolbar_vuetify import BasicJupyterToolbar
+from glue_jupyter.widgets.subset_mode_vuetify import SelectionModeMenu
+from glue_jupyter.widgets.subset_select_vuetify import SubsetSelect
 
-class SelectionModeMenu(v.Menu, HubListener):
-
-    def __init__(self, viewer):
-
-        self.session = viewer.session
-
-        self.modes = viewer.toolbar_selection_mode.selection_modes
-
-        items = []
-        for mode in self.modes:
-            item = v.ListTile(children=[v.ListTileAction(children=[mode[1]]),
-                                        v.ListTileTitle(children=[mode[0]])])
-            items.append(item)
-
-        for item in items:
-            item.on_event('click', self._sync_state_from_ui)
-
-        mylist = v.List(children=items)
-
-        self.main = v.Btn(icon=True,
-                          children=[self.modes[0][1]], slot='activator')
-
-        super().__init__(children=[self.main, mylist])
-
-        self.session.hub.subscribe(self, msg.EditSubsetMessage,
-                                   handler=self._on_edit_subset_msg)
-
-        self._sync_ui_from_state(self.session.edit_subset_mode.mode)
-
-    def _sync_state_from_ui(self, widget, event, data):
-        icon = widget.children[0].children[0]
-        self.main.children = [icon]
-        for mode in self.modes:
-            if icon in mode[1]:
-                break
-        else:
-            mode = self.modes[0]
-        self.session.edit_subset_mode.mode = mode
-
-    def _on_edit_subset_msg(self, msg):
-        self._sync_ui_from_state(msg.mode)
-
-    def _sync_ui_from_state(self, mode):
-        if self.session.edit_subset_mode.mode != mode:
-            self.session.edit_subset_mode.mode = mode
-        for m in self.modes:
-            if mode is m[2]:
-                icon = m[1]
-        else:
-            icon = self.modes[0][1]
-        self.main.children = [icon]
+__all__ = ['vuetify_layout_factory']
 
 
 def vuetify_layout_factory(viewer):
@@ -73,22 +28,33 @@ def vuetify_layout_factory(viewer):
                                           viewer.viewer_options,
                                           viewer.layer_options])
 
-    toolbar_selection_tools = [v.Btn(icon=True, children=[button.children[0]])
-                               for button in viewer.toolbar_selection_tools.children]
+    toolbar_selection_tools = BasicJupyterToolbar(viewer)
+
+    tool_ids, subtool_ids = get_viewer_tools(viewer.__class__)
+
+    if subtool_ids:
+        raise ValueError('subtools are not yet supported in Jupyter viewers')
+
+    for tool_id in tool_ids:
+        mode_cls = viewer_tool.members[tool_id]
+        mode = mode_cls(viewer)
+        toolbar_selection_tools.add_tool(mode)
+
+    toolbar_active_subset = SubsetSelect(viewer)
 
     toolbar_selection_mode = SelectionModeMenu(viewer)
 
     toolbar = v.Toolbar(dense=True,
-                        children=[v.ToolbarItems(children=toolbar_selection_tools +
-                                                          [viewer.toolbar_active_subset,
-                                                           toolbar_selection_mode]),
+                        children=[v.ToolbarItems(children=[toolbar_selection_tools,
+                                                           toolbar_selection_mode,
+                                                           toolbar_active_subset]),
                                   v.Spacer(),
                                   sidebar_button])
 
     layout = v.Layout(row=True, wrap=True, children=[
         toolbar,
-        v.Flex(x12=True,
-               children=[viewer.figure_widget]),
+        v.Flex(x12=True, children=[viewer.figure_widget]),
+        v.Flex(x12=True, children=[viewer.output_widget]),
         drawer
     ])
 

--- a/glue_jupyter/vuetify_layout.py
+++ b/glue_jupyter/vuetify_layout.py
@@ -1,0 +1,95 @@
+# A vuetify layout for the glue data viewers
+
+import ipyvuetify as v
+from ipywidgets import HBox
+
+import glue.core.message as msg
+from glue.core.hub import HubListener
+
+
+class SelectionModeMenu(v.Menu, HubListener):
+
+    def __init__(self, viewer):
+
+        self.session = viewer.session
+
+        self.modes = viewer.toolbar_selection_mode.selection_modes
+
+        items = []
+        for mode in self.modes:
+            item = v.ListTile(children=[v.ListTileAction(children=[mode[1]]),
+                                        v.ListTileTitle(children=[mode[0]])])
+            items.append(item)
+
+        for item in items:
+            item.on_event('click', self._sync_state_from_ui)
+
+        mylist = v.List(children=items)
+
+        self.main = v.Btn(icon=True,
+                          children=[self.modes[0][1]], slot='activator')
+
+        super().__init__(children=[self.main, mylist])
+
+        self.session.hub.subscribe(self, msg.EditSubsetMessage,
+                                   handler=self._on_edit_subset_msg)
+
+        self._sync_ui_from_state(self.session.edit_subset_mode.mode)
+
+    def _sync_state_from_ui(self, widget, event, data):
+        icon = widget.children[0].children[0]
+        self.main.children = [icon]
+        for mode in self.modes:
+            if icon in mode[1]:
+                break
+        else:
+            mode = self.modes[0]
+        self.session.edit_subset_mode.mode = mode
+
+    def _on_edit_subset_msg(self, msg):
+        self._sync_ui_from_state(msg.mode)
+
+    def _sync_ui_from_state(self, mode):
+        if self.session.edit_subset_mode.mode != mode:
+            self.session.edit_subset_mode.mode = mode
+        for m in self.modes:
+            if mode is m[2]:
+                icon = m[1]
+        else:
+            icon = self.modes[0][1]
+        self.main.children = [icon]
+
+
+def vuetify_layout_factory(viewer):
+
+    def on_click(widget, event, data):
+        drawer.v_model = not drawer.v_model
+
+    sidebar_button = v.ToolbarSideIcon()
+    sidebar_button.on_event('click', on_click)
+
+    drawer = v.NavigationDrawer(v_model=False, absolute=True, right=True,
+                                children=[sidebar_button,
+                                          viewer.viewer_options,
+                                          viewer.layer_options])
+
+    toolbar_selection_tools = [v.Btn(icon=True, children=[button.children[0]])
+                               for button in viewer.toolbar_selection_tools.children]
+
+    toolbar_selection_mode = SelectionModeMenu(viewer)
+
+    toolbar = v.Toolbar(dense=True,
+                        children=[v.ToolbarItems(children=toolbar_selection_tools +
+                                                          [viewer.toolbar_active_subset,
+                                                           toolbar_selection_mode]),
+                                  v.Spacer(),
+                                  sidebar_button])
+
+    layout = v.Layout(row=True, wrap=True, children=[
+        toolbar,
+        v.Flex(x12=True,
+               children=[viewer.figure_widget]),
+        drawer
+    ])
+
+    return layout

--- a/glue_jupyter/vuetify_layout.py
+++ b/glue_jupyter/vuetify_layout.py
@@ -3,7 +3,6 @@
 # default layout.
 
 import ipyvuetify as v
-from ipywidgets import Output
 
 from glue.config import viewer_tool
 
@@ -44,16 +43,16 @@ def vuetify_layout_factory(viewer):
 
     toolbar_selection_mode = SelectionModeMenu(viewer)
 
-    toolbar = v.Toolbar(dense=True,
+    toolbar = v.Toolbar(dense=True, class_='elevation-0',
                         children=[v.ToolbarItems(children=[toolbar_selection_tools,
                                                            toolbar_selection_mode,
                                                            toolbar_active_subset]),
                                   v.Spacer(),
                                   sidebar_button])
 
-    layout = v.Layout(row=True, wrap=True, children=[
+    layout = v.Layout(row=True, wrap=True, color='transparent', children=[
         toolbar,
-        v.Flex(x12=True, children=[viewer.figure_widget]),
+        v.Flex(x12=True, children=[viewer.figure_widget], color='transparent'),
         v.Flex(x12=True, children=[viewer.output_widget]),
         drawer
     ])

--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -13,7 +13,7 @@ class LayerOptionsWidget(VBox):
     def __init__(self, viewer):
 
         self.viewer = viewer
-        self._layer_dropdown = Dropdown(description="Layers")
+        self._layer_dropdown = Dropdown(description="Layer")
 
         self.viewer.state.add_callback('layers', self._update_ui_from_glue_state)
         self._update_ui_from_glue_state()

--- a/glue_jupyter/widgets/subset_mode_vuetify.py
+++ b/glue_jupyter/widgets/subset_mode_vuetify.py
@@ -3,6 +3,7 @@ import ipyvuetify as v
 
 import glue.core.message as msg
 from glue.core.hub import HubListener
+from glue.utils.decorators import avoid_circular
 
 __all__ = ['SelectionModeMenu']
 
@@ -37,6 +38,7 @@ class SelectionModeMenu(v.Menu, HubListener):
 
         self._sync_ui_from_state(self.session.edit_subset_mode.mode)
 
+    @avoid_circular
     def _sync_state_from_ui(self, widget, event, data):
         with self.output:
             icon = widget.children[0].children[0]
@@ -51,6 +53,7 @@ class SelectionModeMenu(v.Menu, HubListener):
     def _on_edit_subset_msg(self, msg):
         self._sync_ui_from_state(msg.mode)
 
+    @avoid_circular
     def _sync_ui_from_state(self, mode):
         with self.output:
             if self.session.edit_subset_mode.mode != mode:

--- a/glue_jupyter/widgets/subset_mode_vuetify.py
+++ b/glue_jupyter/widgets/subset_mode_vuetify.py
@@ -1,0 +1,63 @@
+
+import ipyvuetify as v
+
+import glue.core.message as msg
+from glue.core.hub import HubListener
+
+__all__ = ['SelectionModeMenu']
+
+
+class SelectionModeMenu(v.Menu, HubListener):
+
+    def __init__(self, viewer):
+
+        self.output = viewer.output_widget
+        self.session = viewer.session
+
+        self.modes = viewer.toolbar_selection_mode.selection_modes
+
+        items = []
+        for mode in self.modes:
+            item = v.ListTile(children=[v.ListTileAction(children=[mode[1]]),
+                                        v.ListTileTitle(children=[mode[0]])])
+            items.append(item)
+
+        for item in items:
+            item.on_event('click', self._sync_state_from_ui)
+
+        mylist = v.List(children=items)
+
+        self.main = v.Btn(icon=True,
+                          children=[self.modes[0][1]], slot='activator')
+
+        super().__init__(children=[self.main, mylist])
+
+        self.session.hub.subscribe(self, msg.EditSubsetMessage,
+                                   handler=self._on_edit_subset_msg)
+
+        self._sync_ui_from_state(self.session.edit_subset_mode.mode)
+
+    def _sync_state_from_ui(self, widget, event, data):
+        with self.output:
+            icon = widget.children[0].children[0]
+            self.main.children = [icon]
+            for mode in self.modes:
+                if icon is mode[1]:
+                    break
+            else:
+                mode = self.modes[0]
+            self.session.edit_subset_mode.mode = mode[2]
+
+    def _on_edit_subset_msg(self, msg):
+        self._sync_ui_from_state(msg.mode)
+
+    def _sync_ui_from_state(self, mode):
+        with self.output:
+            if self.session.edit_subset_mode.mode != mode:
+                self.session.edit_subset_mode.mode = mode
+            for m in self.modes:
+                if mode is m[2]:
+                    icon = m[1]
+            else:
+                icon = self.modes[0][1]
+            self.main.children = [icon]

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -19,7 +19,7 @@ class SubsetSelect(v.Menu, HubListener):
         self.session = viewer.session
         self.data_collection = viewer.session.data_collection
 
-        self.main = v.Btn(children=["No selection (create new)"], slot='activator')
+        self.main = v.Btn(children=["No selection (create new)"], slot='activator', flat=True)
 
         self.widget_menu_item_no_active = v.ListTile(children=[v.ListTileTitle(children=["No selection (create new)"])])
         self.widget_menu_item_no_active.on_event('click', self._sync_state_from_ui)

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -1,0 +1,79 @@
+import ipyvuetify as v
+
+from glue.core import message as msg
+from glue.core.hub import HubListener
+
+__all__ = ['SubsetSelect']
+
+
+class SubsetSelect(v.Menu, HubListener):
+    """
+    Widget responsible for selecting which subsets are active, sync state between UI and glue.
+    """
+
+    def __init__(self, viewer):
+
+        super().__init__(children=[])
+
+        self.output = viewer.output_widget
+        self.session = viewer.session
+        self.data_collection = viewer.session.data_collection
+
+        self.main = v.Btn(children=["No selection (create new)"], slot='activator')
+
+        self.widget_menu_item_no_active = v.ListTile(children=[v.ListTileTitle(children=["No selection (create new)"])])
+        self.widget_menu_item_no_active.on_event('click', self._sync_state_from_ui)
+
+        self.subset_list = v.List(children=[self.widget_menu_item_no_active])
+
+        # state change events from glue come in from the hub
+        self.session.hub.subscribe(self, msg.EditSubsetMessage, handler=self._on_edit_subset_msg)
+        self.session.hub.subscribe(self, msg.SubsetCreateMessage, handler=self._on_subset_create_msg)
+
+        # state changes from the UI via this observed trait
+        self.on_event('change', self._sync_state_from_ui)
+
+        # manually trigger to set up the initial state
+        self._sync_ui_from_state(self.session.edit_subset_mode.edit_subset)
+
+        self.children = [self.main, self.subset_list]
+
+    def _on_edit_subset_msg(self, msg):
+        self._sync_ui_from_state(msg.subset)
+
+    def _on_subset_create_msg(self, msg):
+        self._sync_ui_from_state(self.session.edit_subset_mode.edit_subset)
+
+    def _sync_state_from_ui(self, widget, event, data):
+
+        # triggered when ui's value changes
+
+        with self.output:
+
+            index = self.subset_list.children.index(widget) - 1
+
+            if index < 0:
+                self.session.edit_subset_mode.edit_subset = []
+            else:
+                self.session.edit_subset_mode.edit_subset = [self.data_collection.subset_groups[index]]
+
+    def _sync_ui_from_state(self, subset_groups_selected):
+
+        # this is called when the state in glue is changed, we sync the UI to reflect its state
+
+        with self.output:
+
+            items = [self.widget_menu_item_no_active]
+
+            for i, subset_group in enumerate(self.data_collection.subset_groups):
+                # TODO: could avoid re-creating widgets as we do for the material UI version
+                item = v.ListTile(children=[v.ListTileTitle(children=[subset_group.label])])
+                item.on_event('click', self._sync_state_from_ui)
+                items.append(item)
+
+            self.subset_list.children = items
+
+            if self.session.edit_subset_mode.edit_subset:
+                self.main.children = [self.session.edit_subset_mode.edit_subset[0].label]
+            else:
+                self.main.children = ["No selection (create new)"]

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -62,18 +62,20 @@ class SubsetSelect(v.Menu, HubListener):
         # this is called when the state in glue is changed, we sync the UI to reflect its state
 
         with self.output:
-
             items = [self.widget_menu_item_no_active]
-
-            for i, subset_group in enumerate(self.data_collection.subset_groups):
-                # TODO: could avoid re-creating widgets as we do for the material UI version
-                item = v.ListTile(children=[v.ListTileTitle(children=[subset_group.label])])
-                item.on_event('click', self._sync_state_from_ui)
-                items.append(item)
+            with self.main.hold_sync():
+                self.main.children = ["No selection (create new)"]
+                for subset_group in self.data_collection.subset_groups:
+                    # TODO: could avoid re-creating widgets as we do for the material UI version
+                    # we're using a triangular icon here, since in the UI it's close to a round icon, which is confusing
+                    item = v.ListTile(children=[
+                        v.ListTileAvatar(children=[v.Icon(children=['signal_cellular_4_bar'], color=subset_group.style.color)]),
+                        v.ListTileTitle(children=[subset_group.label])
+                    ])
+                    item.on_event('click', self._sync_state_from_ui)
+                    items.append(item)
+                    # TODO: this supports only a single active subset (it will actually only show the last)
+                    if subset_group in self.session.edit_subset_mode.edit_subset:
+                        self.main.children = item.children[:]
 
             self.subset_list.children = items
-
-            if self.session.edit_subset_mode.edit_subset:
-                self.main.children = [self.session.edit_subset_mode.edit_subset[0].label]
-            else:
-                self.main.children = ["No selection (create new)"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     ipyvolume
     ipywidgets
     ipymaterialui>=0.1.1
+    ipyvuetify
     bqplot-image-gl
     bqplot==0.12.0a2
 


### PR DESCRIPTION
This starts to implement a vuetify-based interface for viewers. To try it out:

```python
from glue_jupyter import set_layout_factory
from glue_jupyter.vuetify_layout import vuetify_layout_factory
set_layout_factory(vuetify_layout_factory)
```

Preview of scatter viewer with sidebar collapsed:

![Screenshot from 2019-06-07 17-43-22](https://user-images.githubusercontent.com/314716/59119867-d0ca9280-894b-11e9-87c4-ba83f432acaf.png)


and with sidebar open:

![Screenshot from 2019-06-07 17-43-32](https://user-images.githubusercontent.com/314716/59119873-d4f6b000-894b-11e9-98a9-d6ef774efbd8.png)


I haven't yet re-implemented the way to allow multiple subset selections, but it's definitely possible. Also, the viewer and layer options in the sidebar still use ipywidgets - for now we might want to keep this as is since it's actually pretty compact.