### PR TITLE
feat: dlink attribute labels to ipvolume labels

### DIFF
--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -5,6 +5,7 @@ from glue.core.subset import RoiSubsetState3d
 from glue.core.command import ApplySubsetState
 
 from ...view import IPyWidgetView
+from ...link import dlink
 
 from .viewer_options_widget import Viewer3DStateWidget
 
@@ -29,6 +30,15 @@ class IpyvolumeBaseView(IPyWidgetView):
 
         # FIXME: hack for the movie maker to have access to the figure
         self.state.figure = self.figure
+
+        # note that for ipyvolume, we use axis in the order x, z, y in order to have
+        # the z axis of glue pointing up
+        def attribute_to_label(attribute):
+            return 'null' if attribute is None else attribute.label
+
+        dlink((self.state, 'x_att'), (self.figure, 'xlabel'), attribute_to_label)
+        dlink((self.state, 'y_att'), (self.figure, 'zlabel'), attribute_to_label)
+        dlink((self.state, 'z_att'), (self.figure, 'ylabel'), attribute_to_label)
 
         self.state.add_callback('x_min', self.limits_to_scales)
         self.state.add_callback('x_max', self.limits_to_scales)

--- a/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
@@ -32,3 +32,22 @@ def test_non_hex_colors(app, dataxyz):
     viewer.layer_options._layer_dropdown.value = viewer.layers[1]
     dataxyz.subsets[0].style.color = '0.5'
     dataxyz.subsets[0].style.color = 'purple'
+
+
+def test_labels(app, dataxyz):
+    # test the syncing of attributes to labels
+    app.add_data(dataxyz)
+    scatter = app.scatter3d(data=dataxyz)
+    assert scatter.state.x_att.label == 'x'
+    assert scatter.figure.xlabel == 'x'
+    assert scatter.state.y_att.label == 'y'
+    assert scatter.figure.zlabel == 'y'
+    assert scatter.state.z_att.label == 'z'
+    assert scatter.figure.ylabel == 'z'
+
+    scatter.state.x_att = dataxyz.id['y']
+    assert scatter.figure.xlabel == 'y'
+    scatter.state.y_att = dataxyz.id['z']
+    assert scatter.figure.zlabel == 'z'
+    scatter.state.z_att = dataxyz.id['x']
+    assert scatter.figure.ylabel == 'x'


### PR DESCRIPTION
Now we link the attribute labels to the labels of ipyvolume. The link is directional, so only when the attribute changes does the plot label change, not the other way around.

I am sure when the label gets changed how i should detect that.

This PR assumes #150 is merged, since it flips y and z.