### PR TITLE
Improve behavior of selection tools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.2 (unreleased)
 ================
 
+* De-select selection tools after a selection has been made. [#164]
+
 * Removed ipymaterialui widgets and fix cases where these widgets were
   used over ipyvuetify widgets. [#143]
 

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -9,6 +9,7 @@ __all__ = []
 ICON_WIDTH = 20
 INTERACT_COLOR = '#cbcbcb'
 
+
 class InteractCheckableTool(CheckableTool):
 
     def __init__(self, viewer):

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -7,7 +7,7 @@ from glue.viewers.common.tool import CheckableTool
 __all__ = []
 
 ICON_WIDTH = 20
-
+INTERACT_COLOR = '#cbcbcb'
 
 class InteractCheckableTool(CheckableTool):
 
@@ -51,7 +51,7 @@ class BqplotRectangleMode(InteractCheckableTool):
 
         self.interact = BrushSelector(x_scale=self.viewer.scale_x,
                                       y_scale=self.viewer.scale_y,
-                                      color="green")
+                                      color=INTERACT_COLOR)
 
         self.interact.observe(self.update_selection, "brushing")
 
@@ -62,6 +62,7 @@ class BqplotRectangleMode(InteractCheckableTool):
                 y = self.interact.selected_y
                 roi = RectangularROI(xmin=min(x), xmax=max(x), ymin=min(y), ymax=max(y))
                 self.viewer.apply_roi(roi)
+                self.viewer.toolbar.active_tool = None
 
 
 @viewer_tool
@@ -77,7 +78,7 @@ class BqplotXRangeMode(InteractCheckableTool):
         super().__init__(viewer, **kwargs)
 
         self.interact = BrushIntervalSelector(scale=self.viewer.scale_x,
-                                              color="green")
+                                              color=INTERACT_COLOR)
 
         self.interact.observe(self.update_selection, "brushing")
 
@@ -88,6 +89,7 @@ class BqplotXRangeMode(InteractCheckableTool):
                 if x is not None and len(x):
                     roi = RangeROI(min=min(x), max=max(x), orientation='x')
                     self.viewer.apply_roi(roi)
+                    self.viewer.toolbar.active_tool = None
 
 
 @viewer_tool
@@ -104,7 +106,7 @@ class BqplotYRangeMode(InteractCheckableTool):
 
         self.interact = BrushIntervalSelector(scale=self.viewer.scale_y,
                                               orientation='vertical',
-                                              color="green")
+                                              color=INTERACT_COLOR)
 
         self.interact.observe(self.update_selection, "brushing")
 
@@ -115,3 +117,4 @@ class BqplotYRangeMode(InteractCheckableTool):
                 if y is not None and len(y):
                     roi = RangeROI(min=min(y), max=max(y), orientation='y')
                     self.viewer.apply_roi(roi)
+                    self.viewer.toolbar.active_tool = None

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -11,7 +11,7 @@ ICON_WIDTH = 20
 
 
 class BasicJupyterToolbar(v.BtnToggle):
-    active_tool = traitlets.Instance(glue.viewers.common.tool.Tool)
+    active_tool = traitlets.Instance(glue.viewers.common.tool.Tool, allow_none=True)
 
     def __init__(self, viewer):
         self.output = viewer.output_widget
@@ -23,14 +23,18 @@ class BasicJupyterToolbar(v.BtnToggle):
         with self.output:
             if change.new is not None:
                 self.active_tool = self.tools[change.new]
+            else:
+                self.active_tool = None
 
     @traitlets.observe('active_tool')
     def _on_change_active_tool(self, change):
-        with self.output:
-            if change.old:
-                change.old.deactivate()
-            if change.new:
-                change.new.activate()
+        if change.old:
+            change.old.deactivate()
+        if change.new:
+            change.new.activate()
+            self.v_model = change.new.tool_id
+        else:
+            self.v_model = None
 
     def add_tool(self, tool):
         self.tools[tool.tool_id] = tool


### PR DESCRIPTION
This improves the behavior of selection tools - for now the main change is to make the selections 'single use' as in the Qt application which we have found reduces confusion and mistakes.

The next step is to make it so that if the user clicks on a region and drags it it should move.

Once finished this should fix https://github.com/glue-viz/glue-jupyter/issues/158