### PR TITLE
Fix issue where profile of subset was not correctly hidden if the subset was emptied

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 0.2 (unreleased)
 ================
 
-- Removed ipymaterialui widgets and fix cases where these widgets were
+* Removed ipymaterialui widgets and fix cases where these widgets were
   used over ipyvuetify widgets. [#143]
+
+* Fixed a bug that caused profiles of subsets to not be hidden if an
+  existing subset was emptied. [#162]
 
 0.1 (2020-01-08)
 ================
 
-- Initial version.
+* Initial version.

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -91,9 +91,10 @@ class BqplotProfileLayerArtist(LayerArtist):
             with self.line_mark.hold_sync():
                 self.line_mark.x = x
                 self.line_mark.y = y
-                self.line_mark.visible = self.state.visible
         else:
-            self.line_mark.visible = False
+            with self.line_mark.hold_sync():
+                self.line_mark.x = [0.]
+                self.line_mark.y = [0.]
 
         if not self._viewer_state.normalize and len(y) > 0:
 


### PR DESCRIPTION
This PR fixes #160 and is related to https://github.com/glue-viz/glue/pull/2095