### PR TITLE
FEAT: Expose fill attribute for scatter plot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 * Fix a bug that caused the eye icon to not be updated when toggling
   the visibility of a layer.
 
+* Add the ability to set fill attribute for scatter plot. [#292]
+
 0.10.1 (2021-09-16)
 ===================
 

--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -82,6 +82,8 @@ class BqplotScatterLayerArtist(LayerArtist):
         dlink((self.state, 'alpha'), (self.quiver, 'opacities'), lambda x: [x])
         dlink((self.state, 'alpha'), (self.image, 'opacity'))
 
+        dlink((self.state, 'fill'), (self.scatter, 'fill'))
+
         on_change([(self.state, 'vector_visible', 'vx_att', 'vy_att')])(self._update_quiver)
         dlink((self.state, 'vector_visible'), (self.quiver, 'visible'))
 

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -16,6 +16,9 @@ class ScatterLayerStateWidget(VBox):
         self.widget_visible = Checkbox(description='visible', value=self.state.visible)
         link((self.state, 'visible'), (self.widget_visible, 'value'))
 
+        self.widget_fill = Checkbox(description='fill', value=self.state.fill)
+        link((self.state, 'fill'), (self.widget_fill, 'value'))
+
         self.widget_opacity = FloatSlider(min=0, max=1, step=0.01, value=self.state.alpha,
                                           description='opacity')
         link((self.state, 'alpha'), (self.widget_opacity, 'value'))
@@ -42,7 +45,7 @@ class ScatterLayerStateWidget(VBox):
                                          description='bin count')
             link((self.state, 'bins'), (self.widget_bins, 'value'))
 
-        super().__init__([self.widget_visible, self.widget_opacity,
+        super().__init__([self.widget_visible, self.widget_fill, self.widget_opacity,
                           self.widget_size, self.widget_color,
                           self.widget_vector, self.widget_vector_x,
                           self.widget_vector_y])


### PR DESCRIPTION
## Description

This PR enables setting `fill` attribute in scatter plot and also exposes the option as a checkbox in GUI.