### PR TITLE
fix: prevent color picker from entering an update loop

### DIFF
--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -27,6 +27,7 @@ class LayerOptionsWidget(v.VuetifyTemplate, HubListener):
         self.viewer = viewer
 
         widgetCache = WidgetCache()
+        self.observe(self._update_glue_state_from_layers, 'layers')
 
         self.current_layers_data = None
 
@@ -90,11 +91,7 @@ class LayerOptionsWidget(v.VuetifyTemplate, HubListener):
         self.viewer.state.add_callback('layers', _update_layers_from_glue_state)
         _update_layers_from_glue_state()
 
-    def vue_toggle_visible(self, index):
-        state = self.viewer.layers[index].state
-        state.visible = not state.visible
-
-    def vue_set_color(self, data):
-        index = data['index']
-        color = data['color']
-        self.viewer.layers[index].state.color = color
+    def _update_glue_state_from_layers(self, *args):
+        for layer_data, layer in zip(self.layers, self.viewer.layers):
+            layer.state.visible = layer_data['visible']
+            layer.state.color = layer_data['color']

--- a/glue_jupyter/widgets/layeroptions.vue
+++ b/glue_jupyter/widgets/layeroptions.vue
@@ -22,11 +22,10 @@
                                 <v-btn icon @click="color_menu_open = false">
                                     <v-icon>mdi-close</v-icon>
                                 </v-btn>
-                                <v-color-picker :value="data.item.color"
-                                            @update:color="set_color({index: data.item.index, color: $event.hex})"></v-color-picker>
+                                <v-color-picker v-model="data.item.color"></v-color-picker>
                             </div>
                         </v-menu>
-                        <v-btn icon @click.stop="toggle_visible(data.item.index)">
+                        <v-btn icon @click.stop="data.item.visible = !data.item.visible">
                             <v-icon>mdi-eye{{ data.item.visible ? '' : '-off' }}</v-icon>
                         </v-btn>
                         {{ data.item.label }}
@@ -37,7 +36,7 @@
                         <span class="glue-color-menu"
                               :style="`background:${data.item.color}`"
                         >&nbsp;</span>
-                        <v-icon style="padding: 0 4px" @click.stop="toggle_visible(data.item.index)">
+                        <v-icon style="padding: 0 4px" @click.stop="data.item.visible = !data.item.visible">
                             mdi-eye{{ data.item.visible ? '' : '-off' }}
                         </v-icon>
                         {{ data.item.label }}


### PR DESCRIPTION
Supersedes #313 and #284
 * Closes #313
 * Closes #312 


We now make use of a trait, which automatically gives us a debounce, after the fix in [ipywidgets](https://github.com/jupyter-widgets/ipywidgets/issues/3469).

Also, we use the same trait for input and output (using v-model) instead of using a different trait (as in #313) or custom methods. Using a different trait for setting can cause loops or setting to old values when there is high latency.