### PR TITLE
Attach ViewListener to different bqplot plot element to not include selectors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@
 
 * No changes yet.
 
+0.6.1 (unreleased)
+==================
+
+* Fix bug that caused the aspect ratio of the image viewer to change when a
+  selection region was partially outside plot.
+
 0.6 (2021-06-08)
 ================
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -50,7 +50,7 @@ class BqplotImageView(BqplotBaseView):
 
     def _setup_view_listener(self):
         self._vl = ViewListener(widget=self.figure,
-                                css_selector=".svg-figure > g")
+                                css_selector=".plotarea_events")
         self._vl.observe(self._on_view_change, names=['view_data'])
 
     def _reset_limits(self, *args):


### PR DESCRIPTION
Before this change, this is what happened:

![Peek 2021-06-10 15-01](https://user-images.githubusercontent.com/314716/121539515-a78ee200-c9fd-11eb-9196-1b90886513de.gif)
