### PR TITLE
feat: truncate text that doesn't fit and show tooltip with full text

### DIFF
--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -9,13 +9,13 @@
       :options.sync="options"
       :items_per_page.sync="items_per_page"
       :server-items-length="total_length"
-      class="elevation-1"
+      class="elevation-1 glue-data-table"
     >
       <template v-slot:header="props">
         <thead>
           <tr>
-            <th style="padding: 0 10px">#</th>
-            <th style="padding: 0 1px" v-if="selection_enabled">
+            <th style="padding: 0 10px; width: 40px">#</th>
+            <th style="padding: 0 1px; width: 30px" v-if="selection_enabled">
               <v-btn icon color="primary" text small @click="apply_filter">
                 <v-icon>filter_list</v-icon>
               </v-btn>
@@ -51,9 +51,13 @@
               >brightness_1</v-icon>
             </v-fade-transition>
           </td>
-          <td v-for="header in headers" class="text-xs-right" :key="header.text">
+          <td v-for="header in headers" class="text-xs-right"
+              :key="header.text"
+              class="text-truncate text-no-wrap"
+              :title="props.item[header.value]"
+          >
             <v-slide-x-transition appear>
-              <span class="text-truncate" style="display: inline-block">{{ props.item[header.value] }}</span>
+              <span>{{ props.item[header.value] }}</span>
             </v-slide-x-transition>
           </td>
         </tr>
@@ -63,8 +67,12 @@
 </template>
 
 
-<style scoped>
+<style id="glue_table">
 .highlightedRow {
     background-color: #E3F2FD;
+}
+
+.glue-data-table table {
+  table-layout: fixed;
 }
 </style>


### PR DESCRIPTION
## Description

Long text in the table is pushing text of other cells out of view:
<img width="964" alt="Screenshot 2021-09-28 at 12 24 48" src="https://user-images.githubusercontent.com/46192475/135071736-ae47ad8a-8887-44c3-aee2-baeebce43fab.png">

With this PR the content is truncated and on hover a tooltip appears with the full text:
<img width="968" alt="Screenshot 2021-09-28 at 12 27 01" src="https://user-images.githubusercontent.com/46192475/135071794-4261844a-1c5e-45b6-8086-a9539ffdcce2.png">

