### PR TITLE
fix: client-side state change triggered by update from backend

### DIFF
--- a/glue_jupyter/common/state_widgets/viewer_image.vue
+++ b/glue_jupyter/common/state_widgets/viewer_image.vue
@@ -24,7 +24,9 @@
         </div>
         <div v-for="slider of sliders">
             <v-subheader class="pl-0 slider-label">{{ slider.label }}: {{ glue_state.slices[slider.index] }} ({{  slider.world_value  }} {{ slider.unit }})</v-subheader>
-            <glue-throttled-slider wait="300" :max="slider.max" :value.sync="glue_state.slices[slider.index]" hide-details />
+            <glue-throttled-slider
+                v-if="glue_state.slices && glue_state.slices.length > 0"
+                wait="300" :max="slider.max" :value.sync="glue_state.slices[slider.index]" hide-details />
         </div>
     </div>
 </template>


### PR DESCRIPTION
When an empty slices property is received from the backend, but
the sliders property is not yet updated, the slider will add its
default value to the slices list, thereby changing the state
which gets synced back to the backend.

Releted to: spacetelescope/jdaviz#446