### PR TITLE
Set row number column width in Table widget dynamically from no. of digits

### DIFF
--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -15,7 +15,7 @@
       <template v-slot:header="props">
         <thead>
           <tr>
-            <th style="padding: 0 10px; width: 40px">#</th>
+            <th :style="'padding: 0 10px; width: '+Math.ceil(Math.log10(total_length))*20+'px'">#</th>
             <th style="padding: 0 1px; width: 30px" v-if="selection_enabled">
               <v-btn icon color="primary" text small @click="apply_filter">
                 <v-icon>filter_list</v-icon>

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -15,7 +15,7 @@
       <template v-slot:header="props">
         <thead>
           <tr>
-            <th :style="'padding: 0 10px; width: '+Math.ceil(Math.log10(total_length))*20+'px'">#</th>
+            <th :style="'padding: 0 10px; width: '+Math.max(1, Math.ceil(Math.log10(total_length)))*20+'px'">#</th>
             <th style="padding: 0 1px; width: 30px" v-if="selection_enabled">
               <v-btn icon color="primary" text small @click="apply_filter">
                 <v-icon>filter_list</v-icon>


### PR DESCRIPTION
## Description

This pull request modifies the width of the first column (row number) in the table widget to have its width calculated based on the space needed for the largest index, by assuming each digit requires 20px.

Before:

<img width="314" alt="Screen Shot 2022-11-16 at 12 30 54 PM" src="https://user-images.githubusercontent.com/877591/202252234-f91d62fb-84a5-4621-bce4-0f5a45fd1b5c.png">


After:

<img width="314" alt="Screen Shot 2022-11-16 at 12 29 10 PM" src="https://user-images.githubusercontent.com/877591/202252255-d9464ec7-8f6f-436a-9a79-fe90e9c1b1d7.png">

