### PR TITLE
feat: make compatible with future versions of bqplot

### DIFF
--- a/glue_jupyter/bqplot/compatibility.py
+++ b/glue_jupyter/bqplot/compatibility.py
@@ -1,0 +1,13 @@
+from bqplot_image_gl import ImageGL
+import bqplot
+
+ScatterGL = None
+if hasattr(bqplot, "ScatterGL"):
+    ScatterGL = bqplot.ScatterGL
+else:
+    import bqplot_gl
+
+    ScatterGL = bqplot_gl.marks.ScatterGL
+
+
+__all__ = ["ScatterGL", "ImageGL"]

--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -1,6 +1,6 @@
 import numpy as np
 import bqplot
-from bqplot_image_gl import ImageGL
+from ..compatibility import ScatterGL, ImageGL
 
 from glue.core.data import Subset
 from glue.viewers.scatter.state import ScatterLayerState
@@ -40,9 +40,9 @@ class BqplotScatterLayerArtist(LayerArtist):
         self.scales_quiver = dict(self.view.scales, size=self.scale_size_quiver,
                                   rotation=self.scale_rotation)
         self.scales_image = dict(self.view.scales, image=self.scale_image)
-        self.scatter = bqplot.ScatterGL(scales=self.scales, x=[0, 1], y=[0, 1])
-        self.quiver = bqplot.ScatterGL(scales=self.scales_quiver, x=[0, 1], y=[0, 1],
-                                       visible=False, marker='arrow')
+        self.scatter = ScatterGL(scales=self.scales, x=[0, 1], y=[0, 1])
+        self.quiver = ScatterGL(scales=self.scales_quiver, x=[0, 1], y=[0, 1],
+                                visible=False, marker='arrow')
 
         self.counts = None
         self.image = ImageGL(scales=self.scales_image)


### PR DESCRIPTION
A future version of bqplot (0.13.0) will split off the webgl part
into a bqplot-gl package.

This will make it work with that future version, I'm just not sure how we need to optionally depend on bqplot-gl
