### PR TITLE
as_steps support in profile viewer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.13.0 (unreleased)
+===================
+
+* Add button to profile viewer layers to toggle plotting as steps. [#309]
+
 0.12.1 (2022-07-29)
 ===================
 

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -145,7 +145,8 @@ class BqplotProfileLayerArtist(LayerArtist):
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute',
                                                      'function', 'normalize',
-                                                     'v_min', 'v_max')):
+                                                     'v_min', 'v_max',
+                                                     'as_steps')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import warnings
+import numpy as np
 
 from glue.core import BaseData
 from glue.utils import defer_draw, color2hex
@@ -91,6 +92,12 @@ class BqplotProfileLayerArtist(LayerArtist):
         self.enable()
 
         x, y = visible_data
+        if self.state.as_steps:
+            a = np.insert(x, 0, 2*x[0] - x[1])
+            b = np.append(x, 2*x[-1] - x[-2])
+            edges = (a + b) / 2
+            x = np.concatenate((edges[:1], np.repeat(edges[1:-1], 2), edges[-1:]))
+            y = np.repeat(y, 2)
 
         # Update the data values.
         if len(x) > 0:

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -92,7 +92,7 @@ class BqplotProfileLayerArtist(LayerArtist):
         self.enable()
 
         x, y = visible_data
-        if self.state.as_steps:
+        if self.state.as_steps and len(x) > 0:
             a = np.insert(x, 0, 2*x[0] - x[1])
             b = np.append(x, 2*x[-1] - x[-2])
             edges = (a + b) / 2

--- a/glue_jupyter/common/state_widgets/layer_profile.py
+++ b/glue_jupyter/common/state_widgets/layer_profile.py
@@ -1,7 +1,7 @@
 from ipyvuetify import VuetifyTemplate
 import traitlets
 from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices
+from ...vuetify_helpers import link_glue_choices, link_glue
 
 __all__ = ['ProfileLayerStateWidget']
 
@@ -13,6 +13,7 @@ class ProfileLayerStateWidget(VuetifyTemplate):
 
     attribute_items = traitlets.List().tag(sync=True)
     attribute_selected = traitlets.Int().tag(sync=True)
+    as_steps = traitlets.Bool(False).tag(sync=True)
 
     def __init__(self, layer_state):
         super().__init__()
@@ -20,3 +21,4 @@ class ProfileLayerStateWidget(VuetifyTemplate):
         self.glue_state = layer_state
 
         link_glue_choices(self, layer_state, 'attribute')
+        link_glue(self, 'as_steps', layer_state)

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -7,7 +7,7 @@
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
         <div>
-            <v-switch label="Plot as steps/histogram" v-model="as_steps" />
+            <v-switch label="Plot as steps" v-model="as_steps" />
         </div>
     </div>
 </template>

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -6,5 +6,8 @@
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
+        <div>
+            <v-switch label="Plot as steps/histogram" v-model="as_steps" />
+        </div>
     </div>
 </template>

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_requires = >=3.7
 setup_requires =
   setuptools_scm
 install_requires =
-    glue-core>=1.2.2
+    glue-core>=1.3.0
     glue-vispy-viewers>=1.0
     notebook>=4.0
     ipympl>=0.3.0


### PR DESCRIPTION
## Description

This accompanies https://github.com/glue-viz/glue/pull/2292 to expose the `as_steps` switch in the layer options widget, and handling toggling `as_steps` in the bqplot layer artist for the profile viewer.  The actual binning logic is adopted from https://github.com/astropy/specutils/blob/main/specutils/spectra/spectral_axis.py#L42.