### PR TITLE
Ignore ipywidgets 8.0 self-deprecation warnings

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -38,11 +38,11 @@ jobs:
         - macos: py38-test
         - macos: py39-test
         # One of these to be switched to arm64 running natively once the PLAT var is supported.
-        - macos: py310-test
+        - macos: py311-test
 
-        - windows: py37-test
         - windows: py38-test
         - windows: py39-test
+        - windows: py310-test
 
   no_coverage:
     needs: initial_checks
@@ -53,8 +53,8 @@ jobs:
 
       envs: |
         - linux: py37-notebooks
+        - windows: py37-notebooks
         - macos: py38-notebooks
-        - windows: py39-notebooks
         - linux: py310-notebooks
 
         - linux: py37-docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,10 @@ filterwarnings =
     ignore:distutils Version:DeprecationWarning
     ignore:There is no current event loop:DeprecationWarning
     ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning
+    ignore:Widget._active_widgets is deprecated:DeprecationWarning
+    ignore:Widget._widget_types is deprecated:DeprecationWarning
+    ignore:Widget.widget_types is deprecated:DeprecationWarning
+    ignore:Widget.widgets is deprecated:DeprecationWarning
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Description
Avoid test collection failures with ipywidgets 8.0.3 on its own deprecation warnings:
> ../../opt/mambaforge/envs/glue/lib/python3.11/site-packages/ipywidgets/widgets/utils.py:64: in deprecation
    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel+1)
E   DeprecationWarning: Widget._active_widgets is deprecated.

Could not find another way to resolve them but blanket-ignoring (although no warning appears on `from glue_jupyter.app import JupyterApplication`, and the deprecated methods seem to be only ever called in ipywidgets own `test_widget`).