### PR TITLE
Fix how we handle the default ROIClickAndDrag to use the new interact event infrastructure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.11.3 (unreleased)
+===================
+
+* Fixed a bug that caused clicking and dragging of existing regions to not
+  correctly restore other event. [#301]
+
 0.11.2 (2022-03-22)
 ===================
 


### PR DESCRIPTION
This was previously overwriting the top level MouseInteract rather than using 'next' to set the temporary ROI interact tools. This also switches to listen to only dragstart events using the new ``add_event_callback`` machinery.