### PR TITLE
BUG: Fix out of bounds when viewer shape is zero

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
   updated the active subset dropdown and the layer selection dropdown.
   [#283]
 
+* Fix a bug that caused out of bounds error on subset deletion when
+  viewer shape is zero after the viewer has been destroyed by an
+  application. [#293]
+
 * Fix a bug that caused the eye icon to not be updated when toggling
   the visibility of a layer.
 

--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -64,7 +64,8 @@ class FRBImage(ImageGL):
 
     def update(self, *args, **kwargs):
 
-        if self.shape is None:
+        # Shape can be (0, 0) when viewer was created and then destroyed.
+        if self.shape is None or np.allclose(self.shape, 0):
             return
 
         # Get current limits from the plot


### PR DESCRIPTION
## Description

Sometimes, `self.shape` can have zeroes and causes out of bounds error.

Fix spacetelescope/jdaviz#1102

Pairs well with #270 for the other common error when dealing with subset deletions, and maybe red wine.