### PR TITLE
Provide a way to hide columns in the table viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.10 (unreleased)
+=================
+
+* Add the ability to hide columns in the table viewer by using
+  ``TableViewer.state.hidden_components``. [#259]
+
 0.9 (2021-09-14)
 ================
 


### PR DESCRIPTION
To use this, one needs to pass component IDs to the ``hidden_components`` property on the table viewer state - for example in Mosviz:

```python
data = mosviz.app.data_collection[0]
viewer = mosviz.app.get_viewer_by_id('mosviz-3')
viewer.state.hidden_components = [data.id['Images'], data.id['1D Spectra']]
```