### PR TITLE
Explicitly set toolbar children if uninitialized

### DIFF
--- a/glue_jupyter/common/toolbar.py
+++ b/glue_jupyter/common/toolbar.py
@@ -30,4 +30,8 @@ class BasicJupyterToolbar(ToggleButtonGroup):
         icon = Image.from_file(icon_path(tool.icon, icon_format='svg'),
                                width=ICON_WIDTH)
         button = ToggleButton(children=[icon], value=tool.tool_id)
-        self.children += (button,)
+
+        if self.children is None:
+            self.children = (button,)
+        else:
+            self.children += (button,)


### PR DESCRIPTION
Apparently it's possible that an ipywidget's children attribute is not initialized as an empty list object. In that case, check first before concatenating lists.