### PR TITLE
Allow adjusting z-order for scatter and histogram layers

### DIFF
--- a/glue_jupyter/bqplot/histogram/layer_artist.py
+++ b/glue_jupyter/bqplot/histogram/layer_artist.py
@@ -112,7 +112,9 @@ class BqplotHistogramLayerArtist(LayerArtist):
 
         if not self.enabled:
             return
-        # TODO: set visual attrs
+        # TODO: set other visual attrs
+        sorted_layers = sorted(self.view.layers, key=lambda layer: layer.state.zorder)
+        self.view.figure.marks = [layer.bars for layer in sorted_layers]
         self.redraw()
 
     def _update_histogram(self, force=False, **kwargs):

--- a/glue_jupyter/bqplot/histogram/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/histogram/tests/test_viewer.py
@@ -1,3 +1,6 @@
+from itertools import permutations
+
+
 def test_non_hex_colors(app, dataxyz):
 
     # Make sure non-hex colors such as '0.4' and 'red', which are valid
@@ -22,3 +25,15 @@ def test_remove(app, dataxz, dataxyz):
     assert len(s.figure.marks) == 2
     s.remove_data(dataxz)
     assert len(s.figure.marks) == 0
+
+
+def test_zorder(app, data_volume, dataxz, dataxyz):
+    s = app.histogram1d(data=dataxyz)
+    s.add_data(dataxz)
+    s.add_data(data_volume)
+    xyz, xz, vol = s.layers
+
+    for p in permutations([1, 2, 3]):
+        vol.state.zorder, xz.state.zorder, xyz.state.zorder = p
+        it = iter(s.figure.marks)
+        assert all(layer.bars in it for layer in s.layers)

--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -76,6 +76,8 @@ class BqplotScatterLayerArtist(LayerArtist):
         self.state.add_callback('vector_visible', self._update_visibility)
         self.state.add_callback('density_map', self._update_visibility)
 
+        self.state.add_callback('zorder', self._update_zorder)
+
         dlink((self.state, 'visible'), (self.scatter, 'visible'))
         dlink((self.state, 'visible'), (self.image, 'visible'))
 
@@ -121,6 +123,11 @@ class BqplotScatterLayerArtist(LayerArtist):
         self.image.visible = self.state.density_map
         self.scatter.visible = not self.state.density_map
         self.quiver.visible = not self.state.density_map and self.state.vector_visible
+
+    def _update_zorder(self, *args):
+        sorted_layers = sorted(self.view.layers, key=lambda layer: layer.state.zorder)
+        self.view.figure.marks = [item for layer in sorted_layers
+                                  for item in (layer.image, layer.scatter, layer.quiver)]
 
     def redraw(self):
         self.update()

--- a/glue_jupyter/bqplot/scatter/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/scatter/tests/test_viewer.py
@@ -1,3 +1,6 @@
+from itertools import permutations
+
+
 def test_scatter2d_nd(app, data_4d):
     # Regression test for a bug that meant that arrays with more than one
     # dimension did not work correctly.
@@ -45,3 +48,15 @@ def test_remove(app, dataxz, dataxyz):
     assert len(s.figure.marks) == 6
     s.remove_data(dataxz)
     assert len(s.figure.marks) == 0
+
+
+def test_zorder(app, data_volume, dataxz, dataxyz):
+    s = app.scatter2d(data=dataxyz)
+    s.add_data(dataxz)
+    s.add_data(data_volume)
+    xyz, xz, vol = s.layers
+
+    for p in permutations([1, 2, 3]):
+        vol.state.zorder, xz.state.zorder, xyz.state.zorder = p
+        it = iter(s.figure.marks)
+        assert all(layer.scatter in it for layer in s.layers)

--- a/glue_jupyter/common/state_widgets/layer_histogram.py
+++ b/glue_jupyter/common/state_widgets/layer_histogram.py
@@ -1,4 +1,4 @@
-from ipywidgets import FloatSlider, VBox
+from ipywidgets import FloatSlider, IntText, VBox
 
 from ...link import link
 
@@ -15,7 +15,10 @@ class HistogramLayerStateWidget(VBox):
                                           description='opacity')
         link((self.state, 'alpha'), (self.widget_opacity, 'value'))
 
-        super().__init__([self.widget_opacity])
+        self.widget_zorder = IntText(description='z-order')
+        link((self.state, 'zorder'), (self.widget_zorder, 'value'))
+
+        super().__init__([self.widget_opacity, self.widget_zorder])
 
     def cleanup(self):
         pass

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -1,4 +1,4 @@
-from ipywidgets import Checkbox, FloatSlider, VBox, IntSlider
+from ipywidgets import Checkbox, FloatSlider, VBox, IntSlider, IntText
 from glue_jupyter.widgets import Color, Size
 
 from ...link import link, dlink
@@ -34,6 +34,9 @@ class ScatterLayerStateWidget(VBox):
         self.widget_vector_y = LinkedDropdown(self.state, 'vy_att', ui_name='vy',
                                               label='vy attribute')
 
+        self.widget_zorder = IntText(description='z-order')
+        link((self.state, 'zorder'), (self.widget_zorder, 'value'))
+
         dlink((self.widget_vector, 'value'), (self.widget_vector_x.layout, 'display'),
               lambda value: None if value else 'none')
         dlink((self.widget_vector, 'value'), (self.widget_vector_y.layout, 'display'),
@@ -48,4 +51,4 @@ class ScatterLayerStateWidget(VBox):
         super().__init__([self.widget_visible, self.widget_fill, self.widget_opacity,
                           self.widget_size, self.widget_color,
                           self.widget_vector, self.widget_vector_x,
-                          self.widget_vector_y])
+                          self.widget_vector_y, self.widget_zorder])

--- a/glue_jupyter/widgets/layeroptions.vue
+++ b/glue_jupyter/widgets/layeroptions.vue
@@ -45,7 +45,7 @@
             </v-select>
         </div>
         <div>
-            <jupyter-widget v-if="layers && layers[selected]" :widget="layers[selected].layer_panel"></jupyter-widget>
+            <jupyter-widget v-if="layers && current_panel" :widget="current_panel"></jupyter-widget>
         </div>
     </div>
 </template>


### PR DESCRIPTION
This PR adds support for modifying the z-orders of layers in the scatter and histogram viewers. In the layer artist, this is achieved by re-ordering all of the marks of viewer's figure, sorted by layer z-order. In the UI, since we don't (yet) have anywhere to do the drag-and-drop reordering that one would do in desktop glue, this PR also adds `IntText` widgets to the layer option widgets for the histogram and scatter layers for setting the z-order. Note that in principle there's nothing that prevents a similar approach for the profile and image viewers, aside from the fact that the `IntText` widget doesn't match the Vuetify styling of their layer option widgets.

The last piece of this makes some changes to the layer options widget. Currently the layer options widget stores the index of the selected layer in the layers list, and displays the panel that corresponds to that index in the list of layers. Without any adjustment, this leads to an unpleasant effect where the selected layer will change if a user changes the z-order such that layers get re-ordered. To work around this, I've addeds member value that stores the information for the current layer and panel. When the layers get updated from glue, there's a check of whether the current layer info exists in the layer list (which it should if the change is a z-order change). If so, selected is updated to match the new index, and so the user's current layer is unchanged. Otherwise there is no change from the current behavior.