### PR TITLE
Remove layer options that aren't relevant to profile viewers

### DIFF
--- a/glue_jupyter/common/state_widgets/layer_profile.py
+++ b/glue_jupyter/common/state_widgets/layer_profile.py
@@ -14,13 +14,9 @@ class ProfileLayerStateWidget(VuetifyTemplate):
     attribute_items = traitlets.List().tag(sync=True)
     attribute_selected = traitlets.Int().tag(sync=True)
 
-    percentile_items = traitlets.List().tag(sync=True)
-    percentile_selected = traitlets.Int().tag(sync=True)
-
     def __init__(self, layer_state):
         super().__init__()
 
         self.glue_state = layer_state
 
         link_glue_choices(self, layer_state, 'attribute')
-        link_glue_choices(self, layer_state, 'percentile')

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -6,14 +6,5 @@
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
-        <div>
-            <glue-float-field label="vmin" :value.sync="glue_state.v_min" />
-        </div>
-        <div>
-            <glue-float-field label="vmax" :value.sync="glue_state.v_max" />
-        </div>
-        <div>
-            <v-select label="percentile" :items="percentile_items" v-model="percentile_selected" />
-        </div>
     </div>
 </template>


### PR DESCRIPTION
The `vmin`, `vmax` and `percentile` options are currently included in the profile viewer `Layer` options, but they aren't editable by the user and don't really do anything in the profile viewer. They seem to be related to color scaling in the 2D viewers and thus aren't relevant to the profile viewer, so I removed them.
