### PR TITLE
chore: update dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,8 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=0.3.0
-    bqplot>=0.12
+    bqplot-image-gl>=0.6.1
+    bqplot>=0.12.17
 
 [options.extras_require]
 test =


### PR DESCRIPTION
cc @eteq 

This updates the dependencies for glue-jupyter, required for jdaviz:

bqplot-image-gl:
 * Fixes https://github.com/spacetelescope/jdaviz/issues/218

bqplot:
 * https://github.com/bqplot/bqplot/issues/1174


One could argue these should go into jdaviz, but I think these fix general issues that affect glue-jupyter.

Note: bqplot-image-gl is not released yet, it requires @astrofrog to give me maintainer rights 