### PR TITLE
Use LinesGL for faster rendering of lines.

### DIFF
--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -11,12 +11,16 @@ from glue.viewers.profile.state import ProfileLayerState
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 
 import bqplot
+from bqplot_image_gl import LinesGL
 
 from glue.viewers.common.layer_artist import LayerArtist
 
 from ...link import dlink
 
 __all__ = ['BqplotProfileLayerArtist']
+
+
+USE_GL = True
 
 
 class BqplotProfileLayerArtist(LayerArtist):
@@ -34,7 +38,8 @@ class BqplotProfileLayerArtist(LayerArtist):
 
         self.view = view
 
-        self.line_mark = bqplot.Lines(scales=self.view.scales, x=[0, 1], y=[0, 1])
+        LinesClass = LinesGL if USE_GL else bqplot.Lines
+        self.line_mark = LinesClass(scales=self.view.scales, x=[0, 1], y=[0, 1])
 
         self.view.figure.marks = list(self.view.figure.marks) + [self.line_mark]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=1.4.1
+    bqplot-image-gl>=1.4.3
     bqplot>=0.12.17
     scikit-image
 


### PR DESCRIPTION
It might be useful to switch off GL, using the `USE_GL` variable. Requires https://github.com/glue-viz/bqplot-image-gl/pull/58