### PR TITLE
Update nodejs version for binder container

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install --upgrade pip
 # Use curl to install nodejs
 
 RUN apt install curl -y
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt install -y nodejs
 
 # Set up user as required by mybinder docs:


### PR DESCRIPTION
## Description

Bump nodejs to 14.x (current LTS version). Fixes the binder build.

[Broken binder build](https://mybinder.org/v2/gh/glue-viz/glue-jupyter/master?filepath=notebooks%2FAstronomy%2FL1448%2FL1448%20in%203D.ipynb), excerpt from the error message:

```
+ jupyter labextension install @jupyter-widgets/jupyterlab-manager ipyvolume jupyter-threejs bqplot bqplot-image-gl jupyter-vuetify --no-build
An error occured.
ValueError: Please install nodejs >=12.0.0 before continuing. nodejs may be installed using conda or directly from the nodejs website.
See the log file for details:  /tmp/jupyterlab-debug-bqfn_mon.log
Removing intermediate container 0a32fb970968
```

[Fixed binder build](https://mybinder.org/v2/gh/sk1p/glue-jupyter/fix-nodejs-deps?filepath=notebooks%2FAstronomy%2FL1448%2FL1448%20in%203D.ipynb)