### PR TITLE
Fixed a bug that caused the image viewer zoom to be reset when adding additional datasets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.12.1 (unreleased)
+===================
+
+* Fixed a bug that caused the image viewer zoom to be reset when adding
+  additional datasets. [#316]
+
 0.12.0 (2022-04-07)
 ===================
 

--- a/glue_jupyter/bqplot/image/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/image/tests/test_viewer.py
@@ -82,3 +82,39 @@ def test_contour_state(app, data_image):
     )
     # Without priority of levels, this gets set to [2, 3]
     assert layer.state.levels == [2.5, 5, 7.5]
+
+
+def test_add_markers_zoom(app, data_image, data_volume, dataxyz):
+
+    # Regression test for a bug that caused the zoom to be
+    # reset when adding markers to an image
+
+    im = app.imshow(data=data_image)
+
+    im.state.x_min = 0.2
+    im.state.x_max = 0.4
+    im.state.y_min = 0.3
+    im.state.y_max = 0.5
+
+    app.add_link(data_image, data_image.pixel_component_ids[0], dataxyz, dataxyz.id['y'])
+    app.add_link(data_image, data_image.pixel_component_ids[1], dataxyz, dataxyz.id['x'])
+    im.add_data(dataxyz)
+
+    assert im.state.x_min == 0.2
+    assert im.state.x_max == 0.4
+    assert im.state.y_min == 0.3
+    assert im.state.y_max == 0.5
+
+    im.add_data(data_volume)
+
+    assert im.state.x_min == 0.2
+    assert im.state.x_max == 0.4
+    assert im.state.y_min == 0.3
+    assert im.state.y_max == 0.5
+
+    im.state.reference_data = data_volume
+
+    assert im.state.x_min == -0.5
+    assert im.state.x_max == 63.5
+    assert im.state.y_min == -0.5
+    assert im.state.y_max == 63.5

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -41,9 +41,9 @@ class BqplotImageView(BqplotBaseView):
         self._composite = CompositeArray()
         self._composite_image = FRBImage(self, self._composite)
         self.figure.marks = list(self.figure.marks) + [self._composite_image]
-        self.state.add_callback('reference_data', self._reset_limits)
-        self.state.add_callback('x_att', self._reset_limits)
-        self.state.add_callback('y_att', self._reset_limits)
+        self.state.add_callback('reference_data', self._reset_limits, echo_old=True)
+        self.state.add_callback('x_att', self._reset_limits, echo_old=True)
+        self.state.add_callback('y_att', self._reset_limits, echo_old=True)
 
         self._setup_view_listener()
 
@@ -55,8 +55,9 @@ class BqplotImageView(BqplotBaseView):
                                 css_selector=".plotarea_events")
         self._vl.observe(self._on_view_change, names=['view_data'])
 
-    def _reset_limits(self, *args):
-        self.state.reset_limits()
+    def _reset_limits(self, old, new):
+        if new is not old:
+            self.state.reset_limits()
 
     def _on_view_change(self, *args):
         views = sorted(self._vl.view_data)


### PR DESCRIPTION
Ideally it would be good to understand why echo is calling the callbacks when the value doesn't change, but this fix will do for now.