### PR TITLE
EXP: Another feeble stab at Specviz histogram

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -34,13 +34,12 @@ class BqplotBaseView(IPyWidgetView):
         self.axis_y = bqplot.Axis(scale=self.scale_y, orientation='vertical', tick_format='0.2f',
                                   grid_lines='none', label='y')
 
-        self.figure = bqplot.Figure(scale_x=self.scale_x, scale_y=self.scale_y,
-                                    animation_duration=0,
-                                    axes=[self.axis_x, self.axis_y],
-                                    fig_margin={'left': 60, 'bottom': 60, 'top': 10, 'right': 10})
+        self.figure = bqplot.Hist(scales={"sample": self.scale_x, "count": self.scale_y},
+                                  animation_duration=0,
+                                  axes=[self.axis_x, self.axis_y])
         self.figure.padding_y = 0
-        self._fig_margin_default = self.figure.fig_margin
-        self._fig_margin_zero = dict(self.figure.fig_margin)
+        self._fig_margin_default = 0  # self.figure.fig_margin
+        self._fig_margin_zero = {}  # dict(self.figure.fig_margin)
         self._fig_margin_zero['left'] = 0
         self._fig_margin_zero['bottom'] = 0
 


### PR DESCRIPTION
## Description

This is a even more feeble attempt than spacetelescope/jdaviz#1080 for spacetelescope/jdaviz#385 . Does not work at all. Goes with the following change in Jdaviz:

```diff
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1009,7 +1009,7 @@ class Application(VuetifyTemplate, HubListener):
                 for viewer_item in stack.get('viewers'):
                     viewer = self._viewer_by_id(viewer_item['id'])

-                    if viewer is not None:
+                    if viewer is not None and hasattr(viewer.figure_widget, 'layout'):
                         viewer.figure_widget.layout.height = '99.9%'
                         viewer.figure_widget.layout.height = '100%'
```

### Fantasy

![Screenshot 2022-02-14 214014](https://user-images.githubusercontent.com/2090236/153982291-64f59e12-4170-4ec3-9b6b-10bfa73d6aa2.png)

### Reality

```
.../jdaviz/jdaviz/configs/specviz/helper.py in load_spectrum(self, data, data_label, format, show_in_viewer)
     39 
     40     def load_spectrum(self, data, data_label=None, format=None, show_in_viewer=True):
---> 41         super().load_data(data,
     42                           'specviz-spectrum1d-parser',
     43                           data_label=data_label,

.../jdaviz/jdaviz/core/helpers.py in load_data(self, data, parser_reference, **kwargs)
     67 
     68     def load_data(self, data, parser_reference=None, **kwargs):
---> 69         self.app.load_data(data, parser_reference=parser_reference, **kwargs)
     70 
     71     @property

.../jdaviz/jdaviz/app.py in load_data(self, file_obj, parser_reference, **kwargs)
    368                 # If the parser returns something other than known, assume it's
    369                 #  a message we want to make the user aware of.
--> 370                 msg = parser(self, file_obj, **kwargs)
    371 
    372                 if msg is not None:

.../jdaviz/jdaviz/configs/specviz/plugins/parsers.py in specviz_spectrum1d_parser(app, data, data_label, format, show_in_viewer)
     81             # Only auto-show the first spectrum in a list
     82             if i == 0 and show_in_viewer:
---> 83                 app.add_data_to_viewer("spectrum-viewer", data_label[i])

.../jdaviz/jdaviz/app.py in add_data_to_viewer(self, viewer_reference, data_path, clear_other_data, ext)
    808         if data_id is not None:
    809             data_ids.append(data_id)
--> 810             self._update_selected_data_items(viewer_item['id'], data_ids)
    811         else:
    812             raise ValueError(

.../jdaviz/jdaviz/app.py in _update_selected_data_items(self, viewer_id, selected_items)
   1137             [data] = [x for x in self.data_collection if x.label == label]
   1138 
-> 1139             viewer.add_data(data)
   1140 
   1141             add_data_message = AddDataMessage(data, viewer,

.../jdaviz/jdaviz/configs/specviz/plugins/viewers.py in add_data(self, data, color, alpha, **layer_state)
    341         # The base class handles the plotting of the main
    342         # trace representing the spectrum itself.
--> 343         result = super().add_data(data, color, alpha, **layer_state)
    344 
    345         # Index of spectrum trace plotted by the super class. It is

.../glue-jupyter/glue_jupyter/view.py in add_data(self, data, color, alpha, **layer_state)
    115         data = validate_data_argument(self._data, data)
    116 
--> 117         result = super().add_data(data)
    118 
    119         if not result:

.../glue/glue/viewers/common/viewer.py in add_data(self, data)
    205         # Create layer artist and add to container. First check whether any
    206         # plugins want to make a custom layer artist.
--> 207         layer = get_layer_artist_from_registry(data, self) or self.get_data_layer_artist(data)
    208 
    209         if layer is None:

.../glue/glue/viewers/common/viewer.py in get_data_layer_artist(self, layer, layer_state)
    236 
    237     def get_data_layer_artist(self, layer=None, layer_state=None):
--> 238         return self.get_layer_artist(self._data_artist_cls, layer=layer, layer_state=layer_state)
    239 
    240     def get_subset_layer_artist(self, layer=None, layer_state=None):

.../glue-jupyter/glue_jupyter/view.py in get_layer_artist(self, cls, layer, layer_state)
    140 
    141     def get_layer_artist(self, cls, layer=None, layer_state=None):
--> 142         return cls(self, self.state, layer=layer, layer_state=layer_state)
    143 
    144     def initialize_layer_options(self):

.../glue-jupyter/glue_jupyter/bqplot/profile/layer_artist.py in __init__(self, view, viewer_state, layer_state, layer)
     35         self.line_mark = bqplot.Lines(scales=self.view.scales, x=[0, 1], y=[0, 1])
     36 
---> 37         self.view.figure.marks = list(self.view.figure.marks) + [self.line_mark]
     38 
     39         dlink((self.state, 'color'), (self.line_mark, 'colors'), lambda x: [color2hex(x)])

AttributeError: 'Hist' object has no attribute 'marks'
```