### PR TITLE
BUG: Deselect when all subsets deleted

### DIFF
--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -80,6 +80,8 @@ class SubsetSelect(v.VuetifyTemplate, HubListener):
     def _sync_available_from_state(self):
         self.available = [subset_to_dict(subset) for subset in
                           self.data_collection.subset_groups]
+        if len(self.available) == 0:
+            self.selected = []
 
     @traitlets.observe('selected')
     def _sync_selected_from_ui(self, change):


### PR DESCRIPTION
## Description

This fixes the bug where when the last subset is deleted, the dropdown menu and display behaviors do not make sense.

* Fix spacetelescope/jdaviz#642 cc @camipacifici
* Fix spacetelescope/jdaviz#216 cc @PatrickOgle