### PR TITLE
Make the 'allow multiple subsets' toggle optional and disable it by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 * Removed ipymaterialui widgets and fix cases where these widgets were
   used over ipyvuetify widgets. [#143]
 
+* Make the 'allow multiple subsets' button optional and disabled by
+  default. [#163]
+
 * Fixed a bug that caused profiles of subsets to not be hidden if an
   existing subset was emptied. [#162]
 

--- a/glue_jupyter/widgets/subset_select.vue
+++ b/glue_jupyter/widgets/subset_select.vue
@@ -46,7 +46,7 @@
                 </v-list-item-content>
             </v-list-item>
 
-            <v-switch v-model="multiple" label="Allow multiple subsets" @click="handleMultiple" class="px-4"></v-switch>
+            <v-switch v-if="show_allow_multiple_subsets" v-model="multiple" label="Allow multiple subsets" @click="handleMultiple" class="px-4"></v-switch>
         </v-list>
     </v-menu>
 </template>

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -30,6 +30,7 @@ class SubsetSelect(v.VuetifyTemplate, HubListener):
     no_selection_text = traitlets.Unicode('No selection (create new)').tag(sync=True)
     multiple = traitlets.Bool(False).tag(sync=True)
     nr_of_full_names = traitlets.Int(2).tag(sync=True)
+    show_allow_multiple_subsets = traitlets.Bool(False).tag(sync=True)
 
     methods = traitlets.Unicode('''{
         toSubsets(indices) {


### PR DESCRIPTION
For now enabling this option will require modifying a trait on the widget, which can't easily be done via the notebook, but in future we could choose to expose an 'advanced' mode that would enable this (and other) options.

Fixes #159 
