### PR TITLE
BUG: Only recast float if image is not None

### DIFF
--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -93,9 +93,9 @@ class FRBImage(ImageGL):
 
         # Get the array and assign it to the artist
         image = self.array_maker(bounds=bounds)
-        if image.dtype == np.dtype("float64"):
-            image = image.astype(np.float32)
         if image is not None:
+            if image.dtype == np.dtype("float64"):
+                image = image.astype(np.float32)
             with self.hold_sync():
                 self.image = image
                 self.x = (xmin, xmax)


### PR DESCRIPTION
This is a direct follow-up of #318 . Without this patch dev job is failing at Jdaviz.