### PR TITLE
Added 'home' tool in bqplot viewers to reset limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4 (unreleased)
+================
+
+* Added a new 'home' tool in bqplot viewers to reset limits. [#218]
+
 0.3 (2021-04-15)
 ================
 

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -4,7 +4,7 @@ from bqplot_image_gl.interacts import BrushEllipseSelector, MouseInteraction
 from glue.core.roi import RectangularROI, RangeROI, CircularROI, EllipticalROI, PolygonalROI
 from glue.core.subset import RoiSubsetState
 from glue.config import viewer_tool
-from glue.viewers.common.tool import CheckableTool
+from glue.viewers.common.tool import Tool, CheckableTool
 import numpy as np
 
 __all__ = []
@@ -329,3 +329,15 @@ class ROIClickAndDrag(InteractCheckableTool):
 
     def release(self):
         self.viewer.figure.interaction = self.interact
+
+
+@viewer_tool
+class HomeTool(Tool):
+
+    tool_id = 'bqplot:home'
+    icon = 'glue_home'
+    action_text = 'Home'
+    tool_tip = 'Reset original zoom'
+
+    def activate(self):
+        self.viewer.state.reset_limits()

--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -24,7 +24,7 @@ class BqplotHistogramView(BqplotBaseView):
     _subset_artist_cls = BqplotHistogramLayerArtist
     _layer_style_widget_cls = HistogramLayerStateWidget
 
-    tools = ['bqplot:panzoom', 'bqplot:xrange']
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:xrange']
 
     def _roi_to_subset_state(self, roi):
         # TODO: copy paste from glue/viewers/histogram/qt/data_viewer.py

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -31,7 +31,7 @@ class BqplotImageView(BqplotBaseView):
     _state_cls = ImageViewerState
     _options_cls = ImageViewerStateWidget
 
-    tools = ['bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle']
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle']
 
     def __init__(self, session):
 

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -26,7 +26,7 @@ class BqplotProfileView(BqplotBaseView):
     _subset_artist_cls = BqplotProfileLayerArtist
     _layer_style_widget_cls = ProfileLayerStateWidget
 
-    tools = ['bqplot:panzoom', 'bqplot:panzoom_x', 'bqplot:panzoom_y',
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:panzoom_x', 'bqplot:panzoom_y',
              'bqplot:xrange']
 
     def _roi_to_subset_state(self, roi):

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -22,5 +22,5 @@ class BqplotScatterView(BqplotBaseView):
     _subset_artist_cls = BqplotScatterLayerArtist
     _layer_style_widget_cls = ScatterLayerStateWidget
 
-    tools = ['bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle',
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle',
              'bqplot:xrange', 'bqplot:yrange']


### PR DESCRIPTION
This works as for the Matplotlib viewers and I think users should be familiar with the icon.