### PR TITLE
fix: flip y and z axis of ipyvolume scatter to be consistent with glue-qt (z-up)

### DIFF
--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -75,12 +75,12 @@ class IpyvolumeBaseView(IPyWidgetView):
         if self.state.x_min is not None and self.state.x_max is not None:
             self.figure.xlim = self.state.x_min, self.state.x_max
         if self.state.y_min is not None and self.state.y_max is not None:
-            self.figure.ylim = self.state.y_min, self.state.y_max
+            self.figure.zlim = self.state.y_min, self.state.y_max
         # if self.state.z_min is not None and self.state.z_max is not None:
         #     self.figure.zlim = self.state.z_min, self.state.z_max
         if hasattr(self.state, 'z_min'):
             if self.state.z_min is not None and self.state.z_max is not None:
-                self.figure.zlim = self.state.z_min, self.state.z_max
+                self.figure.ylim = self.state.z_min, self.state.z_max
 
     def redraw(self):
         pass

--- a/glue_jupyter/ipyvolume/scatter/layer_artist.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_artist.py
@@ -96,11 +96,11 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
     def update(self):
         # we don't use layer, but layer.data to get everything
         self.scatter.x = ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel()
-        self.scatter.y = ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel()
-        self.scatter.z = ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel()
+        self.scatter.z = ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel()
+        self.scatter.y = ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel()
         self.quiver.x = self.scatter.x
-        self.quiver.y = self.scatter.y
-        self.quiver.z = self.scatter.z
+        self.quiver.z = self.scatter.y
+        self.quiver.y = self.scatter.z
         if isinstance(self.layer, Subset):
 
             try:
@@ -124,8 +124,8 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
     def _update_quiver(self):
         with self.quiver.hold_sync():
             self.quiver.vx = self.layer.data[self.state.vx_att].ravel()
-            self.quiver.vy = self.layer.data[self.state.vy_att].ravel()
-            self.quiver.vz = self.layer.data[self.state.vz_att].ravel()
+            self.quiver.vz = self.layer.data[self.state.vy_att].ravel()
+            self.quiver.vy = self.layer.data[self.state.vz_att].ravel()
 
     def _update_size(self):
         size = self.state.size

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -37,16 +37,16 @@ def test_scatter3d(app, dataxyz, dataxz):
     assert s.layers[1].layer['z'].tolist() == [7]
 
     assert s.layers[1].scatter.x.tolist() == [1, 2, 3]
-    assert s.layers[1].scatter.y.tolist() == [2, 3, 4]
-    assert s.layers[1].scatter.z.tolist() == [5, 6, 7]
+    assert s.layers[1].scatter.z.tolist() == [2, 3, 4]
+    assert s.layers[1].scatter.y.tolist() == [5, 6, 7]
     assert s.layers[1].scatter.selected == [2]
 
     s.state.x_att = dataxyz.id['y']
     s.state.y_att = dataxyz.id['z']
     s.state.z_att = dataxyz.id['x']
     assert s.layers[1].scatter.x.tolist() == [2, 3, 4]
-    assert s.layers[1].scatter.y.tolist() == [5, 6, 7]
-    assert s.layers[1].scatter.z.tolist() == [1, 2, 3]
+    assert s.layers[1].scatter.z.tolist() == [5, 6, 7]
+    assert s.layers[1].scatter.y.tolist() == [1, 2, 3]
     assert s.layers[1].scatter.selected == [2]
 
     size_previous = s.layers[0].scatter.size


### PR DESCRIPTION


Closes #146 