### PR TITLE
MNT: Pin maxversion of glue-core until package catches up

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_requires = >=3.7
 setup_requires =
   setuptools_scm
 install_requires =
-    glue-core>=1.3.0
+    glue-core>=1.3.0,<1.6
     glue-vispy-viewers>=1.0
     notebook>=4.0
     ipympl>=0.3.0


### PR DESCRIPTION
## Description

@kecnry said glue-jupyter will be incompatible with glue-core when glue-core v1.6 is released.