### PR TITLE
fix: do not upload float64 data to the widget, cast to float32

### DIFF
--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -93,6 +93,8 @@ class FRBImage(ImageGL):
 
         # Get the array and assign it to the artist
         image = self.array_maker(bounds=bounds)
+        if image.dtype == np.dtype("float64"):
+            image = image.astype(np.float32)
         if image is not None:
             with self.hold_sync():
                 self.image = image


### PR DESCRIPTION
WebGL cannot handle float64 data, so we need to cast it to float32. If not, the frontend will do it for us, but that will be a waste of bandwidth.

Addressses: https://github.com/spacetelescope/jdaviz/issues/1367

