### PR TITLE
Fix updating of layers list

### DIFF
--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -69,7 +69,7 @@ class LayerOptionsWidget(v.VuetifyTemplate):
             self.layers = [layer_to_dict(layer_artist, i) for i, layer_artist in
                            enumerate(self.viewer.layers)]
 
-        self.viewer.state.add_callback('layers', _update_layers_from_glue_state)
+        self.viewer._layer_artist_container.on_changed(_update_layers_from_glue_state)
         _update_layers_from_glue_state()
 
     def vue_toggle_visible(self, index):


### PR DESCRIPTION
Alternative to #250 - we weren't connecting the callback in the right place, and were ending up in a state where the layers state had been updated but not layer artists. This uses private API but in glue-core so this is fine (though we should probably expose this publicly anyway).