### PR TITLE
Fix broken selections in image viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,10 @@
 0.6.1 (unreleased)
 ==================
 
+* Fix bug that caused selection tools to not work correctly in 0.6 release. [#234]
+
 * Fix bug that caused the aspect ratio of the image viewer to change when a
-  selection region was partially outside plot.
+  selection region was partially outside plot. [#233]
 
 0.6 (2021-06-08)
 ================

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -35,8 +35,6 @@ class FRBImage(ImageGL):
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'min')
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'max')
 
-        self.shape = None
-
         self.update()
 
     @debounced(method=True)
@@ -45,12 +43,7 @@ class FRBImage(ImageGL):
 
     @property
     def shape(self):
-        return self._shape
-
-    @shape.setter
-    def shape(self, value):
-        self._shape = value
-        self.update()
+        return self.viewer.shape
 
     def update(self, *args, **kwargs):
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -36,6 +36,8 @@ class BqplotImageView(BqplotBaseView):
 
         super(BqplotImageView, self).__init__(session)
 
+        self.shape = None
+
         self._composite = CompositeArray()
         self._composite_image = FRBImage(self, self._composite)
         self.figure.marks = list(self.figure.marks) + [self._composite_image]
@@ -60,15 +62,15 @@ class BqplotImageView(BqplotBaseView):
         views = sorted(self._vl.view_data)
         if len(views) > 0:
             first_view = self._vl.view_data[views[0]]
-            self._composite_image.shape = (int(first_view['height']), int(first_view['width']))
+            self.shape = (int(first_view['height']), int(first_view['width']))
         else:
-            self._composite_image.shape = None
+            self.shape = None
         self._sync_figure_aspect()
 
     def _sync_figure_aspect(self, *args, **kwargs):
         with self.figure.hold_trait_notifications():
             if self.state.aspect == 'equal':
-                if self._composite_image.shape is None:
+                if self.shape is None:
                     axes_ratio = None
                 else:
                     height, width = self._composite_image.shape


### PR DESCRIPTION
Region selections were broken in the image viewer in v0.6