### PR TITLE
Replace deprecated Div reference with Html

### DIFF
--- a/glue_jupyter/widgets/linked_dropdown.py
+++ b/glue_jupyter/widgets/linked_dropdown.py
@@ -95,7 +95,7 @@ class LinkedDropdown(Dropdown):
                     self.value = None
 
 
-class LinkedDropdownMaterial(mui.Div):
+class LinkedDropdownMaterial(mui.Html):
     """
     A dropdown widget that is automatically linked to a SelectionCallbackProperty
     and syncs changes both ways (Material UI version)

--- a/glue_jupyter/widgets/subset_mode.py
+++ b/glue_jupyter/widgets/subset_mode.py
@@ -14,7 +14,7 @@ icon_xor = widgets.Image.from_file(glue.icons.icon_path("glue_xor", icon_format=
 icon_andnot = widgets.Image.from_file(glue.icons.icon_path("glue_andnot", icon_format="svg"), width=ICON_WIDTH)
 
 
-class SubsetMode(mui.Div, HubListener):
+class SubsetMode(mui.Html, HubListener):
     """Widget that manages the subset mode (replace/add/and/xor/remove) state between UI and glue state.
 
     On glue's side, the state is in `session.edit_subset_mode.mode`. On the UI side, the state

--- a/glue_jupyter/widgets/subset_select.py
+++ b/glue_jupyter/widgets/subset_select.py
@@ -5,7 +5,7 @@ from glue.core import message as msg
 from glue.core.hub import HubListener
 
 
-class SubsetSelect(mui.Div, HubListener):
+class SubsetSelect(mui.Html, HubListener):
     """Widget responsible for selecting which subsets are active, sync state between UI and glue.
 
     On glue's side, the state is in `session.edit_subset_mode.edit_subset`. On the UI side, the state


### PR DESCRIPTION
The `Div` bindings seems to have been removed in the latest versions of ipymaterialui. Replacing with the `Html` component seems to solve the issue.