### PR TITLE
Handle numpy serialization in json

### DIFF
--- a/glue_jupyter/state_traitlets_helpers.py
+++ b/glue_jupyter/state_traitlets_helpers.py
@@ -68,6 +68,12 @@ class GlueStateJSONEncoder(json.JSONEncoder):
             return MAGIC_IGNORE
         elif isinstance(obj, Colormap):
             return obj.name
+
+        # JSON cannot serialized native numpy types, so check if the object
+        #  is a numpy dtype, and if it is, convert to python type
+        if hasattr(obj, 'dtype'):
+            return obj.item()
+
         return json.JSONEncoder.default(self, obj)
 
 


### PR DESCRIPTION
Fixes an issue in which the json serialization would fail on numpy dtypes:

`TypeError: Object of type 'int64' is not JSON serializable`