### PR TITLE
feat: include state to reproduce the visual state

### DIFF
--- a/glue_jupyter/widgets/disconnect.py
+++ b/glue_jupyter/widgets/disconnect.py
@@ -1,0 +1,40 @@
+import ipyvue
+import ipyvuetify as v
+import traitlets
+import ipywidgets as widgets
+from traitlets import Unicode, Dict, List
+import ipywidgets as w
+
+class Disconnect(v.VuetifyTemplate):
+    main = traitlets.Instance(widgets.Widget).tag(sync=True, **widgets.widget_serialization)
+    broken = traitlets.Instance(widgets.Widget).tag(sync=True, **widgets.widget_serialization)
+    connected = traitlets.Bool(True).tag(sync=True)
+    template = Unicode("""
+    <template>
+        <view-context-wrapper :widget="connected ? main : broken"></view-context-wrapper>
+    </template>
+    """).tag(sync=True)
+    
+    # we need to put our code in a component, otherwise inject: ['viewCtx'] does not work
+    components = Dict({
+        'view-context-wrapper': """
+            <template>
+                <jupyter-widget :widget="widget"></jupyter-widget>
+            </template>
+            <script>
+            module.exports = {
+                props: ["widget"],
+                inject: ['viewCtx'],
+                created() {
+                    const model = this.viewCtx.getView().model;
+                    model.set('connected', Boolean(model.comm_live));
+                    model.on('comm_live_update', () => {
+                        const connected = Boolean(model.comm_live)
+                        model.set('connected', connected);
+                        model.save_changes()
+                    })
+                },
+            };
+            </script>
+        """
+    }).tag(sync=True)


### PR DESCRIPTION
cc @eteq

For any notebook, we'd like to be able to reproduce what was done by including the state of the glue app in the notebook. To get to this, a human-readable text with all parameters that are changed from default would do.

However, this means we have to render a custom text when:
 1. The kernel is disconnected
 2. The widget state is not in the notebook (is this required?)
 3. The widget libraries do not work/or render

#  1. The kernel is disconnected
The PR as it is now, would allow for the following:

After we render this:
![image](https://user-images.githubusercontent.com/1765949/104335475-af506600-54f3-11eb-9780-ba1684fe53da.png)

and then kill the kernel, it would show:

![image](https://user-images.githubusercontent.com/1765949/104335523-baa39180-54f3-11eb-9e50-2ba743e2c6e3.png)

Which can include a custom msg that can 'implement' the reproducibility text.

If the widget state is saved in the notebook, this would also render on page refresh, or when someone else would open the notebook on his/her computer.

# 2. (?) The widget state is not in the notebook

If the widget state is not included in the notebook, classical notebook will always render like:
![image](https://user-images.githubusercontent.com/1765949/104336155-677e0e80-54f4-11eb-828c-074b164c770e.png)

Which is due to https://github.com/jupyter-widgets/ipywidgets/blob/90c1c14211a6be685c6077646f40973f96faced1/widgetsnbextension/src/extension.js#L149

The same in JupyterLab:
![image](https://user-images.githubusercontent.com/1765949/104336718-0145bb80-54f5-11eb-933d-86eba6a47cf8.png)

Which is due to:
https://github.com/jupyter-widgets/ipywidgets/blob/90c1c14211a6be685c6077646f40973f96faced1/packages/jupyterlab-manager/src/renderer.ts#L56

Both is theory could default to do something else (render the HTML instead, like in item 3), but this might be a difficult change (does this break things?), or a difficult to configure setting (in notebook metadata?). Technically not difficult to change though.

# 3. The widget libraries do not work/or render

When a notebook is opened, but rendering fails due to js libraries not being present, or in the case of GitHub because of security concerns, Jupyter will fall back to rendering lower priority mine types, such as HTML. This means we need to get the mime bundle in the output of the notebook up to date with the state of the glue application/viewer.

One way to do this:

```python
# create widget
import glue_jupyter as gj
points = gj.example_data_xyz(loc=60, scale=30, N=10*1000)
app = gj.jglue(points=points)
s = app.scatter2d(x='x', y='y', show=False)

# manually construct the mimebundle, like in https://github.com/jupyter-widgets/ipywidgets/blob/90c1c14211a6be685c6077646f40973f96faced1/ipywidgets/widgets/widget.py#L659
self = s.layout
plaintext = repr(self)
if len(plaintext) > 110:
    plaintext = plaintext[:110] + '…'
data = {
    'text/plain': plaintext,
}
data['application/vnd.jupyter.widget-view+json'] = {
    'version_major': 2,
    'version_minor': 0,
    'model_id': self._model_id
}

# display app with our own mime bundle, and give it a display id so we can update it
handle = display(data, raw=True, display_id=1)


......


# any time the app changes state (or after collapsing many state changes, i.e. debouncing),
# we can update the mime bundle

# construct custom msg
html_info = '''
<h1>Oops</h1>
If you see this, your Python kernel is not alive anymore, to reproduce the...
'''

# and update the mime bundle
handle.update({'application/vnd.jupyter.widget-view+json': data['application/vnd.jupyter.widget-view+json'],
               'text/html': html_info
              }, raw=True)
```

This last step will however redraw the whole application/widget/viewer, and does not look good or lead to a good user experience.

We could possibly see if we can optimize this rendering (e.g. detect if we can skip a redraw), or find other ways of updating the mime bundle.



I hope this gives a bit of an overview of what is possible and what requires changes to the ecosystem.




