### PR TITLE
Allow data as strings and change to kwarg-only arguments for viewers

### DIFF
--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -1,7 +1,7 @@
 import ipywidgets as widgets
 from IPython.display import display
 
-
+from glue.core import Data
 from glue.core.application_base import Application
 from glue.core.link_helpers import LinkSame
 from glue.core.roi import PolygonalROI
@@ -10,7 +10,7 @@ from glue.core.command import ApplySubsetState
 from glue.core.edit_subset_mode import (NewMode, ReplaceMode, AndMode, OrMode,
                                         XorMode, AndNotMode)
 
-from glue_jupyter.utils import _update_not_none
+from glue_jupyter.utils import _update_not_none, validate_data_argument
 from glue_jupyter.widgets.subset_select import SubsetSelect
 from glue_jupyter.widgets.subset_mode import SubsetMode
 
@@ -105,7 +105,7 @@ class JupyterApplication(Application):
             viewer.show()
         return viewer
 
-    def histogram1d(self, x=None, data=None, widget='bqplot', color=None,
+    def histogram1d(self, *, data=None, x=None, widget='bqplot', color=None,
                     x_min=None, x_max=None, n_bin=None, normalize=False,
                     cumulative=False, viewer_state=None, layer_state=None,
                     show=True):
@@ -114,12 +114,12 @@ class JupyterApplication(Application):
 
         Parameters
         ----------
-        x : str or `~glue.core.component_id.ComponentID`, optional
-            The attribute to show on the x axis.
-        data : `~glue.core.data.Data`, optional
+        data : str or `~glue.core.data.Data`, optional
             The initial dataset to show in the viewer. Additional
             datasets can be added later using the ``add_data`` method on
             the viewer object.
+        x : str or `~glue.core.component_id.ComponentID`, optional
+            The attribute to show on the x axis.
         widget : {'bqplot', 'matplotlib'}
             Whether to use bqplot or Matplotlib as the front-end.
         color : str or tuple, optional
@@ -154,11 +154,7 @@ class JupyterApplication(Application):
         else:
             raise ValueError("Widget type should be 'bqplot' or 'matplotlib'")
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         viewer_state_obj = viewer_cls._state_cls()
         viewer_state_obj.x_att_helper.append_data(data)
@@ -180,21 +176,21 @@ class JupyterApplication(Application):
         view.layers[0].state.update_from_dict(layer_state)
         return view
 
-    def scatter2d(self, x=None, y=None, data=None, widget='bqplot', color=None,
+    def scatter2d(self, *, data=None, x=None, y=None, widget='bqplot', color=None,
                   size=None, viewer_state=None, layer_state=None, show=True):
         """
         Open an interactive 2d scatter plot viewer.
 
         Parameters
         ----------
+        data : str or `~glue.core.data.Data`, optional
+            The initial dataset to show in the viewer. Additional
+            datasets can be added later using the ``add_data`` method on
+            the viewer object.
         x : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the x axis.
         y : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the y axis.
-        data : `~glue.core.data.Data`, optional
-            The initial dataset to show in the viewer. Additional
-            datasets can be added later using the ``add_data`` method on
-            the viewer object.
         widget : {'bqplot', 'matplotlib'}
             Whether to use bqplot or Matplotlib as the front-end.
         color : str or tuple, optional
@@ -222,11 +218,7 @@ class JupyterApplication(Application):
         else:
             raise ValueError("Widget type should be 'bqplot' or 'matplotlib'")
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         viewer_state_obj = viewer_cls._state_cls()
         viewer_state_obj.x_att_helper.append_data(data)
@@ -247,22 +239,22 @@ class JupyterApplication(Application):
         view.layers[0].state.update_from_dict(layer_state)
         return view
 
-    def scatter3d(self, x=None, y=None, z=None, data=None, show=True):
+    def scatter3d(self, *, data=None, x=None, y=None, z=None, show=True):
         """
         Open an interactive 3d scatter plot viewer.
 
         Parameters
         ----------
+        data : str or `~glue.core.data.Data`, optional
+            The initial dataset to show in the viewer. Additional
+            datasets can be added later using the ``add_data`` method on
+            the viewer object.
         x : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the x axis.
         y : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the y axis.
         z : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the z axis.
-        data : `~glue.core.data.Data`, optional
-            The initial dataset to show in the viewer. Additional
-            datasets can be added later using the ``add_data`` method on
-            the viewer object.
         show : bool, optional
             Whether to show the view immediately (`True`) or whether to only
             show it later if the ``show()`` method is called explicitly
@@ -271,11 +263,7 @@ class JupyterApplication(Application):
 
         from .ipyvolume import IpyvolumeScatterView
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         view = self.new_data_viewer(IpyvolumeScatterView, data=data, show=show)
         if x is not None:
@@ -289,22 +277,22 @@ class JupyterApplication(Application):
             view.state.z_att = z
         return view
 
-    def imshow(self, x=None, y=None, data=None, widget='bqplot', show=True):
+    def imshow(self, *, data=None, x=None, y=None, widget='bqplot', show=True):
         """
         Open an interactive image viewer.
 
         Parameters
         ----------
+        data : str or `~glue.core.data.Data`, optional
+            The initial dataset to show in the viewer. Additional
+            datasets can be added later using the ``add_data`` method on
+            the viewer object.
         x : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the x axis. This should be one of the
             pixel axis attributes.
         y : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the y axis. This should be one of the
             pixel axis attributes.
-        data : `~glue.core.data.Data`, optional
-            The initial dataset to show in the viewer. Additional
-            datasets can be added later using the ``add_data`` method on
-            the viewer object.
         widget : {'bqplot', 'matplotlib'}
             Whether to use bqplot or Matplotlib as the front-end.
         show : bool, optional
@@ -322,11 +310,7 @@ class JupyterApplication(Application):
         else:
             raise ValueError("Widget type should be 'bqplot' or 'matplotlib'")
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         if len(data.pixel_component_ids) < 2:
             raise ValueError('Only data with two or more dimensions can be used '
@@ -344,19 +328,19 @@ class JupyterApplication(Application):
 
         return view
 
-    def profile1d(self, x=None, data=None, widget='bqplot', show=True):
+    def profile1d(self, *, data=None, x=None, widget='bqplot', show=True):
         """
         Open an interactive 1d profile viewer.
 
         Parameters
         ----------
-        x : str or `~glue.core.component_id.ComponentID`, optional
-            The attribute to show on the x axis. This should be a pixel or
-            world coordinate `~glue.core.component_id.ComponentID`.
-        data : `~glue.core.data.Data`, optional
+        data : str or `~glue.core.data.Data`, optional
             The initial dataset to show in the viewer. Additional
             datasets can be added later using the ``add_data`` method on
             the viewer object.
+        x : str or `~glue.core.component_id.ComponentID`, optional
+            The attribute to show on the x axis. This should be a pixel or
+            world coordinate `~glue.core.component_id.ComponentID`.
         widget : {'bqplot', 'matplotlib'}
             Whether to use bqplot or Matplotlib as the front-end.
         show : bool, optional
@@ -374,11 +358,7 @@ class JupyterApplication(Application):
         else:
             raise ValueError("Widget type should be 'matplotlib'")
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         view = self.new_data_viewer(viewer_cls, data=data, show=show)
 
@@ -388,12 +368,16 @@ class JupyterApplication(Application):
 
         return view
 
-    def volshow(self, x=None, y=None, z=None, data=None, show=True):
+    def volshow(self, *, data=None, x=None, y=None, z=None, show=True):
         """
         Open an interactive volume viewer.
 
         Parameters
         ----------
+        data : str or `~glue.core.data.Data`, optional
+            The initial dataset to show in the viewer. Additional
+            datasets can be added later using the ``add_data`` method on
+            the viewer object.
         x : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the x axis. This should be one of the
             pixel axis attributes.
@@ -403,10 +387,6 @@ class JupyterApplication(Application):
         z : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the z axis. This should be one of the
             pixel axis attributes.
-        data : `~glue.core.data.Data`, optional
-            The initial dataset to show in the viewer. Additional
-            datasets can be added later using the ``add_data`` method on
-            the viewer object.
         show : bool, optional
             Whether to show the view immediately (`True`) or whether to only
             show it later if the ``show()`` method is called explicitly
@@ -414,11 +394,7 @@ class JupyterApplication(Application):
          """
         from .ipyvolume import IpyvolumeVolumeView
 
-        if data is None:
-            if len(self._data) != 1:
-                raise ValueError('There is more than one data set in the data collection, please pass a data argument')
-            else:
-                data = self._data[0]
+        data = validate_data_argument(self.data_collection, data)
 
         view = self.new_data_viewer(IpyvolumeVolumeView, data=data, show=show)
 

--- a/glue_jupyter/bqplot/scatter/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/scatter/tests/test_viewer.py
@@ -2,7 +2,7 @@ def test_scatter2d_nd(app, data_4d):
     # Regression test for a bug that meant that arrays with more than one
     # dimension did not work correctly.
     app.add_data(data_4d)
-    scatter = app.scatter2d('x', 'x', data=data_4d)
+    scatter = app.scatter2d(x='x', y='x', data=data_4d)
     scatter.state.layers[0].vector_visible = True
     scatter.state.layers[0].size_mode = 'Linear'
     scatter.state.layers[0].cmap_mode = 'Linear'

--- a/glue_jupyter/bqplot/tests/data/bqplot.ipynb
+++ b/glue_jupyter/bqplot/tests/data/bqplot.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "histogram = app.histogram1d('x', data=data1d, widget='bqplot')"
+    "histogram = app.histogram1d(x='x', data=data1d, widget='bqplot')"
    ]
   },
   {
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatter = app.scatter2d('x', 'y', data=data1d, widget='bqplot')"
+    "scatter = app.scatter2d(x='x', y='y', data=data1d, widget='bqplot')"
    ]
   },
   {

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -7,7 +7,7 @@ DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 
 def test_histogram1d(app, dataxyz):
-    s = app.histogram1d('y', data=dataxyz)
+    s = app.histogram1d(x='y', data=dataxyz)
     assert s.state.x_att == 'y'
     assert len(s.layers) == 1
     assert s.layers[0].layer['y'].tolist() == [2, 3, 4]
@@ -40,7 +40,7 @@ def test_histogram1d(app, dataxyz):
 
 def test_histogram1d_multiple_subsets(app, data_unlinked, datax):
     # Make sure that things work fine if an incompatible subset is added
-    viewer = app.histogram1d('x', data=datax)
+    viewer = app.histogram1d(x='x', data=datax)
     app.subset('test1', datax.id['x'] > 1)
     app.subset('test2', data_unlinked.id['a'] > 1)
     assert viewer.layers[0].enabled
@@ -49,7 +49,7 @@ def test_histogram1d_multiple_subsets(app, data_unlinked, datax):
 
 
 def test_interact(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     # s.widget_menu_select_x.value = True
     # s.widget_menu_select_x.click()# = True
     tool = s.toolbar.tools['bqplot:xrange']
@@ -58,7 +58,7 @@ def test_interact(app, dataxyz):
 
 
 def test_scatter2d(app, dataxyz, dataxz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     assert s.state.x_att == 'x'
     assert s.state.y_att == 'y'
 
@@ -68,7 +68,7 @@ def test_scatter2d(app, dataxyz, dataxz):
     # assert s.state.y_max == 4
 
     # test when we swap x and x
-    s = app.scatter2d('y', 'x', data=dataxyz)
+    s = app.scatter2d(x='y', y='x', data=dataxyz)
     assert s.state.x_att == 'y'
     assert s.state.y_att == 'x'
     # assert s.state.y_min == 1
@@ -85,7 +85,7 @@ def test_scatter2d(app, dataxyz, dataxz):
 
 
 def test_scatter2d_density(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     s.layers[0].state.points_mode = 'density'
     assert s.layers[0].state.density_map == True
 
@@ -99,7 +99,7 @@ def test_scatter2d_density(app, dataxyz):
 
 
 def test_scatter2d_subset(app, dataxyz, dataxz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     app.subset('test', dataxyz.id['x'] > 2)
     assert len(s.layers) == 2
     assert s.layers[1].layer['x'].tolist() == [3]
@@ -118,7 +118,7 @@ def test_scatter2d_subset(app, dataxyz, dataxz):
 
 def test_scatter2d_multiple_subsets(app, data_unlinked, dataxz):
     # Make sure that things work fine if an incompatible subset is added
-    viewer = app.scatter2d('x', 'z', data=dataxz)
+    viewer = app.scatter2d(x='x', y='z', data=dataxz)
     app.subset('test1', dataxz.id['x'] > 1)
     app.subset('test2', data_unlinked.id['a'] > 1)
     assert viewer.layers[0].enabled
@@ -127,7 +127,7 @@ def test_scatter2d_multiple_subsets(app, data_unlinked, dataxz):
 
 
 def test_scatter2d_brush(app, dataxyz, dataxz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
 
     # 1d x brushing
     tool1d = s.toolbar.tools['bqplot:xrange']
@@ -184,14 +184,14 @@ def test_scatter2d_brush(app, dataxyz, dataxz):
 
 
 def test_scatter2d_properties(app, dataxyz, dataxz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     l1 = s.layers[0]
     l1.state.color = 'green'
     assert l1.scatter.colors == ['#008000']
 
 
 def test_scatter2d_cmap_mode(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     l1 = s.layers[0]
     assert l1.state.cmap_mode == 'Fixed', 'expected default value'
     assert l1.state.cmap_name == 'Gray'
@@ -206,8 +206,8 @@ def test_scatter2d_cmap_mode(app, dataxyz):
 
 
 def test_scatter2d_and_histogram(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
-    h = app.histogram1d('x', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
+    h = app.histogram1d(x='x', data=dataxyz)
     tool = s.toolbar.tools['bqplot:rectangle']
     tool.activate()
     tool.interact.brushing = True
@@ -255,7 +255,7 @@ def test_imshow_nonfloat(app):
 
 
 def test_show_axes(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz)
+    s = app.scatter2d(x='x', y='y', data=dataxyz)
     assert s.state.show_axes
     assert s.viewer_options.widget_show_axes.value
     margin_initial = s.figure.fig_margin

--- a/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
@@ -2,7 +2,7 @@ def test_scatter3d_nd(app, data_4d):
     # Make sure that things work correctly with arrays that have more than
     # one dimension.
     app.add_data(data_4d)
-    scatter = app.scatter3d('x', 'x', 'x', data=data_4d)
+    scatter = app.scatter3d(x='x', y='x', z='x', data=data_4d)
     scatter.state.layers[0].vector_visible = True
     scatter.state.layers[0].size_mode = 'Linear'
     scatter.state.layers[0].cmap_mode = 'Linear'

--- a/glue_jupyter/ipyvolume/tests/data/ipyvolume.ipynb
+++ b/glue_jupyter/ipyvolume/tests/data/ipyvolume.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatter = app.scatter3d('x', 'y', 'z', data=data1d)"
+    "scatter = app.scatter3d(x='x', y='y', z='z', data=data1d)"
    ]
   },
   {

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -16,7 +16,7 @@ xyzw2yxzw = np.array([
 
 
 def test_scatter3d(app, dataxyz, dataxz):
-    s = app.scatter3d('x', 'y', 'z', data=dataxyz)
+    s = app.scatter3d(x='x', y='y', z='z', data=dataxyz)
     assert s.state.x_att == 'x'
     assert s.state.y_att == 'y'
     # assert s.state.z_att == 'z'
@@ -73,7 +73,7 @@ def test_scatter3d(app, dataxyz, dataxz):
 
 def test_scatter3d_cmap_mode(app, dataxyz):
 
-    s = app.scatter3d('x', 'y', data=dataxyz)
+    s = app.scatter3d(x='x', y='y', data=dataxyz)
     l1 = s.layers[0]
 
     layer_widget = s.layer_options.children[-1]
@@ -109,7 +109,7 @@ def test_roi3d(dataxyz):
     assert roi.contains3d(dataxyz['x'], dataxyz['y'], dataxyz['z']).tolist() == [True, True, False]
 
 def test_lasso3d(app, dataxyz):
-    s = app.scatter3d('x', 'y', 'z', data=dataxyz)
+    s = app.scatter3d(x='x', y='y', z='z', data=dataxyz)
     s.figure.matrix_world = np.eye(4).ravel().tolist()
     s.figure.matrix_projection = np.eye(4).ravel().tolist()
     # similar to the roi3d test above, and this is the format that ipyvolume send back
@@ -141,7 +141,7 @@ def test_lasso3d(app, dataxyz):
 
 def test_scatter3d_multiple_subsets(app, data_unlinked, dataxyz):
     # Make sure that things work fine if an incompatible subset is added
-    viewer = app.scatter3d('x', 'y', 'z', data=dataxyz)
+    viewer = app.scatter3d(x='x', y='y', z='z', data=dataxyz)
     app.subset('test1', dataxyz.id['x'] > 1)
     app.subset('test2', data_unlinked.id['a'] > 1)
     assert viewer.layers[0].enabled

--- a/glue_jupyter/matplotlib/tests/data/matplotlib.ipynb
+++ b/glue_jupyter/matplotlib/tests/data/matplotlib.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "histogram = app.histogram1d('x', data=data1d, widget='matplotlib')"
+    "histogram = app.histogram1d(x='x', data=data1d, widget='matplotlib')"
    ]
   },
   {
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatter = app.scatter2d('x', 'y', data=data1d, widget='matplotlib')"
+    "scatter = app.scatter2d(x='x', y='y', data=data1d, widget='matplotlib')"
    ]
   },
   {
@@ -100,7 +100,7 @@
    },
    "outputs": [],
    "source": [
-    "profile = app.profile1d('Pixel Axis 1 [x]', data=data2d, widget='matplotlib')"
+    "profile = app.profile1d(x='Pixel Axis 1 [x]', data=data2d, widget='matplotlib')"
    ]
   },
   {

--- a/glue_jupyter/tests/main_test.py
+++ b/glue_jupyter/tests/main_test.py
@@ -1,7 +1,11 @@
 import os
 
+import pytest
 import nbformat
+import numpy as np
 from nbconvert.preprocessors import ExecutePreprocessor
+
+from glue.core import Data
 
 import glue_jupyter as gj
 
@@ -30,7 +34,7 @@ def test_default_components(app, datax, dataxz, dataxyz):
 
 
 def test_viewer_state(app, dataxyz):
-    s = app.scatter2d('x', 'y', data=dataxyz, viewer_state=dict(x_att=dataxyz.id['y'], y_att=dataxyz.id['z'], x_min=-1, x_max=1))
+    s = app.scatter2d(x='x', y='y', data=dataxyz, viewer_state=dict(x_att=dataxyz.id['y'], y_att=dataxyz.id['z'], x_min=-1, x_max=1))
     # direct argument have preference over the viewer_state
     assert s.state.x_att is dataxyz.id['x']
     assert s.state.y_att is dataxyz.id['y']
@@ -38,13 +42,13 @@ def test_viewer_state(app, dataxyz):
     assert s.state.x_max == 1
 
     # was testing with x_min, but it gets reset to hist_x_min
-    s = app.histogram1d('y', data=dataxyz, viewer_state=dict(x_att=dataxyz.id['z'], hist_x_min=-1, hist_x_max=1))
+    s = app.histogram1d(x='y', data=dataxyz, viewer_state=dict(x_att=dataxyz.id['z'], hist_x_min=-1, hist_x_max=1))
     assert s.state.x_att is dataxyz.id['y']
     assert s.state.hist_x_min == -1
     assert s.state.hist_x_max == 1
 
     # x_min is used for the API, this sets viewer.state.hist_x_min/max which sets again viewer.state.x_min
-    s = app.histogram1d('y', data=dataxyz, x_min=-2, x_max=2)
+    s = app.histogram1d(x='y', data=dataxyz, x_min=-2, x_max=2)
     assert s.state.x_att is dataxyz.id['y']
     assert s.state.hist_x_min == -2
     assert s.state.hist_x_max == 2
@@ -59,12 +63,12 @@ def test_layer_state(app, dataxyz):
     s = app.scatter2d(data=dataxyz, size=11, layer_state=dict(size=10))
     assert s.layers[0].state.size == 11
 
-    s = app.histogram1d('x', data=dataxyz, layer_state=dict(color='green'))
+    s = app.histogram1d(x='x', data=dataxyz, layer_state=dict(color='green'))
     assert s.layers[0].state.color == '#008000'
 
 
 def test_add_data_with_state(app, dataxz, dataxyz):
-    s = app.scatter2d('x', 'z', data=dataxz, color='green')
+    s = app.scatter2d(x='x', y='z', data=dataxz, color='green')
     s.add_data(dataxyz, color='red', alpha=0.2, size=3.3)
     assert s.layers[0].state.color == '#008000'
     assert s.layers[1].state.color == 'red'
@@ -94,3 +98,65 @@ def test_state_widget_notebook():
 
     ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
     ep.preprocess(nb, {'metadata': {'path': DATA}})
+
+
+INVALID_TYPE_EXC = """
+The data argument should either be a glue data object or the name of a dataset. The following datasets are available:
+
+  * 'mydata1'
+  * 'mydata2'
+"""
+
+INVALID_NAME_EXC = """
+'mydata3' is not a valid dataset name. The following datasets are available:
+
+  * 'mydata1'
+  * 'mydata2'
+"""
+
+
+VIEWERS = ['histogram1d', 'scatter2d', 'scatter3d', 'imshow', 'profile1d', 'volshow']
+
+
+@pytest.mark.parametrize('viewer_name', VIEWERS)
+def test_data_names(app, viewer_name):
+
+    # Make sure that we can refer to datasets by name in the viewers, and check
+    # the error message if an invalid object is passed.
+
+    data1 = Data(x=np.ones((2, 3, 4)))
+    data2 = Data(y=np.ones((2, 3, 4)))
+
+    app.data_collection.clear()
+    app.add_data(mydata1=data1)
+    app.add_data(mydata2=data2)
+
+    viewer_method = getattr(app, viewer_name)
+
+    # If we pass something that isn't a valid data object or a string we should
+    # get an error:
+
+    with pytest.raises(TypeError) as exc:
+        viewer_method(data=1 + 1j)
+    assert exc.value.args[0] == INVALID_TYPE_EXC.strip()
+
+    # If the name of the dataset doesn't exist, we also give an explicit
+    # error.
+
+    with pytest.raises(ValueError) as exc:
+        viewer_method(data='mydata3')
+    assert exc.value.args[0] == INVALID_NAME_EXC.strip()
+
+    # Passing a valid name should work
+
+    hist = viewer_method(data='mydata1')
+
+    # We can check for the validation again when calling add_data
+
+    with pytest.raises(TypeError) as exc:
+        hist.add_data(data=1 + 1j)
+    assert exc.value.args[0] == INVALID_TYPE_EXC.strip()
+
+    with pytest.raises(ValueError) as exc:
+        hist.add_data(data='mydata3')
+    assert exc.value.args[0] == INVALID_NAME_EXC.strip()

--- a/glue_jupyter/tests/main_test.py
+++ b/glue_jupyter/tests/main_test.py
@@ -8,6 +8,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from glue.core import Data
 
 import glue_jupyter as gj
+from glue_jupyter.utils import GLUE_LT_016
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -127,7 +128,12 @@ def test_data_names(app, viewer_name):
     data1 = Data(x=np.ones((2, 3, 4)))
     data2 = Data(y=np.ones((2, 3, 4)))
 
-    app.data_collection.clear()
+    if GLUE_LT_016:
+        for data in list(app.data_collection):
+            app.data_collection.remove(data)
+    else:
+        app.data_collection.clear()
+
     app.add_data(mydata1=data1)
     app.add_data(mydata2=data2)
 

--- a/glue_jupyter/utils.py
+++ b/glue_jupyter/utils.py
@@ -6,6 +6,7 @@ import PIL.Image
 import numpy as np
 from io import BytesIO as StringIO # python3
 
+from glue.core import Data
 
 def float_or_none(x):
     return float(x) if x is not None else None
@@ -129,3 +130,30 @@ def colormap_to_hexlist(cmap, N=256):
     x = np.linspace(0, 1, N)
     colors = ["#%02x%02x%02x" % tuple([int(k*255) for k in color]) for color in cmap(x)[:,:3]]
     return colors
+
+
+def validate_data_argument(data_collection, data):
+    """
+    Validate the data argument passed to the viewer functions and return
+    a glue data object.
+    """
+
+    if data is None:
+        if len(data_collection) != 1:
+            raise ValueError('There is more than one data set in the data collection, please pass a data argument')
+        else:
+            return data_collection[0]
+    elif isinstance(data, str):
+        if data in data_collection:
+            return data_collection[data]
+        else:
+            raise ValueError(f"'{data}' is not a valid dataset name. The "
+                                "following datasets are available:\n\n" +
+                                "\n".join([f"  * '{d.label}'" for d in data_collection]) )
+    elif not isinstance(data, Data):
+        raise TypeError('The data argument should either be a glue data '
+                        'object or the name of a dataset. The following '
+                        'datasets are available:\n\n' +
+                        '\n'.join([f"  * '{d.label}'" for d in data_collection]) )
+    else:
+        return data

--- a/glue_jupyter/utils.py
+++ b/glue_jupyter/utils.py
@@ -1,12 +1,17 @@
 import functools
 import collections
 import time
+from distutils.version import LooseVersion
 
 import PIL.Image
 import numpy as np
 from io import BytesIO as StringIO # python3
 
+from glue import __version__ as glue_version
 from glue.core import Data
+
+GLUE_LT_016 = LooseVersion(glue_version) < LooseVersion('0.16')
+
 
 def float_or_none(x):
     return float(x) if x is not None else None
@@ -144,7 +149,11 @@ def validate_data_argument(data_collection, data):
         else:
             return data_collection[0]
     elif isinstance(data, str):
-        if data in data_collection:
+        if GLUE_LT_016 and data in [d.label for d in data_collection]:
+            for d in data_collection:
+                if d.label == data:
+                    return d
+        elif not GLUE_LT_016 and data in data_collection:
             return data_collection[data]
         else:
             raise ValueError(f"'{data}' is not a valid dataset name. The "

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -128,11 +128,7 @@ class IPyWidgetView(Viewer):
 
     def add_data(self, data, color=None, alpha=None, **layer_state):
 
-        print(type(data))
-
         data = validate_data_argument(self._data, data)
-
-        print(type(data))
 
         result = super().add_data(data)
 

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -10,7 +10,7 @@ from glue.core.subset import Subset
 
 
 from glue_jupyter import get_layout_factory
-from glue_jupyter.utils import _update_not_none
+from glue_jupyter.utils import _update_not_none, validate_data_argument
 from glue_jupyter.common.toolbar import BasicJupyterToolbar
 from glue_jupyter.widgets.layer_options import LayerOptionsWidget
 
@@ -127,6 +127,12 @@ class IPyWidgetView(Viewer):
         display(self._layout)
 
     def add_data(self, data, color=None, alpha=None, **layer_state):
+
+        print(type(data))
+
+        data = validate_data_argument(self._data, data)
+
+        print(type(data))
 
         result = super().add_data(data)
 

--- a/notebooks/Astronomy/W5/W5 Tutorial.ipynb
+++ b/notebooks/Astronomy/W5/W5 Tutorial.ipynb
@@ -112,7 +112,7 @@
    },
    "outputs": [],
    "source": [
-    "scatter_viewer = app.scatter2d('[4.5]-[5.8]', '[8.0]', data=data_catalog)"
+    "scatter_viewer = app.scatter2d(x='[4.5]-[5.8]', y='[8.0]', data=data_catalog)"
    ]
   },
   {
@@ -148,7 +148,7 @@
    },
    "outputs": [],
    "source": [
-    "histogram_viewer = app.histogram1d('Jmag', data=data_catalog)"
+    "histogram_viewer = app.histogram1d(x='Jmag', data=data_catalog)"
    ]
   },
   {

--- a/notebooks/Generic/demo_gaussian.ipynb
+++ b/notebooks/Generic/demo_gaussian.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = app.scatter2d('x', 'y')"
+    "s = app.scatter2d(x='x', y='y')"
    ]
   },
   {
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = app.scatter3d('x', 'y', 'z')"
+    "s = app.scatter3d(x='x', y='y', z='z')"
    ]
   },
   {
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = app.scatter3d('vx', 'vy', 'vz')"
+    "s = app.scatter3d(x='vx', y='vy', z='vz')"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = app.histogram1d('speed')"
+    "s = app.histogram1d(x='speed')"
    ]
   }
  ],

--- a/notebooks/Planes/Boston Planes.ipynb
+++ b/notebooks/Planes/Boston Planes.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatter_viewer = app.scatter2d('x', 'y', planes)"
+    "scatter_viewer = app.scatter2d(x='x', y='y', data=planes)"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "histogram_viewer = app.histogram1d('vertical_rate', planes)"
+    "histogram_viewer = app.histogram1d(x='vertical_rate', data=planes)"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatter_3d_viewer = app.scatter3d('x', 'y', 'altitude', planes)"
+    "scatter_3d_viewer = app.scatter3d(x='x', y='y', z='altitude', data=planes)"
    ]
   }
  ],


### PR DESCRIPTION
This does two things:

* It allows data to be specified using the data labels both when creating viewers and when calling ``add_data`` later.

* It changes the arguments for the viewers to be keyword-only (see https://github.com/glue-viz/glue-jupyter/issues/73 for a discussion). This might  compatibility with some existing notebooks but I think this is better to fix before we actually have a first stable release.