### PR TITLE
Allow BqplotCircleModel to return a CircularROI

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -143,17 +143,12 @@ class BqplotCircleMode(InteractCheckableTool):
             if self.interact.selected_x is not None and self.interact.selected_y is not None:
                 x = self.interact.selected_x
                 y = self.interact.selected_y
-                # similar to https://github.com/glue-viz/glue/blob/b14ccffac6a5
-                # 271c2869ead9a562a2e66232e397/glue/core/roi.py#L1275-L1297
-                # We should now check if the radius in data coordinates is the same
-                # along x and y, as if so then we can return a circle, otherwise we
-                # should return an ellipse.
                 xc = x.mean()
                 yc = y.mean()
                 rx = abs(x[1] - x[0])/2
                 ry = abs(y[1] - y[0])/2
-                if np.allclose(rx, ry):
-                    roi = CircularROI(xc=xc, yc=yc, radius=rx)
+                if self.interact.pixel_aspect == 1:
+                    roi = CircularROI(xc=xc, yc=yc, radius=np.mean((rx, ry)))
                 else:
                     roi = EllipticalROI(xc=xc, yc=yc, radius_x=rx, radius_y=ry)
                 self.viewer.apply_roi(roi)


### PR DESCRIPTION
Currently, `BqplotCircleModel` uses a `BrushEllipseSelector` with `pixel_aspect=1` to update the internal ROI.  The checks for determining if this will produce a `CircularROI` or an `EllipticalROI` end up always producing an `EllipticalROI`.  I'm not sure why this is the case, but it has something to do with computing it from quantized selected pixels.

This fix allows a Circular brush on a viewer with equal aspect ratio to produce a `CircularROI`.

I'm not sure what unit tests are possible here, as I don't know exactly how to simulate using the selector brush in the viewer.  Suggestions welcome.

It would be nice to show in a test the old behavior as well.