### PR TITLE
MNT: glue-core uses override_mode since 2018

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -191,7 +191,7 @@ class BqplotBaseView(IPyWidgetView):
                 subset_state = self._roi_to_subset_state(roi)
                 cmd = ApplySubsetState(data_collection=self._data,
                                        subset_state=subset_state,
-                                       use_current=use_current)
+                                       override_mode=use_current)
                 self._session.command_stack.do(cmd)
 
     def _roi_to_subset_state(self, roi):

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -78,7 +78,7 @@ class IpyvolumeBaseView(IPyWidgetView):
             subset_state = RoiSubsetState3d(x, y, z, roi)
             cmd = ApplySubsetState(data_collection=self._data,
                                    subset_state=subset_state,
-                                   use_current=use_current)
+                                   override_mode=use_current)
             self._session.command_stack.do(cmd)
 
     def limits_to_scales(self, *args):


### PR DESCRIPTION
## Description

See this upstream change from 2018:

* glue-viz/glue#1793

p.s. Ugh, I was trying out [GitHub's new repo editor](https://twitter.com/github/status/1425505817827151872) and it made me push changes to my fork's `master` branch, so here we are...