### PR TITLE
Check if contours are in image before layer_artist attempts removal

### DIFF
--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -46,7 +46,8 @@ class BqplotImageLayerArtist(ImageLayerArtist):
     def remove(self):
         super().remove()
         marks = list(self.view.figure.marks)
-        marks.remove(self.contour_artist)
+        if self.contour_artist in marks:
+            marks.remove(self.contour_artist)
         self.view.figure.marks = marks
         self.uuid = None
 


### PR DESCRIPTION
Jdaviz has reported issue #[295](https://github.com/spacetelescope/jdaviz/issues/295) when trying to change the image displayed in the image viewer after the contours update since eae1c83f9744440e6fdf17a4858c44abad6a2b66. Basically if no contours are selected, we get a crash when the image layer artist tries to remove the contour marks anyways. This one line check (checking if the contours are in the marks before attempting removal) seems to fix things on our end.

Thanks!
Duy
