### PR TITLE
Implement a way to remove subsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@
 * Fixed a bug that caused exceptions when trying to remove data from
   bqplot viewers. [#166]
 
-- Added circular selection to scatter and image viewer. [#165]
+* Added circular selection to scatter and image viewer. [#165]
+
+* Make it possible to remove subsets from the UI
 
 0.1 (2020-01-08)
 ================

--- a/glue_jupyter/widgets/subset_select.vue
+++ b/glue_jupyter/widgets/subset_select.vue
@@ -42,7 +42,12 @@
                     <v-icon :color="subset.color">signal_cellular_4_bar</v-icon>
                 </v-list-item-icon>
                 <v-list-item-content>
-                    <v-list-item-title>{{ subset.label }}</v-list-item-title>
+                    <v-list-item-title>
+                        {{ subset.label }}
+                        <v-btn icon @click.stop="remove_subset(index)">
+                            <v-icon>mdi-delete</v-icon>
+                        </v-btn>
+                    </v-list-item-title>
                 </v-list-item-content>
             </v-list-item>
 

--- a/glue_jupyter/widgets/subset_select.vue
+++ b/glue_jupyter/widgets/subset_select.vue
@@ -43,8 +43,8 @@
                 </v-list-item-icon>
                 <v-list-item-content>
                     <v-list-item-title>
-                        {{ subset.label }}
-                        <v-btn icon @click="remove_subset(index)">
+                        <span style="line-height: 2.2">{{ subset.label }}</span>
+                        <v-btn icon @click="remove_subset(index)" class="float-right">
                             <v-icon>mdi-delete</v-icon>
                         </v-btn>
                     </v-list-item-title>

--- a/glue_jupyter/widgets/subset_select.vue
+++ b/glue_jupyter/widgets/subset_select.vue
@@ -44,7 +44,7 @@
                 <v-list-item-content>
                     <v-list-item-title>
                         {{ subset.label }}
-                        <v-btn icon @click.stop="remove_subset(index)">
+                        <v-btn icon @click="remove_subset(index)">
                             <v-icon>mdi-delete</v-icon>
                         </v-btn>
                     </v-list-item-title>

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -91,3 +91,6 @@ class SubsetSelect(v.VuetifyTemplate, HubListener):
                 if len(self.selected) > 1:
                     # take the first item of the selected items as the single selected item
                     self.selected = self.selected[:1]
+
+    def vue_remove_subset(self, index):
+        print(f'remove: {index}')

--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -61,7 +61,6 @@ class SubsetSelect(v.VuetifyTemplate, HubListener):
         self.edit_subset_mode = session.edit_subset_mode
         self.data_collection = session.data_collection
 
-
         # state change events from glue come in from the hub
         session.hub.subscribe(self, msg.EditSubsetMessage,
                               handler=lambda _: self._sync_selected_from_state())

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     ipympl>=0.3.0
     ipyvolume>=0.5.0
     ipywidgets>=7.4.0
-    ipyvuetify>=1.0.4,<2
+    ipyvuetify>=1.2,<2
     bqplot-image-gl>=0.2
     bqplot>=0.12
 


### PR DESCRIPTION
This almost works but the drop-down menu doesn't go away when I click on the remove button:

![Peek 2020-03-20 10-54](https://user-images.githubusercontent.com/314716/77157391-2a461d00-6a99-11ea-9733-d0315f865167.gif)

The subset is removed from the list, it's more that the UI doesn't refresh immediately. Code for the above example:

```python
import numpy as np
import glue_jupyter as gj
app = gj.jglue(data={'x': np.random.normal(0, 1, 100), 'y':np.random.normal(0, 1, 100)})
scatter_viewer = app.scatter2d()
```

Closes https://github.com/glue-viz/glue-jupyter/issues/161