### PR TITLE
Add registry for adding viewers from plugins

### DIFF
--- a/docs/developer_notes.rst
+++ b/docs/developer_notes.rst
@@ -110,3 +110,39 @@ this can be done by calling::
 
 After this call, you will see when clients subscribe to the hub for messages
 and when particular messages are being broadcast.
+
+Adding new viewers via plug-ins
+-------------------------------
+
+New viewers can be added via the normal glue plug-in infrastructure. One
+subtlety is that these new viewers have to be added to the viewer registry
+and then created using the generic :func:`~glue_jupyter.app.new_data_viewer`
+function. To add a viewer to the registry add an entry_point in your
+plugin's setup.cfg:
+
+    [options.entry_points]
+    glue.plugins =
+        my_plugin_viewer = my_plugin_viewer:setup
+            
+And then define a setup function in your plugin's __init__.py file:
+
+    def setup():
+        from .viewer import MyPluginViewer
+        from glue_jupyter.registries import viewer_registry
+        viewer_registry.add("myviewer",MyPluginViewer)
+        
+A MyPluginViewer can now be created in a glue-jupyter app as follows:
+
+    >>> from glue_jupyter import jglue
+    >>> app = jglue()
+    >>> myviewer = app.new_data_viewer('myviewer')
+    
+You can add data to the viewer at creation time:
+
+    >>> table = app.load_data('mytable.csv')
+    >>> myviewer = app.new_data_viewer('myviewer', data=table)
+
+Currently it is not possible to specific other configuration options
+at viewer creation time for plug-in viewer; they can still be modified
+programmatically 
+:ref:`glue-jupyter:data_tutorial:Modifying viewers and layers programmatically`

--- a/docs/developer_notes.rst
+++ b/docs/developer_notes.rst
@@ -118,26 +118,26 @@ New viewers can be added via the normal glue plug-in infrastructure. One
 subtlety is that these new viewers have to be added to the viewer registry
 and then created using the generic :func:`~glue_jupyter.app.new_data_viewer`
 function. To add a viewer to the registry add an entry_point in your
-plugin's setup.cfg:
+plugin's setup.cfg::
 
     [options.entry_points]
     glue.plugins =
         my_plugin_viewer = my_plugin_viewer:setup
             
-And then define a setup function in your plugin's __init__.py file:
+And then define a setup function in your plugin's __init__.py file::
 
     def setup():
         from .viewer import MyPluginViewer
         from glue_jupyter.registries import viewer_registry
         viewer_registry.add("myviewer",MyPluginViewer)
         
-A MyPluginViewer can now be created in a glue-jupyter app as follows:
+A MyPluginViewer can now be created in a glue-jupyter app as follows::
 
     >>> from glue_jupyter import jglue
     >>> app = jglue()
     >>> myviewer = app.new_data_viewer('myviewer')
     
-You can add data to the viewer at creation time:
+You can add data to the viewer at creation time::
 
     >>> table = app.load_data('mytable.csv')
     >>> myviewer = app.new_data_viewer('myviewer', data=table)

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -151,6 +151,18 @@ class JupyterApplication(Application):
         return viewers
 
     def new_data_viewer(self, *args, **kwargs):
+        """
+        Create a new data viewer
+
+        This function can be called directly with the name of a viewer
+        as the first parameter for any viewer types registered in the
+        viewer_registry.
+
+        s = app.new_data_viewer('table')
+
+        This is the preferred way to call viewers defined in external plugins.
+        Built-in viewers can also be called using the custom functions
+        """
         show = kwargs.pop('show', True)
         viewer_name = args[0]
         if isinstance(viewer_name, str):

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -17,6 +17,8 @@ from glue_jupyter.utils import _update_not_none, validate_data_argument
 from glue_jupyter.widgets.subset_select_vuetify import SubsetSelect
 from glue_jupyter.widgets.subset_mode_vuetify import SelectionModeMenu
 
+from glue_jupyter.registries import viewer_registry
+
 __all__ = ['JupyterApplication']
 
 # TODO: move this to glue-core so that the subset mode can be set ot a string
@@ -150,6 +152,12 @@ class JupyterApplication(Application):
 
     def new_data_viewer(self, *args, **kwargs):
         show = kwargs.pop('show', True)
+        if isinstance(args[0], str):
+            try:
+                viewer_cls = viewer_registry.members[args[0]]['cls']
+            except KeyError:
+                raise ValueError("No registered viewer found with name {0}".format(args[0]))
+            args = (viewer_cls, )
         viewer = super().new_data_viewer(*args, **kwargs)
         self._viewer_refs.append(weakref.ref(viewer))
         if show:

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -156,12 +156,18 @@ class JupyterApplication(Application):
 
         This function can be called directly with the name of a viewer
         as the first parameter for any viewer types registered in the
-        viewer_registry.
+        viewer_registry. Thus if a plug-in defines a viewer class as
 
-        s = app.new_data_viewer('table')
+        from glue_jupyter.registries import viewer_registry
+        @viewer_registry("pluginviewer")
+        class PluginViewer(Viewer):
+            ...
+
+        then this viewer can be created in a glue-jupyter app via:
+
+        s = app.new_data_viewer('pluginviewer')
 
         This is the preferred way to call viewers defined in external plugins.
-        Built-in viewers can also be called using the custom functions
         """
         show = kwargs.pop('show', True)
         viewer_name = args[0]

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -152,11 +152,16 @@ class JupyterApplication(Application):
 
     def new_data_viewer(self, *args, **kwargs):
         show = kwargs.pop('show', True)
-        if isinstance(args[0], str):
-            try:
-                viewer_cls = viewer_registry.members[args[0]]['cls']
-            except KeyError:
-                raise ValueError("No registered viewer found with name {0}".format(args[0]))
+        viewer_name = args[0]
+        if isinstance(viewer_name, str):
+            if viewer_name in viewer_registry.members:
+                try:
+                    viewer_cls = viewer_registry.members[viewer_name]['cls']
+                except KeyError:
+                    err_msg = "Registry does not define a Viewer class for {0}".format(viewer_name)
+                    raise ValueError(err_msg)
+            else:
+                raise ValueError("No registered viewer found with name {0}".format(viewer_name))
             args = (viewer_cls, )
         viewer = super().new_data_viewer(*args, **kwargs)
         self._viewer_refs.append(weakref.ref(viewer))

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -7,9 +7,12 @@ from .layer_artist import BqplotScatterLayerArtist
 from glue_jupyter.common.state_widgets.layer_scatter import ScatterLayerStateWidget
 from glue_jupyter.common.state_widgets.viewer_scatter import ScatterViewerStateWidget
 
+from glue_jupyter.registries import viewer_registry
+
 __all__ = ['BqplotScatterView']
 
 
+@viewer_registry("scatter")
 class BqplotScatterView(BqplotBaseView):
 
     allow_duplicate_data = False

--- a/glue_jupyter/registries.py
+++ b/glue_jupyter/registries.py
@@ -8,13 +8,13 @@ class ViewerRegistry(DictRegistry):
     Registry containing references to custom viewers.
     """
 
-    def __call__(self, name=None, label=None):
+    def __call__(self, name=None):
         def decorator(cls):
-            self.add(name, cls, label)
+            self.add(name, cls)
             return cls
         return decorator
 
-    def add(self, name, cls, label=None):
+    def add(self, name, cls):
         """
         Add an item to the registry.
 
@@ -26,14 +26,12 @@ class ViewerRegistry(DictRegistry):
         cls : type
             The class definition (not instance) associated with the name given
             in the first parameter.
-        label : str, optional
-            A label for this viewer type (not currently used)
         """
         if name in self.members:
             raise ValueError(f"Viewer with the name {name} already exists, "
                              f"please choose a different name.")
         else:
-            self.members[name] = {'cls': cls, 'label': label}
+            self.members[name] = {'cls': cls}
 
 
 viewer_registry = ViewerRegistry()

--- a/glue_jupyter/registries.py
+++ b/glue_jupyter/registries.py
@@ -1,0 +1,39 @@
+from glue.config import DictRegistry
+
+__all__ = ['viewer_registry', 'ViewerRegistry']
+
+
+class ViewerRegistry(DictRegistry):
+    """
+    Registry containing references to custom viewers.
+    """
+
+    def __call__(self, name=None, label=None):
+        def decorator(cls):
+            self.add(name, cls, label)
+            return cls
+        return decorator
+
+    def add(self, name, cls, label=None):
+        """
+        Add an item to the registry.
+
+        Parameters
+        ----------
+        name : str
+            The key referencing the associated class in the registry
+            dictionary.
+        cls : type
+            The class definition (not instance) associated with the name given
+            in the first parameter.
+        label : str, optional
+            A label for this viewer type (not currently used)
+        """
+        if name in self.members:
+            raise ValueError(f"Viewer with the name {name} already exists, "
+                             f"please choose a different name.")
+        else:
+            self.members[name] = {'cls': cls, 'label': label}
+
+
+viewer_registry = ViewerRegistry()

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -9,6 +9,8 @@ from glue.core.exceptions import IncompatibleAttribute
 from glue.viewers.common.layer_artist import LayerArtist
 from glue.viewers.common.state import ViewerState
 
+from glue_jupyter.registries import viewer_registry
+
 from ..view import IPyWidgetView
 
 
@@ -205,6 +207,7 @@ class TableViewerStateWidget(widgets.VBox):
         self.state = viewer_state
 
 
+@viewer_registry("table")
 class TableViewer(IPyWidgetView):
     allow_duplicate_data = False
     allow_duplicate_subset = False

--- a/glue_jupyter/tests/data_viewer_test.py
+++ b/glue_jupyter/tests/data_viewer_test.py
@@ -1,0 +1,7 @@
+from glue_jupyter.registries import viewer_registry
+from glue.viewers.common.viewer import Viewer
+
+
+@viewer_registry("externalviewer")
+class ExternalViewerTest(Viewer):
+    pass

--- a/glue_jupyter/tests/test_viewer_registry.py
+++ b/glue_jupyter/tests/test_viewer_registry.py
@@ -1,3 +1,4 @@
+import pytest
 from glue_jupyter.registries import viewer_registry
 from glue.viewers.common.viewer import Viewer
 import glue_jupyter as gj
@@ -11,6 +12,21 @@ def test_add_client():
         pass
 
     assert viewer_registry.members['test']['cls'] == ClientTest
+
+
+def test_access_missing_malformed_viewer():
+    app = gj.jglue()
+    with pytest.raises(ValueError, match='No registered viewer found with name missing'):
+        app.new_data_viewer('missing', data=None, show=False)
+
+    @viewer_registry("malformed")
+    class MalformedViewer(Viewer):
+        pass
+
+    del viewer_registry.members['malformed']['cls']
+
+    with pytest.raises(ValueError, match='Registry does not define a Viewer class for malformed'):
+        app.new_data_viewer('malformed', data=None, show=False)
 
 
 def test_adding_viewers():

--- a/glue_jupyter/tests/test_viewer_registry.py
+++ b/glue_jupyter/tests/test_viewer_registry.py
@@ -1,0 +1,41 @@
+from glue_jupyter.registries import viewer_registry
+from glue.viewers.common.viewer import Viewer
+import glue_jupyter as gj
+
+from .data_viewer_test import ExternalViewerTest # noqa
+
+
+def test_add_client():
+    @viewer_registry("test")
+    class ClientTest(object):
+        pass
+
+    assert viewer_registry.members['test']['cls'] == ClientTest
+
+
+def test_adding_viewers():
+
+    @viewer_registry("test2")
+    class ViewerTest(Viewer):
+        pass
+
+    app = gj.jglue()
+
+    from glue_jupyter.table import TableViewer
+    viewer_cls = TableViewer
+
+    s1 = app.new_data_viewer(viewer_cls, data=None)
+    assert len(app.viewers) == 1
+    assert app.viewers[0] is s1
+
+    s2 = app.new_data_viewer('test2', data=None, show=False)
+    assert len(app.viewers) == 2
+    assert app.viewers[1] is s2
+    assert isinstance(s2, ViewerTest)
+
+
+def test_external_viewer():
+    app = gj.jglue()
+    s = app.new_data_viewer('externalviewer', data=None, show=False)
+    assert len(app.viewers) == 1
+    assert app.viewers[0] is s

--- a/glue_jupyter/tests/test_viewer_registry.py
+++ b/glue_jupyter/tests/test_viewer_registry.py
@@ -20,10 +20,8 @@ def test_adding_viewers():
         pass
 
     app = gj.jglue()
-
     from glue_jupyter.table import TableViewer
     viewer_cls = TableViewer
-
     s1 = app.new_data_viewer(viewer_cls, data=None)
     assert len(app.viewers) == 1
     assert app.viewers[0] is s1
@@ -37,5 +35,23 @@ def test_adding_viewers():
 def test_external_viewer():
     app = gj.jglue()
     s = app.new_data_viewer('externalviewer', data=None, show=False)
+    assert len(app.viewers) == 1
+    assert app.viewers[0] is s
+
+
+def test_builtin_table_viewer(app, dataxyz):
+    from glue_jupyter.table import TableViewer # noqa
+
+    s = app.new_data_viewer('table', data=dataxyz)
+    assert len(app.viewers) == 1
+    assert app.viewers[0] is s
+    assert len(s.layers) == 1
+    assert s.widget_table is not None
+
+
+def test_builtin_scatter_viewer(app, dataxyz):
+    from glue_jupyter.bqplot.scatter import BqplotScatterView # noqa
+
+    s = app.new_data_viewer('scatter', data=dataxyz)
     assert len(app.viewers) == 1
     assert app.viewers[0] is s

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,6 @@ docs =
     nbsphinx
     sphinx-rtd-theme
 
-[options.entry_points]
-glue.plugins =
-    table_viewer = glue_jupyter.table:setup
-
-
 [options.package_data]
 glue_jupyter.table = *.vue
 glue_jupyter.widgets = *.vue

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,11 @@ docs =
     nbsphinx
     sphinx-rtd-theme
 
+[options.entry_points]
+glue.plugins =
+    table_viewer = glue_jupyter.table:setup
+
+
 [options.package_data]
 glue_jupyter.table = *.vue
 glue_jupyter.widgets = *.vue


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a registry of viewer types (analogous to `qt_client` in QTglue). It allows an external plug-in to define a new viewer that is then available to the glue_jupyter application `new_data_viewer` function. The new viewer class is registered via a decorator which allows the developer to specify a nice string name for ease of creating a new viewer.

`app = gj.jglue()`
`s = app.new_data_viewer('externalviewer')`

This PR addresses #134 and mostly uses the jdaviz code referenced therein for the `ViewerRegistry` logic. 