### PR TITLE
BUG: Fix Gaia example notebook

### DIFF
--- a/notebooks/Astronomy/GAIA/Distance to The Pleiades with Glupyter and Gaia DR2.ipynb
+++ b/notebooks/Astronomy/GAIA/Distance to The Pleiades with Glupyter and Gaia DR2.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "view3d = app.scatter3d('ra', 'dec', 'distance')"
+    "view3d = app.scatter3d(x='ra', y='dec', z='distance')"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scats.append(app.scatter2d('distance', 'phot_g_mean_mag'))"
+    "scats.append(app.scatter2d(x='distance', y='phot_g_mean_mag'))"
    ]
   },
   {
@@ -155,7 +155,7 @@
    },
    "outputs": [],
    "source": [
-    "scats.append(app.scatter2d('bp_rp', 'phot_g_mean_mag'))\n",
+    "scats.append(app.scatter2d(x='bp_rp', y='phot_g_mean_mag'))\n",
     "\n",
     "state = scats[-1].state\n",
     "state.y_max, state.y_min = state.y_min, state.y_max"
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scats.append(app.scatter2d('pmra', 'pmdec'))\n",
+    "scats.append(app.scatter2d(x='pmra', y='pmdec'))\n",
     "scats[-1].scale_x.min = -100\n",
     "scats[-1].scale_x.max = 100\n",
     "scats[-1].scale_y.min = -100\n",
@@ -180,10 +180,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scats.append(app.scatter2d('pmra', 'pmra_error'))\n",
+    "scats.append(app.scatter2d(x='pmra', y='pmra_error'))\n",
     "scats[-1].state.x_min, scats[-1].state.x_max = -50, 50\n",
     "\n",
-    "scats.append(app.scatter2d('pmdec', 'pmdec_error'))\n",
+    "scats.append(app.scatter2d(x='pmdec', y='pmdec_error'))\n",
     "scats[-1].state.x_min, scats[-1].state.x_max = -100, 50"
    ]
   },
@@ -388,7 +388,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -402,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

Notebook from #28 no longer runs with positional argument calls. This updates the call signature to use keywords. Notebook does not crash anymore with this patch. Fixing science content is out of scope.

cc @eteq 