### PR TITLE
Implement JupyterApplication.viewers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.3.0 (unreleased)
+==================
+
+* Fixed implementation of ``JupyterApplication.viewers`` to now return
+  list of viewers as opposed to empty list. [#214]
+
 0.2.2 (2021-03-18)
 ==================
 

--- a/glue_jupyter/tests/main_test.py
+++ b/glue_jupyter/tests/main_test.py
@@ -216,3 +216,17 @@ def test_plugins():
     links = find_possible_links(app.data_collection)
 
     assert 'Astronomy WCS' in links
+
+
+def test_viewers(app, datax, dataxz):
+
+    assert app.viewers == []
+
+    s1 = app.scatter2d(data=datax)
+    assert len(app.viewers) == 1
+    assert app.viewers[0] is s1
+
+    s2 = app.scatter2d(data=dataxz)
+    assert len(app.viewers) == 2
+    assert app.viewers[0] is s1
+    assert app.viewers[1] is s2


### PR DESCRIPTION
Prior to this PR this defaulted to the base class implementation which was an empty list