### PR TITLE
fix: don't use css selector specific to notebook context

### DIFF
--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -49,7 +49,7 @@
     }
 </script>
 <style id="layer_image">
-    .vuetify-styles .v-subheader.slider-label {
+    .v-subheader.slider-label {
         font-size: 12px;
         height: 16px;
     }

--- a/glue_jupyter/common/state_widgets/viewer_image.vue
+++ b/glue_jupyter/common/state_widgets/viewer_image.vue
@@ -42,7 +42,7 @@
     }
 </script>
 <style id="viewer_image">
-    .vuetify-styles .v-subheader.slider-label {
+    .v-subheader.slider-label {
         font-size: 12px;
         height: 16px;
     }


### PR DESCRIPTION
The .vuetify-styles selector is only available in the notebook
context and thus will not be applied when used in voila-vuetify.