### PR TITLE
Fix IndexError that occurred in some cases during JSON to State translation

### DIFF
--- a/glue_jupyter/state_traitlets_helpers.py
+++ b/glue_jupyter/state_traitlets_helpers.py
@@ -45,12 +45,14 @@ def update_state_from_dict(state, changes):
             if isinstance(getattr(state, name), CallbackList):
                 callback_list = getattr(state, name)
                 for i in range(len(callback_list)):
-                    if isinstance(callback_list[i], State):
-                        update_state_from_dict(callback_list[i], changes[name][i])
-                    else:
-                        if (changes[name][i] != MAGIC_IGNORE and
-                                callback_list[i] != changes[name][i]):
-                            callback_list[i] = changes[name][i]
+                    if (isinstance(changes[name], dict) and i in changes[name]
+                            or isinstance(changes[name], list) and i < len(changes[name])):
+                        if isinstance(callback_list[i], State):
+                            update_state_from_dict(callback_list[i], changes[name][i])
+                        else:
+                            if (changes[name][i] != MAGIC_IGNORE and
+                                    callback_list[i] != changes[name][i]):
+                                callback_list[i] = changes[name][i]
             elif isinstance(getattr(state, name), CallbackDict):
                 callback_dict = getattr(state, name)
 

--- a/glue_jupyter/state_traitlets_helpers.py
+++ b/glue_jupyter/state_traitlets_helpers.py
@@ -45,6 +45,12 @@ def update_state_from_dict(state, changes):
             if isinstance(getattr(state, name), CallbackList):
                 callback_list = getattr(state, name)
                 for i in range(len(callback_list)):
+                    # Note that for updates to CallbackLists, we support either
+                    # a dictionary with integer indices (specifying the elements
+                    # of the CallbackList to update) or a list. If a dict is
+                    # specified, only indices referring to existing list items
+                    # will be updated, and if a list, extra elements will be
+                    # ignored.
                     if (isinstance(changes[name], dict) and i in changes[name]
                             or isinstance(changes[name], list) and i < len(changes[name])):
                         if isinstance(callback_list[i], State):

--- a/glue_jupyter/tests/test_state_traitlets_helpers.py
+++ b/glue_jupyter/tests/test_state_traitlets_helpers.py
@@ -44,6 +44,8 @@ def test_to_json():
     assert widget.latest_json == {"a": 1, "b": 2, "sub": [{"c": 4}]}
     widget.state.b = 5
     assert widget.latest_json == {"a": 1, "b": 5, "sub": [{"c": 4}]}
+    widget.state.sub.pop(0)
+    assert widget.latest_json == {"a": 1, "b": 5, "sub": []}
 
 
 def test_from_json():
@@ -54,9 +56,17 @@ def test_from_json():
     widget.set_state_from_json({"a": 3})
     assert widget.state.a == 3
     assert widget.latest_json == {"a": 3, "b": 2, "sub": [{"c": 3}]}
-    widget.set_state_from_json({"sub": {0: {"c": 2}}})
+    widget.set_state_from_json({"sub": [{"c": 2}]})
     assert widget.state.sub[0].c == 2
     assert widget.latest_json == {"a": 3, "b": 2, "sub": [{"c": 2}]}
+    # Giving an empty list does not clear the list - it just means that no
+    # items will be updated.
+    widget.set_state_from_json({"sub": []})
+    assert widget.latest_json == {"a": 3, "b": 2, "sub": [{"c": 2}]}
+    # We can also update lists by passing a dict with index: value pairs in
+    # cases where we just want to update some values
+    widget.set_state_from_json({"sub": {0: {'c': 9}}})
+    assert widget.latest_json == {"a": 3, "b": 2, "sub": [{"c": 9}]}
 
 
 def test_to_json_data():


### PR DESCRIPTION
The jdaviz developers have reported an issue with the JSON to Glue State translation which causes exceptions such as here:

https://github.com/spacetelescope/jdaviz/issues/438

The cause of this is that if the glue state has a ``CallbackList`` on a State with e.g. n elements and the front-end sends JSON which has only m elements (where m<n), this triggers an index error. The current fix in this PR is that if the JSON list has fewer items than the ``CallbackList``, we only update the first m elements in the CallbackList.

It's easier to explore this in a notebook so I have made one here:

https://gist.github.com/astrofrog/5fcc633bafb7fda7eee1d1eda192fd33

The bottom line is that there are two (I think mutually exclusive) options when the JSON updates a ``CallbackDict`` or ``CallbackList``:

* Either we require the length of lists in the JSON to match that of the ``CallbackList``, and for the keys in a dictionary to match or be a subset of those in a ``CallbackDict`` (which means that the length of a ``CallbackList`` and the keys of a ``CallbackDict`` cannot be changed by the front-end).
* Or we allow lists to have different lengths, which means that we shorten/lengthen ``CallbackList`` as needed, and we replace all keys in the ``CallbackDict`` with those in the JSON (meaning that ``{}`` in JSON would clear the ``CallbackDict``).

In other words, do we allow the front-end to modify the structure of the ``CallbackDict`` and ``CallbackList``, or only the items inside them?

This PR currently follows the first option - we were basically doing this modulo a bug. With the current implementation:

* If the JSON list is shorter than the CallbackList only the items in the JSON list are changed in the CallbackList
* If the JSON list is longer than the CallbackList the extra elements are ignored
* The JSON list can actually be specified also as a dictionary of index: value pairs in cases where the front-end wants to only update some items in the list
* Keys in the JSON dict that don't exist in ``CallbackDict`` are ignored

Are there cases where we think this would not be sufficient and where we would need the front-end to actually modify the number of items in a CallbackList or a CallbackDict?

