### PR TITLE
Avoid duplicate draws in FRBMark

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.8 (unreleased)
+================
+
+* Avoid updating FRBMark multiple times when adding a new layer. [#248]
+
 0.7 (2021-07-02)
 ================
 

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -78,4 +78,4 @@ class FRBImage(ImageGL):
             self.image = EMPTY_IMAGE
 
     def invalidate_cache(self):
-        self.update()
+        self.debounced_update()

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -78,4 +78,4 @@ class FRBImage(ImageGL):
             self.image = EMPTY_IMAGE
 
     def invalidate_cache(self):
-        self.debounced_update()
+        self.update()

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -35,7 +35,10 @@ class FRBImage(ImageGL):
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'min')
         self.viewer.figure.axes[1].scale.observe(self.debounced_update, 'max')
 
-        self.update()
+        # NOTE: we deliberately don't call .update() here because when FRBImage
+        # is created for the main composite image layer the composite arrays
+        # haven't been set up yet, and for subset layers the layer gets force
+        # updated anyway when the layers are added to the viewer.
 
     @debounced(method=True)
     def debounced_update(self, *args, **kwargs):

--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -207,5 +207,11 @@ class BqplotImageSubsetLayerArtist(BaseImageLayerArtist):
             self.image_artist.invalidate_cache()
             self._update_visual_attributes(redraw=redraw)
 
+    def update(self, *event):
+        ARRAY_CACHE.pop(self.state.uuid, None)
+        PIXEL_CACHE.pop(self.state.uuid, None)
+        self._update_image(force=True)
+        self.redraw()
+
     def redraw(self):
         pass

--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -135,7 +135,7 @@ class BqplotImageLayerArtist(ImageLayerArtist):
             self._update_contour_lines()
 
     def _update_image_data(self, *args, **kwargs):
-        super()._update_image_data(*args, **kwargs)
+        self.composite_image.invalidate_cache()
         # if the image data change, the contour lines are invalid
         self._contour_line_cache.clear()
         self._update_contour_lines()
@@ -206,12 +206,6 @@ class BqplotImageSubsetLayerArtist(BaseImageLayerArtist):
         if hasattr(self, 'image_artist'):
             self.image_artist.invalidate_cache()
             self._update_visual_attributes(redraw=redraw)
-
-    def update(self, *event):
-        ARRAY_CACHE.pop(self.state.uuid, None)
-        PIXEL_CACHE.pop(self.state.uuid, None)
-        self._update_image(force=True)
-        self.redraw()
 
     def redraw(self):
         pass


### PR DESCRIPTION
This does some small optimizations with FRBMark updating to avoid updating too many times when adding a layer