### PR TITLE
Change all bqplot limits in one go when glue viewer state limits are updated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.11.5 (unreleased)
+===================
+
+* Speed up syncing of glue and bqplot limits in viewers.
+
 0.11.4 (2022-03-31)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.11.5 (unreleased)
 ===================
 
-* Speed up syncing of glue and bqplot limits in viewers.
+* Speed up syncing of glue and bqplot limits in viewers. [#306]
 
 0.11.4 (2022-03-31)
 ===================

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -107,12 +107,18 @@ class BqplotBaseView(IPyWidgetView):
                                  self.state.y_min, self.state.y_max):
             return
 
-        with self.scale_x.hold_trait_notifications():
-            with self.scale_y.hold_trait_notifications():
-                self.scale_x.min = float_or_none(self.state.x_min)
-                self.scale_x.max = float_or_none(self.state.x_max)
-                self.scale_y.min = float_or_none(self.state.y_min)
-                self.scale_y.max = float_or_none(self.state.y_max)
+        # NOTE: in the following, the figure will still update twice. There
+        # isn't a way around it at the moment and nesting the context managers
+        # doesn't change this - at the end of the day, the two scales are
+        # separate widgets so will result in two updates.
+
+        with self.scale_x.hold_sync():
+            self.scale_x.min = float_or_none(self.state.x_min)
+            self.scale_x.max = float_or_none(self.state.x_max)
+
+        with self.scale_y.hold_sync():
+            self.scale_y.min = float_or_none(self.state.y_min)
+            self.scale_y.max = float_or_none(self.state.y_max)
 
         self._last_limits = (self.state.x_min, self.state.x_max,
                              self.state.y_min, self.state.y_max)

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -91,14 +91,31 @@ class BqplotBaseView(IPyWidgetView):
         self.scale_x.observe(self.update_glue_scales, names=['min', 'max'])
         self.scale_y.observe(self.update_glue_scales, names=['min', 'max'])
 
-        dlink((self.state, 'x_min'), (self.scale_x, 'min'), float_or_none)
-        dlink((self.state, 'x_max'), (self.scale_x, 'max'), float_or_none)
-        dlink((self.state, 'y_min'), (self.scale_y, 'min'), float_or_none)
-        dlink((self.state, 'y_max'), (self.scale_y, 'max'), float_or_none)
+        self._last_limits = None
+        self.state.add_callback('x_min', self._update_bqplot_limits)
+        self.state.add_callback('x_max', self._update_bqplot_limits)
+        self.state.add_callback('y_min', self._update_bqplot_limits)
+        self.state.add_callback('y_max', self._update_bqplot_limits)
 
         on_change([(self.state, 'show_axes')])(self._sync_show_axes)
 
         self.create_layout()
+
+    def _update_bqplot_limits(self, *args):
+
+        if self._last_limits == (self.state.x_min, self.state.x_max,
+                                 self.state.y_min, self.state.y_max):
+            return
+
+        with self.scale_x.hold_trait_notifications():
+            with self.scale_y.hold_trait_notifications():
+                self.scale_x.min = float_or_none(self.state.x_min)
+                self.scale_x.max = float_or_none(self.state.x_max)
+                self.scale_y.min = float_or_none(self.state.y_min)
+                self.scale_y.max = float_or_none(self.state.y_max)
+
+        self._last_limits = (self.state.x_min, self.state.x_max,
+                             self.state.y_min, self.state.y_max)
 
     def _callback_key(self, callback):
         if CallbackContainer.is_bound_method(callback):

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -9,7 +9,7 @@ from bqplot_image_gl.interacts import MouseInteraction, keyboard_events, mouse_e
 from echo.callback_container import CallbackContainer
 
 from ...view import IPyWidgetView
-from ...link import dlink, on_change
+from ...link import on_change
 from ...utils import float_or_none, debounced, get_ioloop
 from .tools import ROIClickAndDrag
 

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -95,10 +95,10 @@ def test_scatter2d_density(app, dataxyz):
     s.layers[0].state.points_mode = 'density'
     assert s.layers[0].state.density_map is True
 
-    s.state.x_min == 0.9
-    s.state.x_max == 3.1
-    s.state.y_min == 1.9
-    s.state.y_max == 5.1
+    s.state.x_min = 0.9
+    s.state.x_max = 3.1
+    s.state.y_min = 1.9
+    s.state.y_max = 5.1
     assert s.layers[0].state.density_map is True
     s.layers[0].state.bins = 2
     assert s.layers[0].image.image.tolist() == [[2.0, 0], [0, 1.0]]


### PR DESCRIPTION
@kconroy - this will help towards the issue you were seeing, however there is still an issue remaining on the bqplot side as demonstrated in this notebook: https://gist.github.com/astrofrog/9069845bef13e20afe5a536550cb6811 - I'll investigate further