### PR TITLE
Allow empty data to be loaded to the Table Viewer

### DIFF
--- a/glue_jupyter/conftest.py
+++ b/glue_jupyter/conftest.py
@@ -33,6 +33,11 @@ def data_unlinked():
 
 
 @pytest.fixture
+def data_empty():
+    return Data(label="empty data")
+
+
+@pytest.fixture
 def data_4d():
     return Data(x=np.arange(120).reshape((4, 2, 3, 5)), label='Data 4D')
 

--- a/glue_jupyter/table/tests/test_table.py
+++ b/glue_jupyter/table/tests/test_table.py
@@ -30,7 +30,7 @@ def test_table_add_remove_data(app, dataxyz, dataxz, data_empty):
     table.remove_data(data_empty)
 
     table.add_data(dataxyz)
-    assert table.widget_table.data is dataxz
+    assert table.widget_table.data is dataxyz
     assert table.widget_table.total_length == 3
 
     assert table.widget_table.items, "table should fill automatically"

--- a/glue_jupyter/table/tests/test_table.py
+++ b/glue_jupyter/table/tests/test_table.py
@@ -22,7 +22,17 @@ def test_table_add_remove_data(app, dataxyz, dataxz):
     table = app.new_data_viewer(TableViewer, data=None, show=True)
     assert len(table.layers) == 0
     assert table.widget_table.total_length == 0
+
+    app.add_data(data_empty)
+    table.add_data(data_empty)
+    assert len(table.layers) == 1
+    assert table.widget_table.total_length == 0
+    table.remove_data(data_empty)
+
     table.add_data(dataxyz)
+    assert table.widget_table.data is dataxz
+    assert table.widget_table.total_length == 3
+
     assert table.widget_table.items, "table should fill automatically"
     assert table.widget_table.items[0]['z'] == dataxyz['z'][0]
     assert table.widget_table.total_length, "total length should grow"

--- a/glue_jupyter/table/tests/test_table.py
+++ b/glue_jupyter/table/tests/test_table.py
@@ -18,7 +18,7 @@ def test_table_filter(app, dataxyz):
     assert len(table.widget_table.selections) == 2
 
 
-def test_table_add_remove_data(app, dataxyz, dataxz):
+def test_table_add_remove_data(app, dataxyz, dataxz, data_empty):
     table = app.new_data_viewer(TableViewer, data=None, show=True)
     assert len(table.layers) == 0
     assert table.widget_table.total_length == 0

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -127,7 +127,7 @@ class TableGlue(TableBase):
         self._update()
 
     def __len__(self):
-        if self.data is None:
+        if self.data is None or len(self.data.shape) == 0:
             return 0
         return self.data.shape[0]
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR allows an empty data object to be added to the table viewer, with the intention of adding data later.

This issue was discovered in Jdaviz/Mosviz. Currently, the table data and subsequent "adding to viewer" is done dynamically, once data is parsed, and a column is ready to be added. Hence, up to this point, all initializing `Data` object already contains some parsed information (and thereby a length). We are motivated to move the initialization of the table viewer to the beginning of Mosviz to be more dynamic to the order of data being added, and found the following traceback when attempting to add an empty `Data` object to the table viewer:

```
table_data = Data(label=label)
self.app.add_data(table_data, notify_done=False)
self.app.get_viewer(table_viewer_reference_name).add_data(table_data)
```

<details>
<summary>Traceback: IndexError: tuple index out of range</summary>

```
File E:\STScI\gitRepos\jdaviz\envmain\lib\site-packages\glue_jupyter\table\viewer.py:127, in TableGlue._on_data_change(self, change)
    125 @traitlets.observe('data')
    126 def _on_data_change(self, change):
--> 127     self._update()

File E:\STScI\gitRepos\jdaviz\envmain\lib\site-packages\glue_jupyter\table\viewer.py:44, in TableBase._update(self)
     42 def _update(self):
     43     self._update_columns()
---> 44     self._update_items()
     45     self.total_length = len(self)
     46     self.options = {**self.options, 'totalItems': self.total_length}

File E:\STScI\gitRepos\jdaviz\envmain\lib\site-packages\glue_jupyter\table\viewer.py:83, in TableBase._update_items(self)
     82 def _update_items(self):
---> 83     self.items = self._get_items()

File E:\STScI\gitRepos\jdaviz\envmain\lib\site-packages\glue_jupyter\table\viewer.py:146, in TableGlue._get_items(self)
    144 page_size = self.options['itemsPerPage']
    145 i1 = page * page_size
--> 146 i2 = min(len(self), (page + 1) * page_size)
    148 view = slice(i1, i2)
    149 masks = {}

File E:\STScI\gitRepos\jdaviz\envmain\lib\site-packages\glue_jupyter\table\viewer.py:132, in TableGlue.__len__(self)
    130 if self.data is None:
    131     return 0
--> 132 return self.data.shape[0]

IndexError: tuple index out of range
```

</details>
