### PR TITLE
Fix issue with removing event callbacks

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -146,7 +146,8 @@ class BqplotBaseView(IPyWidgetView):
         """
         Remove a callback function for mouse and keyboard events.
         """
-        self._events_for_callback.pop(callback)
+        key = self._callback_key(callback)
+        self._events_for_callback.pop(key)
         self._event_callbacks.remove(callback)
         self._update_interact_events()
 


### PR DESCRIPTION
I think this should fix the issue mentioned at the end of #279. The key logic for the events dictionary seems to be working fine...I just forgot to connect it to where the callback gets removed, so trying to remove a method callback gives a `KeyError`.

@pllim I ran this through the jdaviz test suite locally, and everything passed (after getting the same error as the CI did before making this fix). If it would be possible for you to run it through the jdaviz CI that would be great. Sorry for any inconvenience this problem caused!