### PR TITLE
BUG: sync_selected_from_ui to handle IndexError

### DIFF
--- a/glue_jupyter/widgets/subset_select_vuetify.py
+++ b/glue_jupyter/widgets/subset_select_vuetify.py
@@ -85,8 +85,15 @@ class SubsetSelect(v.VuetifyTemplate, HubListener):
 
     @traitlets.observe('selected')
     def _sync_selected_from_ui(self, change):
-        self.edit_subset_mode.edit_subset = [self.data_collection.subset_groups[index] for index in
-                                             change['new']]
+        try:
+            self.edit_subset_mode.edit_subset = [self.data_collection.subset_groups[index] for index
+                                                 in change['new']]
+        # https://github.com/spacetelescope/jdaviz/issues/928
+        except IndexError:
+            if len(self.data_collection.subset_groups) == 0:
+                self.edit_subset_mode.edit_subset = None
+            else:
+                self.edit_subset_mode.edit_subset = [self.data_collection.subset_groups[-1]]
 
     @traitlets.observe('multiple')
     def _switch_multiple(self, change):


### PR DESCRIPTION
## Description

This PR is to:

* Fix spacetelescope/jdaviz#928

Workflow:

1. Download notebook from https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/IFU_cube_continuum_fit
2. Only run the code in it to download data and load it into Cubeviz; ignore everything else.
3. In the top-left image viewer, create 9 subsets. All circles are fine. Overlap or not doesn't matter.
4. Delete Subset 2.
5. Delete Subset 7.
6. Delete Subset 9. Without this patch, you will see `IndexError`.
7. Bonus: Delete the rest of the subsets, bottom up. Without this patch, another error will appear when you delete the last one. I cannot tell if this patch renders #266 unnecessary or not. @eteq , you should double check.

Somewhat related: #266 , #293

Disclaimer: I don't grok the VueJS and Glue internals, so more elegant solution is welcome, but this patch should fix the immediate error reported over at Jdaviz.