### PR TITLE
Display proper units information on bqplot axes

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -47,7 +47,7 @@ class BqplotBaseView(IPyWidgetView):
         self.state.add_callback('layers', self._sync_layer_artist_container, priority=10000)
 
         def update_axes(*ignore):
-            try: 
+            try:
                 # Extract units from data
                 x_unit = self.state.reference_data.get_component(self.state.x_att_world).units
             except AttributeError:
@@ -58,7 +58,7 @@ class BqplotBaseView(IPyWidgetView):
                 self.axis_x.label = str(self.state.x_att) + " " + str(x_unit)
             if self.is2d:
                 self.axis_y.label = str(self.state.y_att)
-                try: 
+                try:
                     y_unit = self.state.reference_data.get_component(self.state.y_att_world).units
                 except AttributeError:
                     y_unit = ""

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -48,26 +48,22 @@ class BqplotBaseView(IPyWidgetView):
 
         def update_axes(*ignore):
             try: 
-                # Define label with units
-                self.axis_x.label = str(self.state.x_att) + 
-                                    str(" [" + 
-                                        self.state.reference_data.get_component(
-                                            self.state.x_att_world
-                                        ).units + 
-                                        "]")
+                # Extract units from data
+                x_unit = self.state.reference_data.get_component(self.state.x_att_world).units
             except AttributeError:
                 # If no data loaded yet, ignore units
-                self.axis_x.label = str(self.state.x_att)
+                x_unit = ""
+            finally:
+                # Append units to axis label
+                self.axis_x.label = str(self.state.x_att) + " " + str(x_unit)
             if self.is2d:
+                self.axis_y.label = str(self.state.y_att)
                 try: 
-                    self.axis_y.label = str(self.state.y_att) + 
-                                        str(" [" + 
-                                            self.state.reference_data.get_component(
-                                                self.state.y_att_world
-                                            ).units + 
-                                            "]")
+                    y_unit = self.state.reference_data.get_component(self.state.y_att_world).units
                 except AttributeError:
-                    self.axis_y.label = str(self.state.y_att)
+                    y_unit = ""
+                finally:
+                    self.axis_y.label = str(self.state.y_att) + " " + str(y_unit)
 
         self.state.add_callback('x_att', update_axes)
         if self.is2d:

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -47,9 +47,17 @@ class BqplotBaseView(IPyWidgetView):
         self.state.add_callback('layers', self._sync_layer_artist_container, priority=10000)
 
         def update_axes(*ignore):
-            self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
+            try: 
+                # Define label with units
+                self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
+            except AttributeError:
+                # If no data loaded yet, ignore units
+                self.axis_x.label = str(self.state.x_att)
             if self.is2d:
-                self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
+                try: 
+                    self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.y_att_world).units + "]")
+                except AttributeError:
+                    self.axis_y.label = str(self.state.y_att)
 
         self.state.add_callback('x_att', update_axes)
         if self.is2d:

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -47,9 +47,9 @@ class BqplotBaseView(IPyWidgetView):
         self.state.add_callback('layers', self._sync_layer_artist_container, priority=10000)
 
         def update_axes(*ignore):
-            self.axis_x.label = str(self.state.x_att)
+            self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att).units + "]")
             if self.is2d:
-                self.axis_y.label = str(self.state.y_att)
+                self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att).units + "]")
 
         self.state.add_callback('x_att', update_axes)
         if self.is2d:

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -47,9 +47,9 @@ class BqplotBaseView(IPyWidgetView):
         self.state.add_callback('layers', self._sync_layer_artist_container, priority=10000)
 
         def update_axes(*ignore):
-            self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att).units + "]")
+            self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
             if self.is2d:
-                self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att).units + "]")
+                self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
 
         self.state.add_callback('x_att', update_axes)
         if self.is2d:

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -49,13 +49,23 @@ class BqplotBaseView(IPyWidgetView):
         def update_axes(*ignore):
             try: 
                 # Define label with units
-                self.axis_x.label = str(self.state.x_att) + str(" [" + self.state.reference_data.get_component(self.state.x_att_world).units + "]")
+                self.axis_x.label = str(self.state.x_att) + 
+                                    str(" [" + 
+                                        self.state.reference_data.get_component(
+                                            self.state.x_att_world
+                                        ).units + 
+                                        "]")
             except AttributeError:
                 # If no data loaded yet, ignore units
                 self.axis_x.label = str(self.state.x_att)
             if self.is2d:
                 try: 
-                    self.axis_y.label = str(self.state.y_att) + str(" [" + self.state.reference_data.get_component(self.state.y_att_world).units + "]")
+                    self.axis_y.label = str(self.state.y_att) + 
+                                        str(" [" + 
+                                            self.state.reference_data.get_component(
+                                                self.state.y_att_world
+                                            ).units + 
+                                            "]")
                 except AttributeError:
                     self.axis_y.label = str(self.state.y_att)
 


### PR DESCRIPTION
Small change to display component world attribute units in bqplot. If no data exists yet, the units are ignored.
