### PR TITLE
Fix behavior of selection tools

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -81,7 +81,8 @@ class BqplotCircleMode(InteractCheckableTool):
 
         self.interact = BrushEllipseSelector(x_scale=self.viewer.scale_x,
                                              y_scale=self.viewer.scale_y,
-                                             pixel_aspect=1)
+                                             pixel_aspect=1,
+                                             color=INTERACT_COLOR)
 
         self.interact.observe(self.update_selection, "brushing")
 

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -282,7 +282,7 @@ class ROIClickAndDrag(InteractCheckableTool):
             if layer.visible and isinstance(subset_state, RoiSubsetState):
                 roi = subset_state.roi
                 if roi.contains(x, y):
-                    if isinstance(roi, EllipticalROI):
+                    if isinstance(roi, (EllipticalROI, CircularROI)):
                         self._active_tool = BqplotCircleMode(self.viewer, roi=roi,
                                                              finalize_callback=self.release)
                         self.viewer.figure.interaction = self._active_tool.interact

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -65,7 +65,6 @@ class BqplotRectangleMode(InteractCheckableTool):
                 y = self.interact.selected_y
                 roi = RectangularROI(xmin=min(x), xmax=max(x), ymin=min(y), ymax=max(y))
                 self.viewer.apply_roi(roi)
-                self.viewer.toolbar.active_tool = None
 
 
 @viewer_tool
@@ -105,7 +104,6 @@ class BqplotCircleMode(InteractCheckableTool):
                 else:
                     roi = EllipticalROI(xc=xc, yc=yc, radius_x=rx, radius_y=ry)
                 self.viewer.apply_roi(roi)
-                self.viewer.toolbar.active_tool = None
 
 
 @viewer_tool
@@ -132,7 +130,6 @@ class BqplotXRangeMode(InteractCheckableTool):
                 if x is not None and len(x):
                     roi = RangeROI(min=min(x), max=max(x), orientation='x')
                     self.viewer.apply_roi(roi)
-                    self.viewer.toolbar.active_tool = None
 
 
 @viewer_tool
@@ -160,4 +157,3 @@ class BqplotYRangeMode(InteractCheckableTool):
                 if y is not None and len(y):
                     roi = RangeROI(min=min(y), max=max(y), orientation='y')
                     self.viewer.apply_roi(roi)
-                    self.viewer.toolbar.active_tool = None

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -87,8 +87,16 @@ class BqplotCircleMode(InteractCheckableTool):
 
         self.interact = BrushEllipseSelector(x_scale=self.viewer.scale_x,
                                              y_scale=self.viewer.scale_y,
-                                             pixel_aspect=1,
-                                             color=INTERACT_COLOR)
+                                             pixel_aspect=1)
+
+        # Workaround for bug that causes the `color` trait to not be recognized
+        style = self.interact.style.copy()
+        style['fill'] = INTERACT_COLOR
+        border_style = self.interact.border_style.copy()
+        border_style['fill'] = INTERACT_COLOR
+        border_style['stroke'] = INTERACT_COLOR
+        self.interact.style = style
+        self.interact.border_style = border_style
 
         self.interact.observe(self.update_selection, "brushing")
 

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -1,7 +1,7 @@
-from bqplot import PanZoom, Lines
+from bqplot import PanZoom
 from bqplot.interacts import BrushSelector, BrushIntervalSelector
 from bqplot_image_gl.interacts import BrushEllipseSelector, MouseInteraction
-from glue.core.roi import RectangularROI, RangeROI, CircularROI, EllipticalROI
+from glue.core.roi import RectangularROI, RangeROI, CircularROI, EllipticalROI, PolygonalROI
 from glue.core.subset import RoiSubsetState
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
@@ -283,10 +283,12 @@ class ROIClickAndDrag(InteractCheckableTool):
                 roi = subset_state.roi
                 if roi.contains(x, y):
                     if isinstance(roi, EllipticalROI):
-                        self._active_tool = BqplotCircleMode(self.viewer, roi=roi, finalize_callback=self.release)
+                        self._active_tool = BqplotCircleMode(self.viewer, roi=roi,
+                                                             finalize_callback=self.release)
                         self.viewer.figure.interaction = self._active_tool.interact
                     elif isinstance(roi, RectangularROI):
-                        self._active_tool = BqplotRectangleMode(self.viewer, roi=roi, finalize_callback=self.release)
+                        self._active_tool = BqplotRectangleMode(self.viewer, roi=roi,
+                                                                finalize_callback=self.release)
                         self.viewer.figure.interaction = self._active_tool.interact
                     else:
                         raise TypeError(f"Unexpected ROI type: {type(roi)}")

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -66,6 +66,12 @@ class BqplotRectangleMode(InteractCheckableTool):
                 roi = RectangularROI(xmin=min(x), xmax=max(x), ymin=min(y), ymax=max(y))
                 self.viewer.apply_roi(roi)
 
+    def activate(self):
+        with self.viewer._output_widget:
+            self.interact.selected_x = None
+            self.interact.selected_y = None
+        super().activate()
+
 
 @viewer_tool
 class BqplotCircleMode(InteractCheckableTool):
@@ -106,6 +112,12 @@ class BqplotCircleMode(InteractCheckableTool):
                     roi = EllipticalROI(xc=xc, yc=yc, radius_x=rx, radius_y=ry)
                 self.viewer.apply_roi(roi)
 
+    def activate(self):
+        with self.viewer._output_widget:
+            self.interact.selected_x = None
+            self.interact.selected_y = None
+        super().activate()
+
 
 @viewer_tool
 class BqplotXRangeMode(InteractCheckableTool):
@@ -131,6 +143,11 @@ class BqplotXRangeMode(InteractCheckableTool):
                 if x is not None and len(x):
                     roi = RangeROI(min=min(x), max=max(x), orientation='x')
                     self.viewer.apply_roi(roi)
+
+    def activate(self):
+        with self.viewer._output_widget:
+            self.interact.selected = None
+        super().activate()
 
 
 @viewer_tool
@@ -158,3 +175,8 @@ class BqplotYRangeMode(InteractCheckableTool):
                 if y is not None and len(y):
                     roi = RangeROI(min=min(y), max=max(y), orientation='y')
                     self.viewer.apply_roi(roi)
+
+    def activate(self):
+        with self.viewer._output_widget:
+            self.interact.selected = None
+        super().activate()

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -5,7 +5,6 @@ from glue.core.roi import RectangularROI, RangeROI, CircularROI, EllipticalROI, 
 from glue.core.subset import RoiSubsetState
 from glue.config import viewer_tool
 from glue.viewers.common.tool import CheckableTool
-from glue_jupyter.bqplot.image.layer_artist import BqplotImageSubsetLayerArtist
 import numpy as np
 
 __all__ = []
@@ -275,6 +274,7 @@ class ROIClickAndDrag(InteractCheckableTool):
             self.press(x, y)
 
     def press(self, x, y):
+        from glue_jupyter.bqplot.image.layer_artist import BqplotImageSubsetLayerArtist
         for layer in self.viewer.layers:
             if not isinstance(layer, BqplotImageSubsetLayerArtist):
                 continue

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -16,6 +16,11 @@ class BasicJupyterToolbar(v.BtnToggle):
     def __init__(self, viewer):
         self.output = viewer.output_widget
         self.tools = {}
+        if viewer._default_mouse_mode_cls is not None:
+            self._default_mouse_mode = viewer._default_mouse_mode_cls(viewer)
+            self._default_mouse_mode.activate()
+        else:
+            self._default_mouse_mode = None
         super().__init__(v_model=None, class_='transparent')
 
     @traitlets.observe('v_model')
@@ -30,11 +35,16 @@ class BasicJupyterToolbar(v.BtnToggle):
     def _on_change_active_tool(self, change):
         if change.old:
             change.old.deactivate()
+        else:
+            if self._default_mouse_mode is not None:
+                self._default_mouse_mode.deactivate()
         if change.new:
             change.new.activate()
             self.v_model = change.new.tool_id
         else:
             self.v_model = None
+            if self._default_mouse_mode is not None:
+                self._default_mouse_mode.activate()
 
     def add_tool(self, tool):
         self.tools[tool.tool_id] = tool

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -26,6 +26,7 @@ class IPyWidgetLayerArtistContainer(LayerArtistContainer):
 class IPyWidgetView(Viewer):
 
     _layer_artist_container_cls = IPyWidgetLayerArtistContainer
+    _default_mouse_mode_cls = None
 
     inherit_tools = True
     tools = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=0.2
+    bqplot-image-gl>=0.3.0
     bqplot>=0.12
 
 [options.extras_require]


### PR DESCRIPTION
This reverts a change I made in #164 which de-selected a selection tool after a selection was made.

There are still some issues with some events being still passed to the circular selection even once the circular selection is deselected. See the following screencast:

![Peek 2020-03-20 15-56](https://user-images.githubusercontent.com/314716/77181894-dd2b7080-6ac3-11ea-8c02-2b9c21ce42f7.gif)

This shows:

* Making rectangular selections works
* Once I deselect the tool selections don't work (=good)
* When I select the circular selection tool selections work
* When I switch back to the rectangular selection there is a small glitch
* When I disable the rectangular selection now clicking causes the circular selection to come back and get updated.
* Another issue is that the circular selection brush color seems to be ignored and is shown in green

@maartenbreddels - could you see if you can reproduce this and investigate what could be going wrong with the circular brush?

