### PR TITLE
Fix Azure Pipelines configuration for Mac builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,24 +15,23 @@ jobs:
 
     envs:
 
-    - linux: pep8
+    - linux: codestyle
       libraries: {}
       coverage: 'false'
 
     - linux: py36-test
     - linux: py37-test
 
-    - macosx: py36-test
-    - macosx: py37-test
+    - macos: py36-test
+    - macos: py37-test
 
     - windows: py36-test
     - windows: py37-test
 
     - linux: py37-notebooks
-    - macosx: py37-notebooks
+    - macos: py37-notebooks
     - windows: py36-notebooks
 
     - linux: py37-docs
-    - macosx: py37-docs
+    - macos: py37-docs
     - windows: py36-docs
-

--- a/binder/setup.sh
+++ b/binder/setup.sh
@@ -15,7 +15,7 @@ pip install . jupyterlab astroquery --user
 
 jupyter labextension install @jupyter-widgets/jupyterlab-manager \
                              ipyvolume jupyter-threejs jupyter-materialui \
-                             bqplot@0.5.0-alpha.0 bqplot-image-gl --no-build
+                             bqplot bqplot-image-gl --no-build
 
 # Re-build Jupyter Lab
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -46,4 +46,4 @@ then install the following extensions manually::
 
     jupyter labextension install @jupyter-widgets/jupyterlab-manager \
                                  ipyvolume jupyter-threejs jupyter-materialui \
-                                 bqplot@0.5.0-alpha.0 bqplot-image-gl
+                                 bqplot bqplot-image-gl

--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -141,7 +141,7 @@ class BqplotScatterLayerArtist(LayerArtist):
             with self.image.hold_sync():
                 self.image.x = range_x
                 self.image.y = range_y
-                self.image.image = self.counts.T.copy(np.float32)
+                self.image.image = self.counts.T.astype(np.float32, copy=True)
 
     def _update_scatter(self, **changes):
         self.update_histogram()

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     ipymaterialui==0.1.1
     ipyvuetify>=1.0.4,<2
     bqplot-image-gl
-    bqplot==0.12.0b0
+    bqplot>=0.12
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-{pep8,test,notebooks,docs}
+    py{36,37,38}-{test,notebooks,docs}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -29,7 +29,7 @@ commands =
     notebooks: python .validate-notebooks.py
     docs: sphinx-build -n -b html -d _build/doctrees   . _build/html
 
-[testenv:pep8]
+[testenv:codestyle]
 deps = flake8
 skipsdist = true
 commands =


### PR DESCRIPTION
This fixes the Azure configuration to use ``macos`` instead of ``macosx``

I've also switched to using the stable version of bqplot! :tada:

Fixes #114