### PR TITLE
Provide option to reference back to calling app

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -32,11 +32,11 @@ class BqplotImageView(BqplotBaseView):
 
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle']
 
-    def __init__(self, session):
+    def __init__(self, session, app=None):
 
         super(BqplotImageView, self).__init__(session)
-
         self.shape = None
+        self.app = app
 
         self._composite = CompositeArray()
         self._composite_image = FRBImage(self, self._composite)


### PR DESCRIPTION
## Description

In Jdaviz, there is no way for the viewer to access the viz app that created it. This PR is needed to remedy that situation.

Needs:

* glue-viz/glue#2256