### PR TITLE
default_opacities is deprecated, use opacities instead

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -78,8 +78,8 @@ class BqplotScatterLayerArtist(LayerArtist):
         dlink((self.state, 'visible'), (self.scatter, 'visible'))
         dlink((self.state, 'visible'), (self.image, 'visible'))
 
-        dlink((self.state, 'alpha'), (self.scatter, 'default_opacities'), lambda x: [x])
-        dlink((self.state, 'alpha'), (self.quiver, 'default_opacities'), lambda x: [x])
+        dlink((self.state, 'alpha'), (self.scatter, 'opacities'), lambda x: [x])
+        dlink((self.state, 'alpha'), (self.quiver, 'opacities'), lambda x: [x])
         dlink((self.state, 'alpha'), (self.image, 'opacity'))
 
         on_change([(self.state, 'vector_visible', 'vx_att', 'vy_att')])(self._update_quiver)


### PR DESCRIPTION
## Description

```
bqplot/marks.py:709: DeprecationWarning: default_opacities is deprecated, use opacities instead.
```

https://github.com/bqplot/bqplot/blob/d8fae93274422e72b7ecf1f464d8d8197103a28d/bqplot/marks.py#L703-L711

@maartenbreddels and @astrofrog should double check that this patch is correct.