### PR TITLE
Initial support for unit conversion in profile viewer

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -28,13 +28,11 @@ jobs:
           - libhdf5-dev
 
       envs: |
-        - linux: py37-test
         - linux: py38-test
         - linux: py39-test
         - linux: py310-test
         - linux: py311-test
 
-        - macos: py37-test
         - macos: py38-test
         - macos: py39-test
         # One of these to be switched to arm64 running natively once the PLAT var is supported.
@@ -52,12 +50,11 @@ jobs:
       pytest: false
 
       envs: |
-        - linux: py37-notebooks
-        - windows: py37-notebooks
+        - windows: py39-notebooks
         - macos: py38-notebooks
         - linux: py310-notebooks
 
-        - linux: py37-docs
+        - linux: py311-docs
         - macos: py39-docs
         - windows: py38-docs
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ texinfo_documents = [
 intersphinx_cache_limit = 10     # days to keep the cached inventories
 intersphinx_mapping = {
     # 'sphinx': ('https://www.sphinx-doc.org/en/latest/', None),
-    'python': ('https://docs.python.org/3.7', None),
+    'python': ('https://docs.python.org/3.11', None),
     # 'matplotlib': ('https://matplotlib.org', None),
     # 'numpy': ('https://docs.scipy.org/doc/numpy', None),
     # 'astropy': ('http://docs.astropy.org/en/stable/', None),

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -10,7 +10,7 @@ installing it in an isolated Python environment for now. If you are using conda,
 you can create an environment and install the latest version of glue-jupyter in
 it using::
 
-    conda create -n glue-jupyter -c glueviz/label/dev python=3.7 glue-jupyter
+    conda create -n glue-jupyter -c glueviz/label/dev python=3.11 glue-jupyter
 
 To switch to the environment, use::
 
@@ -27,7 +27,7 @@ latest version of glue-jupyter, or if you find conda too slow to install all the
 dependencies, you can also create the environment with conda (or another Python
 environment manager)::
 
-    conda create -n glue-jupyter python=3.7
+    conda create -n glue-jupyter python=3.11
 
 then switch to the environment as above and install glue-jupyter and all its
 dependencies with::

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -67,18 +67,23 @@ class JupyterApplication(Application):
             REQUIRED_PLUGINS.clear()
             load_plugins()
 
-        self.output = widgets.Output()
-        self.widget_data_collection = widgets.SelectMultiple()
-        self.widget_subset_select = SubsetSelect(session=self.session)
-        self.widget_subset_mode = SelectionModeMenu(session=self.session)
-        self.widget = widgets.VBox(children=[self.widget_subset_mode, self.output])
-
         self._settings['new_subset_on_selection_tool_change'] = [False, bool]
         self._settings['single_global_active_tool'] = [True, bool]
+        self._settings['disable_output_widget'] = [False, bool]
 
         if settings is not None:
             for key, value in settings.items():
                 self.set_setting(key, value)
+
+        self.output = None if self._settings['disable_output_widget'] else widgets.Output()
+        self.widget_data_collection = widgets.SelectMultiple()
+        self.widget_subset_select = SubsetSelect(session=self.session)
+        self.widget_subset_mode = SelectionModeMenu(session=self.session)
+
+        if self.output is None:
+            self.widget = widgets.VBox(children=[self.widget_subset_mode])
+        else:
+            self.widget = widgets.VBox(children=[self.widget_subset_mode, self.output])
 
         self._viewer_refs = []
 

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -75,7 +75,7 @@ class JupyterApplication(Application):
             for key, value in settings.items():
                 self.set_setting(key, value)
 
-        self.output = None if self._settings['disable_output_widget'] else widgets.Output()
+        self.output = None if self.get_setting('disable_output_widget') else widgets.Output()
         self.widget_data_collection = widgets.SelectMultiple()
         self.widget_subset_select = SubsetSelect(session=self.session)
         self.widget_subset_mode = SelectionModeMenu(session=self.session)

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import os
 from bqplot import PanZoom
 from bqplot.interacts import BrushSelector, BrushIntervalSelector
@@ -132,7 +134,7 @@ class BqplotRectangleMode(BqplotSelectionTool):
     def update_selection(self, *args):
         if self.interact.brushing:
             return
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             if self.interact.selected_x is not None and self.interact.selected_y is not None:
                 x = self.interact.selected_x
                 y = self.interact.selected_y
@@ -142,7 +144,7 @@ class BqplotRectangleMode(BqplotSelectionTool):
                     self.finalize_callback()
 
     def update_from_roi(self, roi):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             if isinstance(roi, RectangularROI):
                 self.interact.selected_x = [roi.xmin, roi.xmax]
                 self.interact.selected_y = [roi.ymin, roi.ymax]
@@ -161,7 +163,7 @@ class BqplotRectangleMode(BqplotSelectionTool):
                 self.finalize_callback()
 
     def activate(self):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             self.interact.selected_x = None
             self.interact.selected_y = None
         super().activate()
@@ -203,7 +205,7 @@ class BqplotCircleMode(BqplotSelectionTool):
     def update_selection(self, *args):
         if self.interact.brushing:
             return
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             if self.interact.selected_x is not None and self.interact.selected_y is not None:
                 x = self.interact.selected_x
                 y = self.interact.selected_y
@@ -242,7 +244,7 @@ class BqplotCircleMode(BqplotSelectionTool):
                 self.finalize_callback()
 
     def activate(self):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             self.interact.selected_x = None
             self.interact.selected_y = None
         super().activate()
@@ -299,7 +301,7 @@ class BqplotXRangeMode(BqplotSelectionTool):
         self.interact.observe(self.update_selection, "brushing")
 
     def update_selection(self, *args):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             if self.interact.selected is not None:
                 x = self.interact.selected
                 if x is not None and len(x):
@@ -307,7 +309,7 @@ class BqplotXRangeMode(BqplotSelectionTool):
                     self.viewer.apply_roi(roi)
 
     def activate(self):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             self.interact.selected = None
         super().activate()
 
@@ -331,7 +333,7 @@ class BqplotYRangeMode(BqplotSelectionTool):
         self.interact.observe(self.update_selection, "brushing")
 
     def update_selection(self, *args):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             if self.interact.selected is not None:
                 y = self.interact.selected
                 if y is not None and len(y):
@@ -339,7 +341,7 @@ class BqplotYRangeMode(BqplotSelectionTool):
                     self.viewer.apply_roi(roi)
 
     def activate(self):
-        with self.viewer._output_widget:
+        with self.viewer._output_widget or nullcontext():
             self.interact.selected = None
         super().activate()
 

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -65,28 +65,13 @@ class BqplotBaseView(IPyWidgetView):
         self.state.remove_callback('layers', self._sync_layer_artist_container)
         self.state.add_callback('layers', self._sync_layer_artist_container, priority=10000)
 
-        def update_axes(*ignore):
-            try:
-                # Extract units from data
-                x_unit = self.state.reference_data.get_component(self.state.x_att_world).units
-            except AttributeError:
-                # If no data loaded yet, ignore units
-                x_unit = ""
-            finally:
-                # Append units to axis label
-                self.axis_x.label = str(self.state.x_att) + " " + str(x_unit)
-            if self.is2d:
-                self.axis_y.label = str(self.state.y_att)
-                try:
-                    y_unit = self.state.reference_data.get_component(self.state.y_att_world).units
-                except AttributeError:
-                    y_unit = ""
-                finally:
-                    self.axis_y.label = str(self.state.y_att) + " " + str(y_unit)
+        self.state.add_callback('x_axislabel', self.update_x_axislabel)
+        # self.state.add_callback('x_axislabel_weight', self.update_x_axislabel)
+        # self.state.add_callback('x_axislabel_size', self.update_x_axislabel)
 
-        self.state.add_callback('x_att', update_axes)
-        if self.is2d:
-            self.state.add_callback('y_att', update_axes)
+        self.state.add_callback('y_axislabel', self.update_y_axislabel)
+        # self.state.add_callback('y_axislabel_weight', self.update_y_axislabel)
+        # self.state.add_callback('y_axislabel_size', self.update_y_axislabel)
 
         self.scale_x.observe(self.update_glue_scales, names=['min', 'max'])
         self.scale_y.observe(self.update_glue_scales, names=['min', 'max'])
@@ -100,6 +85,12 @@ class BqplotBaseView(IPyWidgetView):
         on_change([(self.state, 'show_axes')])(self._sync_show_axes)
 
         self.create_layout()
+
+    def update_x_axislabel(self, *event):
+        self.axis_x.label = self.state.x_axislabel
+
+    def update_y_axislabel(self, *event):
+        self.axis_y.label = self.state.y_axislabel
 
     def _update_bqplot_limits(self, *args):
 

--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -1,5 +1,6 @@
 import bqplot
 from functools import partial
+from contextlib import nullcontext
 
 from glue.core.subset import roi_to_subset_state
 from glue.core.command import ApplySubsetState
@@ -213,7 +214,7 @@ class BqplotBaseView(IPyWidgetView):
 
     def apply_roi(self, roi, use_current=False):
         # TODO: partial copy paste from glue/viewers/matplotlib/qt/data_viewer.py
-        with self._output_widget:
+        with self._output_widget or nullcontext():
             if len(self.layers) > 0:
                 subset_state = self._roi_to_subset_state(roi)
                 cmd = ApplySubsetState(data_collection=self._data,

--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -26,6 +26,23 @@ class BqplotHistogramView(BqplotBaseView):
 
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:xrange']
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('x_log', self._update_axes)
+        self.state.add_callback('normalize', self._update_axes)
+        self._update_axes()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+            self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.normalize:
+            self.state.y_axislabel = 'Normalized number'
+        else:
+            self.state.y_axislabel = 'Number'
+
     def _roi_to_subset_state(self, roi):
         # TODO: copy paste from glue/viewers/histogram/qt/data_viewer.py
         # TODO Does subset get applied to all data or just visible data?

--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -36,7 +36,7 @@ class BqplotHistogramView(BqplotBaseView):
     def _update_axes(self, *args):
 
         if self.state.x_att is not None:
-            self.state.x_axislabel = self.state.x_att.label
+            self.state.x_axislabel = str(self.state.x_att)
 
         if self.state.normalize:
             self.state.y_axislabel = 'Normalized number'

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -55,10 +55,10 @@ class BqplotImageView(BqplotBaseView):
     def _update_axes(self, *args):
 
         if self.state.x_att_world is not None:
-            self.state.x_axislabel = self.state.x_att_world.label
+            self.state.x_axislabel = str(self.state.x_att_world)
 
         if self.state.y_att_world is not None:
-            self.state.y_axislabel = self.state.y_att_world.label
+            self.state.y_axislabel = str(self.state.y_att_world)
 
     def _setup_view_listener(self):
         self._vl = ViewListener(widget=self.figure,

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -44,11 +44,21 @@ class BqplotImageView(BqplotBaseView):
         self.state.add_callback('reference_data', self._reset_limits, echo_old=True)
         self.state.add_callback('x_att', self._reset_limits, echo_old=True)
         self.state.add_callback('y_att', self._reset_limits, echo_old=True)
+        self.state.add_callback('x_att_world', self._update_axes)
+        self.state.add_callback('y_att_world', self._update_axes)
 
         self._setup_view_listener()
 
         on_change([(self.state, 'aspect')])(self._sync_figure_aspect)
         self._sync_figure_aspect()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att_world is not None:
+            self.state.x_axislabel = self.state.x_att_world.label
+
+        if self.state.y_att_world is not None:
+            self.state.y_axislabel = self.state.y_att_world.label
 
     def _setup_view_listener(self):
         self._vl = ViewListener(widget=self.figure,

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -153,7 +153,7 @@ class BqplotProfileLayerArtist(LayerArtist):
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute',
                                                      'function', 'normalize',
                                                      'v_min', 'v_max',
-                                                     'as_steps')):
+                                                     'as_steps', 'x_display_unit', 'y_display_unit')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue_jupyter/bqplot/profile/layer_artist.py
+++ b/glue_jupyter/bqplot/profile/layer_artist.py
@@ -153,7 +153,8 @@ class BqplotProfileLayerArtist(LayerArtist):
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute',
                                                      'function', 'normalize',
                                                      'v_min', 'v_max',
-                                                     'as_steps', 'x_display_unit', 'y_display_unit')):
+                                                     'as_steps',
+                                                     'x_display_unit', 'y_display_unit')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue_jupyter/bqplot/profile/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/profile/tests/test_viewer.py
@@ -1,3 +1,13 @@
+from astropy.wcs import WCS
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from glue.core import Data
+from glue.core.roi import XRangeROI
+from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink
+
+
 def test_non_hex_colors(app, dataxyz):
 
     # Make sure non-hex colors such as '0.4' and 'red', which are valid
@@ -22,3 +32,88 @@ def test_remove(app, data_image, data_volume):
     assert len(s.figure.marks) == 2
     s.remove_data(data_volume)
     assert len(s.figure.marks) == 0
+
+
+def test_unit_conversion(app):
+
+    wcs1 = WCS(naxis=1)
+    wcs1.wcs.ctype = ['FREQ']
+    wcs1.wcs.crval = [1]
+    wcs1.wcs.cdelt = [1]
+    wcs1.wcs.crpix = [1]
+    wcs1.wcs.cunit = ['GHz']
+
+    d1 = Data(f1=[1, 2, 3])
+    d1.get_component('f1').units = 'Jy'
+    d1.coords = wcs1
+
+    wcs2 = WCS(naxis=1)
+    wcs2.wcs.ctype = ['WAVE']
+    wcs2.wcs.crval = [10]
+    wcs2.wcs.cdelt = [10]
+    wcs2.wcs.crpix = [1]
+    wcs2.wcs.cunit = ['cm']
+
+    d2 = Data(f2=[2000, 1000, 3000])
+    d2.get_component('f2').units = 'mJy'
+    d2.coords = wcs2
+
+    session = app.session
+
+    data_collection = session.data_collection
+    data_collection.append(d1)
+    data_collection.append(d2)
+    data_collection.add_link(WCSLink(d1, d2))
+
+    viewer = app.profile1d(data=d1)
+    viewer.add_data(d2)
+
+    assert viewer.layers[0].enabled
+    assert viewer.layers[1].enabled
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [1.e9, 2.e9, 3.e9])
+    assert_allclose(y, [1, 2, 3])
+
+    x, y = viewer.state.layers[1].profile
+    assert_allclose(x, 299792458 / np.array([0.1, 0.2, 0.3]))
+    assert_allclose(y, [2000, 1000, 3000])
+
+    assert viewer.state.x_min == 1.e9
+    assert viewer.state.x_max == 3.e9
+    assert viewer.state.y_min == 1.
+    assert viewer.state.y_max == 3.
+
+    roi = XRangeROI(1.4e9, 2.1e9)
+    viewer.apply_roi(roi)
+
+    assert len(d1.subsets) == 1
+    assert_equal(d1.subsets[0].to_mask(), [0, 1, 0])
+
+    assert len(d2.subsets) == 1
+    assert_equal(d2.subsets[0].to_mask(), [0, 1, 0])
+
+    viewer.state.x_display_unit = 'GHz'
+    viewer.state.y_display_unit = 'mJy'
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [1, 2, 3])
+    assert_allclose(y, [1000, 2000, 3000])
+
+    x, y = viewer.state.layers[1].profile
+    assert_allclose(x, 2.99792458 / np.array([1, 2, 3]))
+    assert_allclose(y, [2000, 1000, 3000])
+
+    assert viewer.state.x_min == 1.
+    assert viewer.state.x_max == 3.
+    assert viewer.state.y_min == 1000.
+    assert viewer.state.y_max == 3000.
+
+    roi = XRangeROI(0.5, 1.2)
+    viewer.apply_roi(roi)
+
+    assert len(d1.subsets) == 1
+    assert_equal(d1.subsets[0].to_mask(), [1, 0, 0])
+
+    assert len(d2.subsets) == 1
+    assert_equal(d2.subsets[0].to_mask(), [0, 0, 1])

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -42,9 +42,9 @@ class BqplotProfileView(BqplotBaseView):
 
         if self.state.x_att is not None:
             if self.state.x_display_unit:
-                self.state.x_axislabel = self.state.x_att.label + f' [{self.state.x_display_unit}]'
+                self.state.x_axislabel = str(self.state.x_att) + f' [{self.state.x_display_unit}]'
             else:
-                self.state.x_axislabel = self.state.x_att.label
+                self.state.x_axislabel = str(self.state.x_att)
 
         if self.state.normalize:
             self.state.y_axislabel = 'Normalized data values'

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -32,6 +32,11 @@ class BqplotProfileView(BqplotBaseView):
         x = roi.to_polygon()[0]
         lo, hi = min(x), max(x)
 
+        # Apply inverse unit conversion, converting from display to native units
+        scale = self.state._x_unit_scale
+        lo /= scale
+        hi /= scale
+
         roi_new = RangeROI(min=lo, max=hi, orientation='x')
 
         return roi_to_subset_state(roi_new, x_att=self.state.x_att)

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -30,6 +30,30 @@ class BqplotProfileView(BqplotBaseView):
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:panzoom_x', 'bqplot:panzoom_y',
              'bqplot:xrange']
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('normalize', self._update_axes)
+        self.state.add_callback('x_display_unit', self._update_axes)
+        self.state.add_callback('y_display_unit', self._update_axes)
+        self._update_axes()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+            if self.state.x_display_unit:
+                self.state.x_axislabel = self.state.x_att.label + f' [{self.state.x_display_unit}]'
+            else:
+                self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.normalize:
+            self.state.y_axislabel = 'Normalized data values'
+        else:
+            if self.state.y_display_unit:
+                self.state.y_axislabel = f'Data values [{self.state.y_display_unit}]'
+            else:
+                self.state.y_axislabel = 'Data values'
+
     def _roi_to_subset_state(self, roi):
 
         x = roi.to_polygon()[0]

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+from glue.core.units import UnitConverter
 from glue.core.subset import roi_to_subset_state
 from glue.core.roi import RangeROI
 from glue.viewers.profile.state import ProfileViewerState
@@ -33,9 +36,10 @@ class BqplotProfileView(BqplotBaseView):
         lo, hi = min(x), max(x)
 
         # Apply inverse unit conversion, converting from display to native units
-        scale = self.state._x_unit_scale
-        lo /= scale
-        hi /= scale
+        converter = UnitConverter()
+        lo, hi = converter.to_native(self.state.reference_data,
+                                     self.state.x_att, np.array([lo, hi]),
+                                     self.state.x_display_unit)
 
         roi_new = RangeROI(min=lo, max=hi, orientation='x')
 

--- a/glue_jupyter/bqplot/scatter/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/scatter/tests/test_viewer.py
@@ -20,8 +20,8 @@ def test_scatter2d_categorical(app, datacat):
     scatter.state.layers[0].vector_visible = True
     scatter.state.layers[0].size_mode = 'Linear'
     scatter.state.layers[0].cmap_mode = 'Linear'
-    assert scatter.state.x_att.label == 'a'
-    assert scatter.state.y_att.label == 'b'
+    assert str(scatter.state.x_att) == 'a'
+    assert str(scatter.state.y_att) == 'b'
 
 
 def test_non_hex_colors(app, dataxyz):

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -37,7 +37,7 @@ class BqplotScatterView(BqplotBaseView):
     def _update_axes(self, *args):
 
         if self.state.x_att is not None:
-            self.state.x_axislabel = self.state.x_att.label
+            self.state.x_axislabel = str(self.state.x_att)
 
         if self.state.y_att is not None:
-            self.state.y_axislabel = self.state.y_att.label
+            self.state.y_axislabel = str(self.state.y_att)

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -27,3 +27,17 @@ class BqplotScatterView(BqplotBaseView):
 
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle',
              'bqplot:xrange', 'bqplot:yrange']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('y_att', self._update_axes)
+        self._update_axes()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+            self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.y_att is not None:
+            self.state.y_axislabel = self.state.y_att.label

--- a/glue_jupyter/common/state_widgets/viewer_profile.py
+++ b/glue_jupyter/common/state_widgets/viewer_profile.py
@@ -20,6 +20,12 @@ class ProfileViewerStateWidget(v.VuetifyTemplate):
     function_items = traitlets.List().tag(sync=True)
     function_selected = traitlets.Int(allow_none=True).tag(sync=True)
 
+    x_display_unit_items = traitlets.List().tag(sync=True)
+    x_display_unit_selected = traitlets.Int(allow_none=True).tag(sync=True)
+
+    y_display_unit_items = traitlets.List().tag(sync=True)
+    y_display_unit_selected = traitlets.Int(allow_none=True).tag(sync=True)
+
     def __init__(self, viewer_state):
         super().__init__()
 
@@ -28,3 +34,5 @@ class ProfileViewerStateWidget(v.VuetifyTemplate):
         link_glue_choices(self, viewer_state, 'reference_data')
         link_glue_choices(self, viewer_state, 'x_att')
         link_glue_choices(self, viewer_state, 'function')
+        link_glue_choices(self, viewer_state, 'x_display_unit')
+        link_glue_choices(self, viewer_state, 'y_display_unit')

--- a/glue_jupyter/common/state_widgets/viewer_profile.vue
+++ b/glue_jupyter/common/state_widgets/viewer_profile.vue
@@ -7,6 +7,12 @@
             <v-select :items="x_att_items" label="x axis" v-model="x_att_selected" hide-details/>
         </div>
         <div>
+            <v-select :items="x_display_unit_items" label="x axis units" v-model="x_display_unit_selected" hide-details/>
+        </div>
+        <div>
+            <v-select :items="y_display_unit_items" label="y axis units" v-model="y_display_unit_selected" hide-details/>
+        </div>
+        <div>
             <v-select :items="function_items" label="function" v-model="function_selected"/>
         </div>
 

--- a/glue_jupyter/ipyvolume/common/tools.py
+++ b/glue_jupyter/ipyvolume/common/tools.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import numpy as np
 
 from glue.core.roi import PolygonalROI, CircularROI, RectangularROI, Projected3dROI
@@ -44,7 +46,7 @@ class IpyvolumeLassoMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer._output_widget:
+            with self.viewer._output_widget or nullcontext():
                 region = data['device']
                 vx, vy = zip(*region)
                 roi_2d = PolygonalROI(vx=vx, vy=vy)
@@ -68,7 +70,7 @@ class IpyvolumeCircleMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer._output_widget:
+            with self.viewer._output_widget or nullcontext():
                 x1, y1 = data['device']['begin']
                 x2, y2 = data['device']['end']
                 dx = x2 - x1
@@ -95,7 +97,7 @@ class IpyvolumeRectanglewMode(IPyVolumeCheckableTool):
             return
 
         if data['device']:
-            with self.viewer._output_widget:
+            with self.viewer._output_widget or nullcontext():
                 x1, y1 = data['device']['begin']
                 x2, y2 = data['device']['end']
                 x = [x1, x2]

--- a/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
@@ -14,9 +14,9 @@ def test_scatter3d_categorical(app, datacat):
     # show the correct categorical labels on the axes.
     app.add_data(datacat)
     scatter = app.scatter3d(data=datacat)
-    assert scatter.state.x_att.label == 'a'
-    assert scatter.state.y_att.label == 'b'
-    assert scatter.state.z_att.label == 'b'
+    assert str(scatter.state.x_att) == 'a'
+    assert str(scatter.state.y_att) == 'b'
+    assert str(scatter.state.z_att) == 'b'
 
 
 def test_non_hex_colors(app, dataxyz):
@@ -38,11 +38,11 @@ def test_labels(app, dataxyz):
     # test the syncing of attributes to labels
     app.add_data(dataxyz)
     scatter = app.scatter3d(data=dataxyz)
-    assert scatter.state.x_att.label == 'x'
+    assert str(scatter.state.x_att) == 'x'
     assert scatter.figure.xlabel == 'x'
-    assert scatter.state.y_att.label == 'y'
+    assert str(scatter.state.y_att) == 'y'
     assert scatter.figure.zlabel == 'y'
-    assert scatter.state.z_att.label == 'z'
+    assert str(scatter.state.z_att) == 'z'
     assert scatter.figure.ylabel == 'z'
 
     scatter.state.x_att = dataxyz.id['y']

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -7,7 +7,6 @@ from glue.viewers.common.utils import get_viewer_tools
 from glue.core.layer_artist import LayerArtistContainer
 from glue.core import message as msg
 
-
 from glue_jupyter import get_layout_factory
 from glue_jupyter.utils import _update_not_none, validate_data_argument
 from glue_jupyter.common.toolbar_vuetify import BasicJupyterToolbar
@@ -34,7 +33,7 @@ class IPyWidgetView(Viewer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._output_widget = Output()
+        self._output_widget = None if self.session.application._settings['disable_output_widget'] else Output()
         self.initialize_layer_options()
         self.initialize_toolbar()
 

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -34,7 +34,7 @@ class IPyWidgetView(Viewer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._output_widget = (None
-                               if self.session.application._settings['disable_output_widget']
+                               if self.session.application.get_setting('disable_output_widget')
                                else Output())
         self.initialize_layer_options()
         self.initialize_toolbar()

--- a/glue_jupyter/view.py
+++ b/glue_jupyter/view.py
@@ -33,7 +33,9 @@ class IPyWidgetView(Viewer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._output_widget = None if self.session.application._settings['disable_output_widget'] else Output()
+        self._output_widget = (None
+                               if self.session.application._settings['disable_output_widget']
+                               else Output())
         self.initialize_layer_options()
         self.initialize_toolbar()
 

--- a/notebooks/Generic/demo_units_custom.ipynb
+++ b/notebooks/Generic/demo_units_custom.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates unit conversion in the profile viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy.wcs import WCS\n",
+    "import glue_jupyter as gj\n",
+    "from glue.core import Data\n",
+    "from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up two datasets with x-axes that use different spectral coordinates (which get auto-converted because of the WCSLink) and y-axes that use different temperature units (just to show how to add custom equivalencies)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs1 = WCS(naxis=1)\n",
+    "wcs1.wcs.ctype = ['WAVE']\n",
+    "wcs1.wcs.crval = [10]\n",
+    "wcs1.wcs.cdelt = [3]\n",
+    "wcs1.wcs.crpix = [1]\n",
+    "wcs1.wcs.cunit = ['cm']\n",
+    "\n",
+    "d1 = Data(temp1=np.random.random(10))\n",
+    "d1.get_component('temp1').units = 'deg_C'\n",
+    "d1.coords = wcs1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs1 = WCS(naxis=1)\n",
+    "wcs1.wcs.ctype = ['FREQ']\n",
+    "wcs1.wcs.crval = [1000]\n",
+    "wcs1.wcs.cdelt = [1000]\n",
+    "wcs1.wcs.crpix = [1]\n",
+    "wcs1.wcs.cunit = ['MHz']\n",
+    "\n",
+    "d2 = Data(temp2=np.random.random(10) + 273)\n",
+    "d2.get_component('temp2').units = 'K'\n",
+    "d2.coords = wcs1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up a custom unit conversion class with equivalencies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "from glue.core.units import unit_converter\n",
+    "\n",
+    "@unit_converter('custom-astropy')\n",
+    "class UnitConverterWithTemperature:\n",
+    "\n",
+    "    def equivalent_units(self, data, cid, units):\n",
+    "        equivalencies = u.temperature() if 'temp' in cid.label.lower() else None\n",
+    "        return map(u.Unit(units).find_equivalent_units(include_prefix_units=True, equivalencies=equivalencies), str)\n",
+    "\n",
+    "    def to_unit(self, data, cid, values, original_units, target_units):\n",
+    "        equivalencies = u.temperature() if 'temp' in cid.label.lower() else None\n",
+    "        return (values * u.Unit(original_units)).to_value(target_units, equivalencies=equivalencies)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the converter class defined above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glue.config import settings\n",
+    "settings.UNIT_CONVERTER = 'custom-astropy'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tom/Code/glue/glue/external/echo/__init__.py:3: UserWarning: glue.external.echo is deprecated, import from echo directly instead\n",
+      "  warnings.warn('glue.external.echo is deprecated, import from echo directly instead')\n",
+      "/home/tom/Code/glue/glue/viewers/common/qt/tool.py:5: UserWarning: glue.viewers.common.qt.tool is deprecated, use glue.viewers.common.tool instead\n",
+      "  warnings.warn('glue.viewers.common.qt.tool is deprecated, use '\n"
+     ]
+    }
+   ],
+   "source": [
+    "app = gj.jglue(spectrum1=d1, spectrum2=d2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a0aecff78eb426ebd3a5d1b126f5450",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "app.output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n"
+     ]
+    }
+   ],
+   "source": [
+    "app.data_collection.add_link(WCSLink(d1, d2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataCollection (2 data sets)\n",
+       "\t  0: spectrum1\n",
+       "\t  1: spectrum2"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "app.data_collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1250dc6ce1344abbab9245ac56c7ff90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "LayoutWidget(controls={'toolbar_selection_tools': BasicJupyterToolbar(template=Template(template='<template>\\n…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n",
+      "WARNING:sunpy:No observer defined on WCS, SpectralCoord will be converted without any velocity frame change\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s = app.profile1d(data=d1)\n",
+    "s.add_data(d2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n",
+      "WARNING:sunpy:No observer defined on WCS, SpectralCoord will be converted without any velocity frame change\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00160>, <function temperature.<locals>.<lambda> at 0x7f13d0f00670>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00700>, <function temperature.<locals>.<lambda> at 0x7f13d0f00790>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00820>, <function temperature.<locals>.<lambda> at 0x7f13d0f008b0>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00940>, <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f00b80>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>)] temp1 True\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f00b80>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f051f0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05160>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05280>, <function temperature.<locals>.<lambda> at 0x7f13d0f05310>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f053a0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05430>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05550>, <function temperature.<locals>.<lambda> at 0x7f13d0f054c0>)] temp2 True\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f053a0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05430>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05550>, <function temperature.<locals>.<lambda> at 0x7f13d0f054c0>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f05af0>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05b80>, <function temperature.<locals>.<lambda> at 0x7f13d0f05c10>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05ca0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05d30>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05dc0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05e50>)] temp1 True\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f008b0>, <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00790>, <function temperature.<locals>.<lambda> at 0x7f13d0f00820>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00700>, <function temperature.<locals>.<lambda> at 0x7f13d0f00160>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00f70>, <function temperature.<locals>.<lambda> at 0x7f13d0f00ee0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00e50>, <function temperature.<locals>.<lambda> at 0x7f13d0f00dc0>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00d30>, <function temperature.<locals>.<lambda> at 0x7f13d0f00ca0>)] temp2 True\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>, <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00790>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00820>, <function temperature.<locals>.<lambda> at 0x7f13d0f00700>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00160>, <function temperature.<locals>.<lambda> at 0x7f13d0f00f70>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00ee0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00e50>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00dc0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00d30>)] temp1 True\n",
+      "equiv None wave False\n",
+      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0c834c0>, <function temperature.<locals>.<lambda> at 0x7f13d0c83670>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0c83550>, <function temperature.<locals>.<lambda> at 0x7f13d0c83820>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4f70>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4d30>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4820>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4af0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4a60>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4ca0>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce44c0>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4e50>)] temp2 True\n"
+     ]
+    }
+   ],
+   "source": [
+    "s.state.x_display_unit = 'cm'\n",
+    "s.state.y_display_unit = 'K'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Generic/demo_units_custom.ipynb
+++ b/notebooks/Generic/demo_units_custom.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
     "\n",
     "    def equivalent_units(self, data, cid, units):\n",
     "        equivalencies = u.temperature() if 'temp' in cid.label.lower() else None\n",
-    "        return map(u.Unit(units).find_equivalent_units(include_prefix_units=True, equivalencies=equivalencies), str)\n",
+    "        return map(str, u.Unit(units).find_equivalent_units(include_prefix_units=True, equivalencies=equivalencies))\n",
     "\n",
     "    def to_unit(self, data, cid, values, original_units, target_units):\n",
     "        equivalencies = u.temperature() if 'temp' in cid.label.lower() else None\n",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,196 +110,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/tom/Code/glue/glue/external/echo/__init__.py:3: UserWarning: glue.external.echo is deprecated, import from echo directly instead\n",
-      "  warnings.warn('glue.external.echo is deprecated, import from echo directly instead')\n",
-      "/home/tom/Code/glue/glue/viewers/common/qt/tool.py:5: UserWarning: glue.viewers.common.qt.tool is deprecated, use glue.viewers.common.tool instead\n",
-      "  warnings.warn('glue.viewers.common.qt.tool is deprecated, use '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "app = gj.jglue(spectrum1=d1, spectrum2=d2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2a0aecff78eb426ebd3a5d1b126f5450",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "app.output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n"
-     ]
-    }
-   ],
-   "source": [
-    "app.data_collection.add_link(WCSLink(d1, d2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataCollection (2 data sets)\n",
-       "\t  0: spectrum1\n",
-       "\t  1: spectrum2"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "app.data_collection"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1250dc6ce1344abbab9245ac56c7ff90",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "LayoutWidget(controls={'toolbar_selection_tools': BasicJupyterToolbar(template=Template(template='<template>\\n…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n",
-      "WARNING:sunpy:No observer defined on WCS, SpectralCoord will be converted without any velocity frame change\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "s = app.profile1d(data=d1)\n",
-    "s.add_data(d2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: No observer defined on WCS, SpectralCoord will be converted without any velocity frame change [astropy.wcs.wcsapi.fitswcs]\n",
-      "WARNING:sunpy:No observer defined on WCS, SpectralCoord will be converted without any velocity frame change\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00160>, <function temperature.<locals>.<lambda> at 0x7f13d0f00670>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00700>, <function temperature.<locals>.<lambda> at 0x7f13d0f00790>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00820>, <function temperature.<locals>.<lambda> at 0x7f13d0f008b0>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00940>, <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f00b80>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>)] temp1 True\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f00b80>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f051f0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05160>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05280>, <function temperature.<locals>.<lambda> at 0x7f13d0f05310>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f053a0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05430>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05550>, <function temperature.<locals>.<lambda> at 0x7f13d0f054c0>)] temp2 True\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f053a0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05430>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05550>, <function temperature.<locals>.<lambda> at 0x7f13d0f054c0>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05a60>, <function temperature.<locals>.<lambda> at 0x7f13d0f05af0>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05b80>, <function temperature.<locals>.<lambda> at 0x7f13d0f05c10>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05ca0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05d30>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f05dc0>, <function temperature.<locals>.<lambda> at 0x7f13d0f05e50>)] temp1 True\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f008b0>, <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00790>, <function temperature.<locals>.<lambda> at 0x7f13d0f00820>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00700>, <function temperature.<locals>.<lambda> at 0x7f13d0f00160>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00f70>, <function temperature.<locals>.<lambda> at 0x7f13d0f00ee0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00e50>, <function temperature.<locals>.<lambda> at 0x7f13d0f00dc0>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00d30>, <function temperature.<locals>.<lambda> at 0x7f13d0f00ca0>)] temp2 True\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00c10>, <function temperature.<locals>.<lambda> at 0x7f13d0f00af0>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f009d0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00790>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00820>, <function temperature.<locals>.<lambda> at 0x7f13d0f00700>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00160>, <function temperature.<locals>.<lambda> at 0x7f13d0f00f70>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00ee0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00e50>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0f00dc0>, <function temperature.<locals>.<lambda> at 0x7f13d0f00d30>)] temp1 True\n",
-      "equiv None wave False\n",
-      "equiv [(Unit(\"K\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0c834c0>, <function temperature.<locals>.<lambda> at 0x7f13d0c83670>), (Unit(\"deg_C\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0c83550>, <function temperature.<locals>.<lambda> at 0x7f13d0c83820>), (Unit(\"K\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4f70>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4d30>), (Unit(\"deg_R\"), Unit(\"deg_F\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4820>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4af0>), (Unit(\"deg_R\"), Unit(\"deg_C\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce4a60>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4ca0>), (Unit(\"deg_R\"), Unit(\"K\"), <function temperature.<locals>.<lambda> at 0x7f13d0ce44c0>, <function temperature.<locals>.<lambda> at 0x7f13d0ce4e50>)] temp2 True\n"
-     ]
-    }
-   ],
-   "source": [
-    "s.state.x_display_unit = 'cm'\n",
-    "s.state.y_display_unit = 'K'"
    ]
   },
   {
@@ -307,7 +122,47 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "app.output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.data_collection.add_link(WCSLink(d1, d2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.data_collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = app.profile1d(data=d1)\n",
+    "s.add_data(d2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s.state.x_display_unit = 'cm'\n",
+    "s.state.y_display_unit = 'K'"
+   ]
   }
  ],
  "metadata": {
@@ -326,9 +181,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.11.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,11 @@ long_description = file: README.rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
   setuptools_scm
 install_requires =
-    glue-core>=1.3.0
+    glue-core>=1.7.0
     glue-vispy-viewers>=1.0
     notebook>=4.0
     ipympl>=0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{test,notebooks,docs,devdeps}
+    py{38,39,310,311}-{test,notebooks,docs,devdeps}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 isolated_build = true

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ isolated_build = true
 passenv =
     DISPLAY
     HOME
+setenv =
+    JUPYTER_PLATFORM_DIRS=1
 whitelist_externals =
     find
     rm


### PR DESCRIPTION
This is a proof of concept of unit conversion in the profile viewer. It is a companion to the following PR in glue-core:

* https://github.com/glue-viz/glue/pull/2296

(that PR is needed for the changes here to work)

For now, this adds dropdowns for the units for the x and y axis, though note that I have not yet implemented the x axis unit conversion. The combo for the y axis currently starts off empty which means 'native units', i.e. no unit conversion, and it is then possible to select a unit. This is demonstrated in the following notebook:

https://gist.github.com/astrofrog/715239c5fb7b015019fdb414ae2b609e

Obviously we should think about what the default should be, and I think we should at least indicate in the 'no conversion' case something like 'native/data units' or similar. My plan going forward is the following:

* [x] Implement unit conversion for the x-axis too
* [x] Make sure x range selections work properly
* [x] Try and make the ability to specify alternative units pluggable so that e.g. jdaviz can opt in to using e.g. the spectral equivalency for the x-axis.
* [x] Add tests/docs/etc

Anyway, I'm putting this up now in case there is any early feedback/ideas!