### PR TITLE
Fix setting of equal aspect ratio for image viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@
 
 * Implement click-and-drag for selections in image viewer. [#170]
 
+* Fixed behavior of equal aspect ratio in image viewer. [#184]
+
 0.1 (2020-01-08)
 ================
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -60,7 +60,6 @@ class BqplotImageView(BqplotBaseView):
                 self.figure.min_aspect_ratio = bqplot.Figure.min_aspect_ratio.default_value
                 self.figure.max_aspect_ratio = bqplot.Figure.max_aspect_ratio.default_value
                 self.state._set_axes_aspect_ratio(None)
-                self.state.reset_limits()
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -55,9 +55,12 @@ class BqplotImageView(BqplotBaseView):
             if self.state.aspect == 'equal':
                 self.figure.max_aspect_ratio = 1
                 self.figure.min_aspect_ratio = 1
+                self.state._set_axes_aspect_ratio(1)
             else:
                 self.figure.min_aspect_ratio = bqplot.Figure.min_aspect_ratio.default_value
                 self.figure.max_aspect_ratio = bqplot.Figure.max_aspect_ratio.default_value
+                self.state._set_axes_aspect_ratio(None)
+                self.state.reset_limits()
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -3,6 +3,7 @@ import nbformat
 import numpy as np
 from numpy.testing import assert_allclose
 from nbconvert.preprocessors import ExecutePreprocessor
+from glue.core import Data
 from glue.core.roi import EllipticalROI
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
@@ -281,16 +282,32 @@ def test_imshow_circular_brush(app, data_image):
 
 
 def test_imshow_equal_aspect(app, data_image):
-    assert data_image in app.data_collection
-    v = app.imshow(data=data_image)
+    data = Data(array=np.random.random((100, 5)))
+    app.data_collection.append(data)
+    v = app.imshow(data=data)
     assert v.figure.min_aspect_ratio == 1
     assert v.figure.max_aspect_ratio == 1
+    assert v.scale_x.min == -48.0
+    assert v.scale_x.max == +52.0
+    assert v.scale_y.min == -0.5
+    assert v.scale_y.max == +99.5
     v.state.aspect = 'auto'
     assert v.figure.min_aspect_ratio == 0.01
     assert v.figure.max_aspect_ratio == 100
+    # NOTE: the limits don't actually change automatically, because if user
+    # is zoomed in they might not want to automatically zoom all the way out
+    # again.
+    assert v.scale_x.min == -48.0
+    assert v.scale_x.max == +52.0
+    assert v.scale_y.min == -0.5
+    assert v.scale_y.max == +99.5
     v.state.aspect = 'equal'
     assert v.figure.min_aspect_ratio == 1
     assert v.figure.max_aspect_ratio == 1
+    assert v.scale_x.min == -48.0
+    assert v.scale_x.max == +52.0
+    assert v.scale_y.min == -0.5
+    assert v.scale_y.max == +99.5
 
 
 def test_imshow_nonfloat(app):


### PR DESCRIPTION
Previously, the pixels weren't really showing up as squares, but this now hooks in to the glue-core infrastructure to make it work properly. For some reason, when switching to 'auto' aspect ratio, the image doesn't change, because somehow changes to ``scale_x/y.min/max`` don't seem to be updating the figure. But as-is, this is already an improvement and I think consistent with how glue Qt works.