### PR TITLE
Only trigger event callbacks on their specified events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.10.2 (unreleased)
 ===================
 
+* Only trigger bqplot viewer callbacks on their specified events. [#279]
+
 * Link opacity of the histogram bars with the layer state in
   the histogram viewer. [#275]
 

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -151,7 +151,9 @@ class BqplotBaseView(IPyWidgetView):
 
     def _on_mouse_interaction(self, interaction, data, buffers):
         for callback in self._event_callbacks:
-            callback(data)
+            events = self._events_for_callback.get(callback, [])
+            if data["event"] in events:
+                callback(data)
 
     @debounced(delay_seconds=0.5, method=True)
     def update_glue_scales(self, *ignored):

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -1,4 +1,5 @@
 import bqplot
+from functools import partial
 
 from glue.core.subset import roi_to_subset_state
 from glue.core.command import ApplySubsetState
@@ -99,6 +100,13 @@ class BqplotBaseView(IPyWidgetView):
 
         self.create_layout()
 
+    def _callback_key(self, callback):
+        if CallbackContainer.is_bound_method(callback):
+            return (callback.__func__, (callback.__self__,))
+        elif isinstance(callback, partial):
+            return (callback.func, callback.args)
+        return callback
+
     def add_event_callback(self, callback, events=None):
         """
         Add a callback function for mouse and keyboard events when the mouse is over the figure.
@@ -129,9 +137,9 @@ class BqplotBaseView(IPyWidgetView):
         if events is None:
             events = keyboard_events + mouse_events
 
-        self._events_for_callback[callback] = set(events)
-
         self._event_callbacks.append(callback)
+        key = self._callback_key(callback)
+        self._events_for_callback[key] = set(events)
         self._update_interact_events()
 
     def remove_event_callback(self, callback):
@@ -151,7 +159,8 @@ class BqplotBaseView(IPyWidgetView):
 
     def _on_mouse_interaction(self, interaction, data, buffers):
         for callback in self._event_callbacks:
-            events = self._events_for_callback.get(callback, [])
+            key = self._callback_key(callback)
+            events = self._events_for_callback.get(key, [])
             if data["event"] in events:
                 callback(data)
 


### PR DESCRIPTION
In order to accommodate multiple event callbacks, the mouse interact on the bqplot viewers currently listens for the set of events that is the union of all events specified via calls to `add_event_callback`. Currently, however, when any one of these events is detected, all callbacks are fired, regardless of whether or not it is one of their specified events.

To fix this issue, this PR modifies the viewer's mouse interact listener to check whether the current event is one of the callback's specified events before firing it.