### PR TITLE
Adding single axis zoom tools to 1D profile viewer toolbar

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -46,7 +46,7 @@ class BqplotPanZoomXMode(InteractCheckableTool):
 
     icon = 'glue_move_x'
     tool_id = 'bqplot:panzoom_x'
-    action_text = 'Pan and Zoom'
+    action_text = 'Pan and Zoom X Axis'
     tool_tip = 'Interactively pan and zoom x axis only'
 
     def __init__(self, viewer, **kwargs):
@@ -61,7 +61,7 @@ class BqplotPanZoomYMode(InteractCheckableTool):
 
     icon = 'glue_move_y'
     tool_id = 'bqplot:panzoom_y'
-    action_text = 'Pan and Zoom'
+    action_text = 'Pan and Zoom Y Axis'
     tool_tip = 'Interactively pan and zoom y axis only'
 
     def __init__(self, viewer, **kwargs):

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -42,6 +42,36 @@ class BqplotPanZoomMode(InteractCheckableTool):
 
 
 @viewer_tool
+class BqplotPanZoomXMode(InteractCheckableTool):
+
+    icon = 'glue_move'
+    tool_id = 'bqplot:panzoom_x'
+    action_text = 'Pan and Zoom'
+    tool_tip = 'Interactively pan and zoom x axis only'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = PanZoom(scales={'x': [self.viewer.scale_x]})
+
+
+@viewer_tool
+class BqplotPanZoomYMode(InteractCheckableTool):
+
+    icon = 'glue_move'
+    tool_id = 'bqplot:panzoom_y'
+    action_text = 'Pan and Zoom'
+    tool_tip = 'Interactively pan and zoom y axis only'
+
+    def __init__(self, viewer, **kwargs):
+
+        super().__init__(viewer, **kwargs)
+
+        self.interact = PanZoom(scales={'y': [self.viewer.scale_y]})
+
+
+@viewer_tool
 class BqplotRectangleMode(InteractCheckableTool):
 
     icon = 'glue_square'

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -44,7 +44,7 @@ class BqplotPanZoomMode(InteractCheckableTool):
 @viewer_tool
 class BqplotPanZoomXMode(InteractCheckableTool):
 
-    icon = 'glue_move'
+    icon = 'glue_move_x'
     tool_id = 'bqplot:panzoom_x'
     action_text = 'Pan and Zoom'
     tool_tip = 'Interactively pan and zoom x axis only'
@@ -59,7 +59,7 @@ class BqplotPanZoomXMode(InteractCheckableTool):
 @viewer_tool
 class BqplotPanZoomYMode(InteractCheckableTool):
 
-    icon = 'glue_move'
+    icon = 'glue_move_y'
     tool_id = 'bqplot:panzoom_y'
     action_text = 'Pan and Zoom'
     tool_tip = 'Interactively pan and zoom y axis only'

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -26,7 +26,8 @@ class BqplotProfileView(BqplotBaseView):
     _subset_artist_cls = BqplotProfileLayerArtist
     _layer_style_widget_cls = ProfileLayerStateWidget
 
-    tools = ['bqplot:panzoom', 'bqplot:xrange']
+    tools = ['bqplot:panzoom', 'bqplot:panzoom_x', 'bqplot:panzoom_y',
+             'bqplot:xrange']
 
     def _roi_to_subset_state(self, roi):
 


### PR DESCRIPTION
This PR adds two buttons to the bqplot profile viewer toolbar, one to zoom/pan only the x-axis, the other for the y-axis. Right now both buttons use the existing glue_move icon (the one used for general pan/zoom) as a placeholder, which should be replaced before this is merged. I'll catch up with Jenn soon about making those.

Tagging in some people I know this is of interest to: @nmearl @dtn5ah @javerbukh @robelgeda 