### PR TITLE
Fix case where Data.coords is None

### DIFF
--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -110,13 +110,12 @@ def example_image(shape=64, limits=[-4, 4]):
     """
     Creates a test 2-d dataset containing an image.
     """
-    from glue.core import Data, Coordinates
+    from glue.core import Data
     import numpy as np
     x = np.linspace(-3, 3, num=shape)
     X, Y = np.meshgrid(x, x)
     rho = 0.8
     intensity = np.exp(-X**2-Y**2-2*X*Y*rho)
     data = Data()
-    data.coords = Coordinates()
     data.add_component(intensity, label='intensity')
     return data

--- a/glue_jupyter/common/slice_helpers.py
+++ b/glue_jupyter/common/slice_helpers.py
@@ -75,7 +75,10 @@ class MultiSliceWidgetHelper(object):
                     self._sliders.append(None)
                     continue
 
-                label = self.viewer_state.reference_data.world_component_ids[i].label
+                if self.viewer_state.reference_data.coords is None:
+                    label = self.viewer_state.reference_data.pixel_component_ids[i].label
+                else:
+                    label = self.viewer_state.reference_data.world_component_ids[i].label
                 slider = IntSlider(min=0, max=self.data.shape[i]-1, description=label)
 
                 slider.observe(self.sync_state_from_sliders, 'value')


### PR DESCRIPTION
This fixes the test suite for the changes in https://github.com/glue-viz/glue/pull/2079 - but in fact the changes here are more general, and are to make sure things work correctly if ``Data.coords`` is ``None``