### PR TITLE
Disable resetting of y_min/y_max in layer artist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-0.11 (unreleased)
-=================
+0.10.1 (unreleased)
+===================
 
 * Prevent jumping around of view in profile viewer when creating
   or updating subsets. [#247]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.11 (unreleased)
+=================
+
+* Prevent jumping around of view in profile viewer when creating
+  or updating subsets. [#247]
+
 0.10 (2021-09-14)
 =================
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,19 +37,22 @@ jobs:
       libraries: {}
       coverage: 'false'
 
-    - linux: py36-test
     - linux: py37-test
+    - linux: py38-test
+    - linux: py39-test
 
-    - macos: py36-test
     - macos: py37-test
+    - macos: py38-test
+    - macos: py39-test
 
-    - windows: py36-test
     - windows: py37-test
+    - windows: py38-test
+    - windows: py39-test
 
     - linux: py37-notebooks
-    - macos: py37-notebooks
-    - windows: py36-notebooks
+    - macos: py38-notebooks
+    - windows: py39-notebooks
 
-    - linux: py37-docs
+    - linux: py39-docs
     - macos: py37-docs
-    - windows: py36-docs
+    - windows: py38-docs

--- a/glue_jupyter/bqplot/histogram/layer_artist.py
+++ b/glue_jupyter/bqplot/histogram/layer_artist.py
@@ -126,7 +126,9 @@ class BqplotHistogramLayerArtist(LayerArtist):
                 self.state.layer is None):
             return
 
-        changed = set() if force else self.pop_changed_properties()
+        # NOTE: we need to evaluate this even if force=True so that the cache
+        # of updated properties is up to date after this method has been called.
+        changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'hist_x_min',
                                                      'hist_x_max', 'hist_n_bin', 'x_log')):

--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -118,7 +118,9 @@ class BqplotImageLayerArtist(ImageLayerArtist):
         if self.uuid is None or self.state.attribute is None or self.state.layer is None:
             return
 
-        changed = set() if force else self.pop_changed_properties()
+        # NOTE: we need to evaluate this even if force=True so that the cache
+        # of updated properties is up to date after this method has been called.
+        changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'attribute',
                                                      'slices', 'x_att', 'y_att')):
@@ -175,7 +177,9 @@ class BqplotImageSubsetLayerArtist(BaseImageLayerArtist):
         if self.subset_array is None or self.state.layer is None:
             return
 
-        changed = set() if force else self.pop_changed_properties()
+        # NOTE: we need to evaluate this even if force=True so that the cache
+        # of updated properties is up to date after this method has been called.
+        changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'attribute', 'color',
                                                      'x_att', 'y_att', 'slices')):

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -134,7 +134,9 @@ class BqplotProfileLayerArtist(LayerArtist):
                 self.state.layer is None):
             return
 
-        changed = set() if force else self.pop_changed_properties()
+        # NOTE: we need to evaluate this even if force=True so that the cache
+        # of updated properties is up to date after this method has been called.
+        changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute',
                                                      'function', 'normalize',

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, division, print_function
 import sys
 import warnings
 
-import numpy as np
-
 from glue.core import BaseData
 from glue.utils import defer_draw, color2hex
 from glue.viewers.profile.state import ProfileLayerState

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -112,15 +112,15 @@ class BqplotProfileLayerArtist(LayerArtist):
             self.state._y_min = y_min - y_range * 0.1
             self.state._y_max = y_max + y_range * 0.1
 
-            largest_y_max = max(getattr(layer, '_y_max', 0)
-                                for layer in self._viewer_state.layers)
-            if largest_y_max != self._viewer_state.y_max:
-                self._viewer_state.y_max = largest_y_max
+            # largest_y_max = max(getattr(layer, '_y_max', 0)
+            #                     for layer in self._viewer_state.layers)
+            # if largest_y_max != self._viewer_state.y_max:
+            #     self._viewer_state.y_max = largest_y_max
 
-            smallest_y_min = min(getattr(layer, '_y_min', np.inf)
-                                 for layer in self._viewer_state.layers)
-            if smallest_y_min != self._viewer_state.y_min:
-                self._viewer_state.y_min = smallest_y_min
+            # smallest_y_min = min(getattr(layer, '_y_min', np.inf)
+            #                      for layer in self._viewer_state.layers)
+            # if smallest_y_min != self._viewer_state.y_min:
+            #     self._viewer_state.y_min = smallest_y_min
 
         self.redraw()
 

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from glue.core import BaseData
-from glue.utils import defer_draw, nanmin, nanmax, color2hex
+from glue.utils import defer_draw, color2hex
 from glue.viewers.profile.state import ProfileLayerState
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 
@@ -102,25 +102,6 @@ class BqplotProfileLayerArtist(LayerArtist):
             with self.line_mark.hold_sync():
                 self.line_mark.x = [0.]
                 self.line_mark.y = [0.]
-
-        if not self._viewer_state.normalize and len(y) > 0:
-
-            y_min = nanmin(y)
-            y_max = nanmax(y)
-            y_range = y_max - y_min
-
-            self.state._y_min = y_min - y_range * 0.1
-            self.state._y_max = y_max + y_range * 0.1
-
-            # largest_y_max = max(getattr(layer, '_y_max', 0)
-            #                     for layer in self._viewer_state.layers)
-            # if largest_y_max != self._viewer_state.y_max:
-            #     self._viewer_state.y_max = largest_y_max
-
-            # smallest_y_min = min(getattr(layer, '_y_min', np.inf)
-            #                      for layer in self._viewer_state.layers)
-            # if smallest_y_min != self._viewer_state.y_min:
-            #     self._viewer_state.y_min = smallest_y_min
 
         self.redraw()
 

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -1,6 +1,11 @@
+import numpy as np
+
+from echo import delay_callback
+
 from glue.core.subset import roi_to_subset_state
 from glue.core.roi import RangeROI
 from glue.viewers.profile.state import ProfileViewerState
+from glue.utils import nanmin, nanmax
 
 from ..common.viewer import BqplotBaseView
 
@@ -11,7 +16,23 @@ from glue_jupyter.common.state_widgets.viewer_profile import ProfileViewerStateW
 
 __all__ = ['BqplotProfileView']
 
-__all__ = ['BqplotProfileView']
+
+class BqplotProfileViewerState(ProfileViewerState):
+
+    def _reset_y_limits(self, *event):
+        if self.normalize:
+            super()._reset_y_limits()
+        else:
+            y_min, y_max = np.inf, -np.inf
+            for layer in self.layers:
+                if layer.profile is not None:
+                    x, y = layer.profile
+                y_min = min(y_min, nanmin(y))
+                y_max = max(y_max, nanmax(y))
+            if y_max > y_min:
+                with delay_callback(self, 'y_min', 'y_max'):
+                    self.y_min = y_min
+                    self.y_max = y_max
 
 
 class BqplotProfileView(BqplotBaseView):
@@ -20,7 +41,7 @@ class BqplotProfileView(BqplotBaseView):
     allow_duplicate_subset = False
     is2d = False
 
-    _state_cls = ProfileViewerState
+    _state_cls = BqplotProfileViewerState
     _options_cls = ProfileViewerStateWidget
     _data_artist_cls = BqplotProfileLayerArtist
     _subset_artist_cls = BqplotProfileLayerArtist

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -1,11 +1,6 @@
-import numpy as np
-
-from echo import delay_callback
-
 from glue.core.subset import roi_to_subset_state
 from glue.core.roi import RangeROI
 from glue.viewers.profile.state import ProfileViewerState
-from glue.utils import nanmin, nanmax
 
 from ..common.viewer import BqplotBaseView
 
@@ -17,31 +12,13 @@ from glue_jupyter.common.state_widgets.viewer_profile import ProfileViewerStateW
 __all__ = ['BqplotProfileView']
 
 
-class BqplotProfileViewerState(ProfileViewerState):
-
-    def _reset_y_limits(self, *event):
-        if self.normalize:
-            super()._reset_y_limits()
-        else:
-            y_min, y_max = np.inf, -np.inf
-            for layer in self.layers:
-                if layer.profile is not None:
-                    x, y = layer.profile
-                y_min = min(y_min, nanmin(y))
-                y_max = max(y_max, nanmax(y))
-            if y_max > y_min:
-                with delay_callback(self, 'y_min', 'y_max'):
-                    self.y_min = y_min
-                    self.y_max = y_max
-
-
 class BqplotProfileView(BqplotBaseView):
 
     allow_duplicate_data = False
     allow_duplicate_subset = False
     is2d = False
 
-    _state_cls = BqplotProfileViewerState
+    _state_cls = ProfileViewerState
     _options_cls = ProfileViewerStateWidget
     _data_artist_cls = BqplotProfileLayerArtist
     _subset_artist_cls = BqplotProfileLayerArtist

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
   setuptools_scm
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_requires = >=3.6
 setup_requires =
   setuptools_scm
 install_requires =
-    glue-core>=1.0
+    glue-core>=1.2.2
     glue-vispy-viewers>=1.0
     notebook>=4.0
     ipympl>=0.3.0


### PR DESCRIPTION
I need to figure out if this code is still needed, but for now it seems it definitely isn't for specviz, so this branch can be used with specviz to avoid rescaling all the time.