### PR TITLE
Improve display of equal aspect ratio mode in image viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 
 * Use SVG icons instead of PNG for toolbar. [#228]
 
+* Make sure image viewer fills all available space even when using
+  equal aspect ratio. [#231]
+
 0.5 (2021-05-13)
 ================
 

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -35,13 +35,27 @@ class FRBImage(ImageGL):
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'min')
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'max')
 
+        self.shape = None
+
         self.update()
 
     @debounced(method=True)
     def debounced_update(self, *args, **kwargs):
         return self.update(self, *args, **kwargs)
 
+    @property
+    def shape(self):
+        return self._shape
+
+    @shape.setter
+    def shape(self, value):
+        self._shape = value
+        self.update()
+
     def update(self, *args, **kwargs):
+
+        if self.shape is None:
+            return
 
         # Get current limits from the plot
         xmin = self.viewer.figure.axes[0].scale.min
@@ -52,12 +66,7 @@ class FRBImage(ImageGL):
         if xmin is None or xmax is None or ymin is None or ymax is None:
             return
 
-        # Find out the size of the widget. Unfortunately there is actually
-        # no way to find this out, so we need to hard-code this, and we could
-        # make it a parameter in future. Bqplot does allow us to constrain the
-        # aspect ratio though so we could envisage trying to use that info
-        # to make sure the ratio of the sizes is sensible..
-        ny, nx = 256, 256
+        ny, nx = self.shape
 
         # Set up bounds
         bounds = [(ymin, ymax, ny), (xmin, xmax, nx)]

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -67,7 +67,7 @@ class BqplotImageView(BqplotBaseView):
 
     def _sync_figure_aspect(self, *args, **kwargs):
         with self.figure.hold_trait_notifications():
-            if self.state.aspect == 'equal' and self._vl is not None:
+            if self.state.aspect == 'equal':
                 if self._composite_image.shape is None:
                     axes_ratio = None
                 else:

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -38,8 +38,7 @@ class BqplotImageView(BqplotBaseView):
 
         super(BqplotImageView, self).__init__(session)
 
-        self._vl = ViewListener(widget=self.figure, css_selector=".svg-figure > g")
-        self._vl.observe(self._sync_figure_aspect, names=['view_data'])
+        self._vl = None
 
         on_change([(self.state, 'aspect')])(self._sync_figure_aspect)
         self._sync_figure_aspect()
@@ -51,19 +50,22 @@ class BqplotImageView(BqplotBaseView):
         self.state.add_callback('x_att', self._reset_limits)
         self.state.add_callback('y_att', self._reset_limits)
 
+    def _setup_view_listener(self):
+        self._vl = ViewListener(widget=self.figure,
+                                css_selector=".svg-figure > g")
+        self._vl.observe(self._sync_figure_aspect, names=['view_data'])
+
     def _reset_limits(self, *args):
         self.state.reset_limits()
 
-    def _sync_figure_aspect(self):
-        print('_sync_figure_aspect')
+    def _sync_figure_aspect(self, *args, **kwargs):
         with self.figure.hold_trait_notifications():
-            if self.state.aspect == 'equal':
-                print(self._vl.view_data)
+            if self.state.aspect == 'equal' and self._vl is not None:
                 views = sorted(self._vl.view_data)
                 print(views)
                 if len(views) > 0:
                     first_view = self._vl.view_data[views[0]]
-                    axes_ratio = first_view.width / first_view.height
+                    axes_ratio = first_view['height'] / first_view['width']
                 else:
                     axes_ratio = None
             else:

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -1,5 +1,3 @@
-import bqplot
-
 from glue.viewers.image.state import ImageViewerState
 from glue.viewers.image.composite_array import CompositeArray
 from bqplot_image_gl.viewlistener import ViewListener

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -288,15 +288,16 @@ def test_imshow_equal_aspect(app, data_image):
     data = Data(array=np.random.random((100, 5)))
     app.data_collection.append(data)
     v = app.imshow(data=data)
-    assert v.figure.min_aspect_ratio == 1
-    assert v.figure.max_aspect_ratio == 1
+    # Since the widget isn't actually shown during the testing we set the axes
+    # ratio manually here
+    v.state._set_axes_aspect_ratio(1)
+    v.state.reset_limits()
+    assert v.state.aspect == 'equal'
     assert v.scale_x.min == -48.0
     assert v.scale_x.max == +52.0
     assert v.scale_y.min == -0.5
     assert v.scale_y.max == +99.5
     v.state.aspect = 'auto'
-    assert v.figure.min_aspect_ratio == 0.01
-    assert v.figure.max_aspect_ratio == 100
     # NOTE: the limits don't actually change automatically, because if user
     # is zoomed in they might not want to automatically zoom all the way out
     # again.
@@ -305,8 +306,6 @@ def test_imshow_equal_aspect(app, data_image):
     assert v.scale_y.min == -0.5
     assert v.scale_y.max == +99.5
     v.state.aspect = 'equal'
-    assert v.figure.min_aspect_ratio == 1
-    assert v.figure.max_aspect_ratio == 1
     assert v.scale_x.min == -48.0
     assert v.scale_x.max == +52.0
     assert v.scale_y.min == -0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=1.3.0
+    bqplot-image-gl>=1.4.1
     bqplot>=0.12.17
     scikit-image
 


### PR DESCRIPTION
This resolves a long standing issue that when in equal aspect ratio mode the figure used to always be square which did not make an efficient use of the available screen space, and caused issues in tabbed viewer mode, e.g. Jupyter Lab or jdaviz. With the latest change:

![Screenshot_2021-05-27_09-53-08](https://user-images.githubusercontent.com/314716/119796565-606b0200-bed1-11eb-8ca8-ee7e0311b663.png)

However this isn't ready yet - for now I need to manually call _setup_view_listener after the bqplot image is visible, otherwise the ViewListener does not find the view.

@maartenbreddels - this might be a good starting point for experimenting with possible fixes for ViewListener