### PR TITLE
Fix bug where empty histogram layer does not redraw

### DIFF
--- a/glue_jupyter/bqplot/histogram/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/histogram/tests/test_viewer.py
@@ -1,3 +1,6 @@
+from glue.core.subset import SubsetState
+
+
 def test_non_hex_colors(app, dataxyz):
 
     # Make sure non-hex colors such as '0.4' and 'red', which are valid
@@ -22,3 +25,13 @@ def test_remove(app, dataxz, dataxyz):
     assert len(s.figure.marks) == 2
     s.remove_data(dataxz)
     assert len(s.figure.marks) == 0
+
+
+def test_redraw_empty_subset(app, dataxz):
+    s = app.histogram1d(data=dataxz)
+    s.add_data(dataxz)
+    app.data_collection.new_subset_group(subset_state=dataxz.id['x'] > 1, label='empty_test')
+    layer_artist = s.layers[-1]
+    subset = layer_artist.layer
+    subset.subset_state = SubsetState()
+    assert all(layer_artist.bars.y == 0)

--- a/glue_jupyter/bqplot/histogram/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/histogram/tests/test_viewer.py
@@ -1,3 +1,4 @@
+from itertools import product
 from glue.core.subset import SubsetState
 
 
@@ -34,4 +35,8 @@ def test_redraw_empty_subset(app, dataxz):
     layer_artist = s.layers[-1]
     subset = layer_artist.layer
     subset.subset_state = SubsetState()
-    assert all(layer_artist.bars.y == 0)
+
+    # Test each combination of cumulative, normalize, and y_log
+    for flags in product([True, False], repeat=3):
+        s.state.cumulative, s.state.normalize, s.state.y_log = flags
+        assert all(layer_artist.bars.y == 0)


### PR DESCRIPTION
This PR aims to address the same issue that https://github.com/glue-viz/glue/pull/2300 dealt with in Qt glue, which is that if a subset group is modified to make it empty, the corresponding histogram layer artist is not redrawn. The changes here follow essentially the same logic as in the Qt update. Note that this PR only needs to update the layer artist, since the bqplot and Qt histogram viewers use the same viewer state class.
