### PR TITLE
fix: composite image not initialized when viewer is not displayed

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -78,6 +78,7 @@ class BqplotImageView(BqplotBaseView):
             else:
                 axes_ratio = None
             self.state._set_axes_aspect_ratio(axes_ratio)
+        self._composite_image.update()
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -63,6 +63,7 @@ class BqplotImageView(BqplotBaseView):
         if len(views) > 0:
             first_view = self._vl.view_data[views[0]]
             self.shape = (int(first_view['height']), int(first_view['width']))
+            self._composite_image.update()
         else:
             self.shape = None
         self._sync_figure_aspect()
@@ -78,7 +79,6 @@ class BqplotImageView(BqplotBaseView):
             else:
                 axes_ratio = None
             self.state._set_axes_aspect_ratio(axes_ratio)
-        self._composite_image.update()
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:


### PR DESCRIPTION
## Description

When data loading is done before the viewer is displayed, the composite image is not initialized. Calling update when the viewer is displayed fixes this.
 
See: spacetelescope/jdaviz#1243

To reproduce, make a notebook with two cells:
Cell 1:
```python
import warnings
warnings.simplefilter('ignore')
from jdaviz import Mosviz
import tempfile
from zipfile import ZipFile
from astropy.utils.data import download_file
import pathlib

mosviz = Mosviz()

data_dir = tempfile.gettempdir()
example_data = 'https://stsci.box.com/shared/static/ovyxi5eund92yoadvv01mynwt8t5n7jv.zip'
fn = download_file(example_data, cache=True)
with ZipFile(fn, 'r') as sample_data_zip:
    sample_data_zip.extractall(data_dir)
    
data_dir = (pathlib.Path(data_dir) / 'mosviz_nirspec_data_0.3' / 'level3')

mosviz.load_data(directory=data_dir, instrument="nirspec")
```
Cell 2:
```python
import time
time.sleep(5)

mosviz.app.get_viewer("spectrum-2d-viewer").show()
```