### PR TITLE
Fix image percentile setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.2.2 (unreleased)
+==================
+
+* Fixed a bug that caused the image percentile value to not have any
+  effect. [#208]
+
 0.2.1 (2020-09-21)
 ==================
 

--- a/glue_jupyter/bqplot/image/state.py
+++ b/glue_jupyter/bqplot/image/state.py
@@ -36,9 +36,9 @@ class BqplotImageLayerState(ImageLayerState):
         BqplotImageLayerState.contour_percentile.set_choices(self, [100, 99.5, 99, 95, 90,
                                                                     'Custom'])
         BqplotImageLayerState.contour_percentile.set_display_func(self, percentile_display.get)
-        self.contour_attribute_lim_helper = StateAttributeLimitsHelper(self, attribute='attribute',
-                                                               percentile='contour_percentile',
-                                                               lower='c_min', upper='c_max')
+        self.contour_lim_helper = StateAttributeLimitsHelper(self, attribute='attribute',
+                                                             percentile='contour_percentile',
+                                                             lower='c_min', upper='c_max')
 
         self.add_callback('n_levels', self._update_levels)
         self.add_callback('c_min', self._update_levels)

--- a/glue_jupyter/bqplot/image/state.py
+++ b/glue_jupyter/bqplot/image/state.py
@@ -36,7 +36,7 @@ class BqplotImageLayerState(ImageLayerState):
         BqplotImageLayerState.contour_percentile.set_choices(self, [100, 99.5, 99, 95, 90,
                                                                     'Custom'])
         BqplotImageLayerState.contour_percentile.set_display_func(self, percentile_display.get)
-        self.attribute_lim_helper = StateAttributeLimitsHelper(self, attribute='attribute',
+        self.contour_attribute_lim_helper = StateAttributeLimitsHelper(self, attribute='attribute',
                                                                percentile='contour_percentile',
                                                                lower='c_min', upper='c_max')
 


### PR DESCRIPTION
The attribute helper for contours was named the same as the one for the image itself which meant that the image attribute helper for the percentile was not working - this fixes the issue.