### PR TITLE
Scatter 3D Default Marker

### DIFF
--- a/glue_jupyter/ipyvolume/scatter/layer_artist.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_artist.py
@@ -17,7 +17,7 @@ __all__ = ['Scatter3DLayerState', 'IpyvolumeScatterLayerArtist']
 class Scatter3DLayerState(ScatterLayerState):
 
     # FIXME: the following should be a SelectionCallbackProperty
-    geo = CallbackProperty('sphere', docstring="Type of marker")
+    geo = CallbackProperty('diamond', docstring="Type of marker")
     vz_att = SelectionCallbackProperty(docstring="The attribute to use for the z vector arrow")
 
     def __init__(self, viewer_state=None, layer=None, **kwargs):

--- a/glue_jupyter/ipyvolume/scatter/layer_style_widget.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_style_widget.py
@@ -16,7 +16,7 @@ class Scatter3DLayerStateWidget(VBox):
         self.widget_visible = Checkbox(description='visible', value=self.state.visible)
         link((self.state, 'visible'), (self.widget_visible, 'value'))
 
-        self.widget_marker = ToggleButtons(options=['sphere', 'box', 'diamond'])
+        self.widget_marker = ToggleButtons(options=['sphere', 'box', 'diamond', 'circle_2d'])
         link((self.state, 'geo'), (self.widget_marker, 'value'))
 
         self.widget_size = Size(state=self.state)


### PR DESCRIPTION
Fix for #144. Change the default scatter3d marker to diamond for performance reasons. Also add circle_2d as a marker option for a better performing circular option.