### PR TITLE
Add a setting to control disabling of tools in other viewers

### DIFF
--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -73,7 +73,8 @@ class JupyterApplication(Application):
         self.widget_subset_mode = SelectionModeMenu(session=self.session)
         self.widget = widgets.VBox(children=[self.widget_subset_mode, self.output])
 
-        self._settings['new_subset_on_selection_tool_change'] = [False, is_bool]
+        self._settings['new_subset_on_selection_tool_change'] = [False, bool]
+        self._settings['single_global_active_tool'] = [True, bool]
 
         if settings is not None:
             for key, value in settings.items():

--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -24,9 +24,10 @@ class InteractCheckableTool(CheckableTool):
     def activate(self):
 
         # Disable any active tool in other viewers
-        for viewer in self.viewer.session.application.viewers:
-            if viewer is not self.viewer:
-                viewer.toolbar.active_tool = None
+        if self.viewer.session.application.get_setting('single_global_active_tool'):
+            for viewer in self.viewer.session.application.viewers:
+                if viewer is not self.viewer:
+                    viewer.toolbar.active_tool = None
 
         self.viewer._mouse_interact.next = self.interact
 


### PR DESCRIPTION
By default, when selecting a tool, tools in other viewers are disabled. This can now be controlled with a setting:

```
app = gj.jglue(data=data, settings={'single_global_active_tool': False}) 
```