### PR TITLE
Catch DeprecationWarnings by specific filterwarnings / fixes

### DIFF
--- a/glue_jupyter/ipyvolume/common/tools.py
+++ b/glue_jupyter/ipyvolume/common/tools.py
@@ -22,9 +22,9 @@ class IPyVolumeCheckableTool(CheckableTool):
 
     @property
     def projection_matrix(self):
-        W = np.matrix(self.viewer.figure.matrix_world).reshape((4, 4))     .T
-        P = np.matrix(self.viewer.figure.matrix_projection).reshape((4, 4)).T
-        M = np.dot(P, W)
+        W = np.array(self.viewer.figure.matrix_world).reshape((4, 4))     .T  # noqa: N806
+        P = np.array(self.viewer.figure.matrix_projection).reshape((4, 4)).T  # noqa: N806
+        M = np.dot(P, W)  # noqa: N806
         return M
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,20 +59,25 @@ filterwarnings =
     error::DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning:glue.config.*:
     ignore:`np.float` is a deprecated alias:DeprecationWarning:glue.*:
+    # possibly more serious issue with overlapping memory in glue/utils/array.py:30: unbroadcast
+    ignore:Numpy has detected .* writing to an array:DeprecationWarning:
     # matplotlib.cbook.deprecation.MatplotlibDeprecationWarning (currently only on Windows...)
     # as glue tries to unset 'keymap.all_axes' - the warning itself is considered deprecated / internal...
-    ignore:The keymap.* rcparam was deprecated:DeprecationWarning:glue.config.*:
+    ignore:The keymap.* rcparam was deprecated::glue.config.*:
     ignore:metadata .* was set from the constructor:DeprecationWarning:bqplot.*:
     ignore:default_opacities is deprecated:DeprecationWarning:bqplot.*:
     ignore:Traits should be given as instances:DeprecationWarning:bqplot_image_gl.*:
     ignore:Traits should be given as instances:DeprecationWarning:ipyvolume.*:
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning:ipyvolume.*:
-    ignore:Passing unrecognized arguments to super:DeprecationWarning:ipywidgets.*:
+    # be thankful there is no SpellingWarning, traitlets!
+    ignore:Passing unrecogi?nized arguments to super:DeprecationWarning:ipywidgets.*:
     ignore:defusedxml.cElementTree is deprecated:DeprecationWarning:nbconvert.filters.*:
     ignore:Keyword `trait:DeprecationWarning:pythreejs.*:
     ignore::DeprecationWarning:traittypes.*:
     ignore::FutureWarning:traitlets.*:
-    # numpy/linalg/linalg.py:2514: `x = asarray(x)` - triggered by `example_volume` from `ipv.examples.ball()
+    # numpy/linalg/linalg.py:2514 (1.21) or numpy/core/_asarray.py:83 (1.19):
+    # `x = asarray(x)` - triggered by `example_volume` from `ipv.examples.ball()
+    ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.core.*:
     ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.linalg.*:
     ignore:'contextfilter' is renamed to 'pass_context':DeprecationWarning:
     # potentially more serious, but possibly also only erratic - report them, but don't raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ glue_jupyter.icons = *.svg
 # -Wignore: See https://github.com/glue-viz/glue-jupyter/issues/237
 # -s: Disable stdout capturing
 filterwarnings =
-    error
+    error::DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning:glue.config.*:
     ignore:`np.float` is a deprecated alias:DeprecationWarning:glue.*:
     # matplotlib.cbook.deprecation.MatplotlibDeprecationWarning (currently only on Windows...)
@@ -75,6 +75,9 @@ filterwarnings =
     # numpy/linalg/linalg.py:2514: `x = asarray(x)` - triggered by `example_volume` from `ipv.examples.ball()
     ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.linalg.*:
     ignore:'contextfilter' is renamed to 'pass_context':DeprecationWarning:
+    # potentially more serious, but possibly also only erratic - report them, but don't raise
+    # ignore:numpy.ndarray size changed:RuntimeWarning:astropy.*:
+    # ignore:numpy.ufunc size changed:RuntimeWarning:pandas.*:
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,9 @@ filterwarnings =
     error
     ignore:the imp module is deprecated:DeprecationWarning:glue.config.*:
     ignore:`np.float` is a deprecated alias:DeprecationWarning:glue.*:
+    # matplotlib.cbook.deprecation.MatplotlibDeprecationWarning (currently only on Windows...)
+    # as glue tries to unset 'keymap.all_axes' - the warning itself is considered deprecated / internal...
+    ignore:The keymap.* rcparam was deprecated:DeprecationWarning:glue.config.*:
     ignore:metadata .* was set from the constructor:DeprecationWarning:bqplot.*:
     ignore:default_opacities is deprecated:DeprecationWarning:bqplot.*:
     ignore:Traits should be given as instances:DeprecationWarning:bqplot_image_gl.*:
@@ -69,9 +72,8 @@ filterwarnings =
     ignore:Keyword `trait:DeprecationWarning:pythreejs.*:
     ignore::DeprecationWarning:traittypes.*:
     ignore::FutureWarning:traitlets.*:
-    # numpy/linalg/linalg.py:2514: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences in `x = asarray(x)`
-    # - triggered by `example_volume` from `ipv.examples.ball()
-    ignore:Creating an ndarray from ragged nested sequences::numpy.linalg.*:
+    # numpy/linalg/linalg.py:2514: `x = asarray(x)` - triggered by `example_volume` from `ipv.examples.ball()
+    ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.linalg.*:
     ignore:'contextfilter' is renamed to 'pass_context':DeprecationWarning:
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,12 +65,14 @@ filterwarnings =
     ignore:Traits should be given as instances:DeprecationWarning:ipyvolume.*:
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning:ipyvolume.*:
     ignore:Passing unrecognized arguments to super:DeprecationWarning:ipywidgets.*:
+    ignore:defusedxml.cElementTree is deprecated:DeprecationWarning:nbconvert.filters.*:
     ignore:Keyword `trait:DeprecationWarning:pythreejs.*:
     ignore::DeprecationWarning:traittypes.*:
     ignore::FutureWarning:traitlets.*:
     # numpy/linalg/linalg.py:2514: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences in `x = asarray(x)`
     # - triggered by `example_volume` from `ipv.examples.ball()
     ignore:Creating an ndarray from ragged nested sequences::numpy.linalg.*:
+    ignore:'contextfilter' is renamed to 'pass_context':DeprecationWarning:
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,22 @@ glue_jupyter.icons = *.svg
 [tool:pytest]
 # -Wignore: See https://github.com/glue-viz/glue-jupyter/issues/237
 # -s: Disable stdout capturing
-addopts = -Wignore -s
+filterwarnings =
+    error
+    ignore:the imp module is deprecated:DeprecationWarning:glue.config.*:
+    ignore:`np.float` is a deprecated alias:DeprecationWarning:glue.*:
+    ignore:metadata .* was set from the constructor:DeprecationWarning:bqplot.*:
+    ignore:default_opacities is deprecated:DeprecationWarning:bqplot.*:
+    ignore:Traits should be given as instances:DeprecationWarning:bqplot_image_gl.*:
+    ignore:Traits should be given as instances:DeprecationWarning:ipyvolume.*:
+    ignore:Using or importing the ABCs from 'collections':DeprecationWarning:ipyvolume.*:
+    ignore:Passing unrecognized arguments to super:DeprecationWarning:ipywidgets.*:
+    ignore:Keyword `trait:DeprecationWarning:pythreejs.*:
+    ignore::DeprecationWarning:traittypes.*:
+    ignore::FutureWarning:traitlets.*:
+    # numpy/linalg/linalg.py:2514: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences in `x = asarray(x)`
+    # - triggered by `example_volume` from `ipv.examples.ball()
+    ignore:Creating an ndarray from ragged nested sequences::numpy.linalg.*:
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Description

Addressing #237, this replaces the `-Wignore` pytest option from #238 with more specific `filterwarnings` for the `DeprecationWarning` instances and setting `error` for any that would be missed. All but one actually originate from various upstream modules. So unless I am missing some error in usage of those modules all to be followed up on would be reporting the warnings upstream.
And take care of the two in `glue` itself, of course – `astype(np.float)` is straightforward; replacing `imp` could be a bit trickier.
Getting rid of `np.matrix` in the second commit was also trivial since `Projected3dROI` has already cast `projection_matrix` to `asarray` all along.