### PR TITLE
Mark `notebook` and `docs` non-publishable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,8 @@ jobs:
 
     - linux: codestyle
       libraries: {}
-      coverage: 'false'
+      coverage: false
+      pytest: false
 
     - linux: py37-test
     - linux: py38-test
@@ -50,9 +51,21 @@ jobs:
     - windows: py39-test
 
     - linux: py37-notebooks
+      coverage: false
+      pytest: false
     - macos: py38-notebooks
+      coverage: false
+      pytest: false
     - windows: py39-notebooks
+      coverage: false
+      pytest: false
 
     - linux: py39-docs
+      coverage: false
+      pytest: false
     - macos: py37-docs
+      coverage: false
+      pytest: false
     - windows: py38-docs
+      coverage: false
+      pytest: false


### PR DESCRIPTION
## Description
to skip `PublishTestResults` task and get rid of warnings about missing ResultsFiles - https://github.com/glue-viz/glue-jupyter/issues/237#issuecomment-1036395402.
Also skip `coverage` tasks, which errored (though without consequences).