### PR TITLE
Link opacity of histogram bars and layer state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.10.2 (unreleased)
+===================
+
+* Link opacity of the histogram bars with the layer state in
+  the histogram viewer. [#275]
+
 0.10.1 (2021-09-16)
 ===================
 

--- a/glue_jupyter/bqplot/histogram/layer_artist.py
+++ b/glue_jupyter/bqplot/histogram/layer_artist.py
@@ -28,6 +28,7 @@ class BqplotHistogramLayerArtist(LayerArtist):
         self.view.figure.marks = list(self.view.figure.marks) + [self.bars]
 
         dlink((self.state, 'color'), (self.bars, 'colors'), lambda x: [color2hex(x)])
+        dlink((self.state, 'alpha'), (self.bars, 'opacities'), lambda x: [x])
 
         self._viewer_state.add_global_callback(self._update_histogram)
         self.state.add_global_callback(self._update_histogram)

--- a/glue_jupyter/common/state_widgets/layer_histogram.py
+++ b/glue_jupyter/common/state_widgets/layer_histogram.py
@@ -1,15 +1,21 @@
-import ipyvuetify as v
+from ipywidgets import FloatSlider, VBox
 
-import traitlets
+from ...link import link
 
 __all__ = ['HistogramLayerStateWidget']
 
 
-class HistogramLayerStateWidget(v.VuetifyTemplate):
-    template = traitlets.Unicode('<span></span>').tag(sync=True)
+class HistogramLayerStateWidget(VBox):
 
     def __init__(self, layer_state):
-        super().__init__()
+
+        self.state = layer_state
+
+        self.widget_opacity = FloatSlider(min=0, max=1, step=0.01, value=self.state.alpha,
+                                          description='opacity')
+        link((self.state, 'alpha'), (self.widget_opacity, 'value'))
+
+        super().__init__([self.widget_opacity])
 
     def cleanup(self):
         pass


### PR DESCRIPTION
This PR connects the opacity of the bars in the histogram viewer to the `alpha` value of the corresponding glue layer state, and adds a corresponding `FloatSlider` in the histogram layer state widget to allow control of this parameter through the UI.