### PR TITLE
Updated ipyvolume and scikit-image requirements for numpy 1.24 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     notebook>=4.0
     ipympl>=0.3.0
     ipyvolume>=0.5.0
-    ipyvolume>=0.6.0a10; python_version > '3.9'
+    ipyvolume>=0.6.0a10; python_version >= '3.8'
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
@@ -98,6 +98,8 @@ filterwarnings =
     ignore:Widget._widget_types is deprecated:DeprecationWarning
     ignore:Widget.widget_types is deprecated:DeprecationWarning
     ignore:Widget.widgets is deprecated:DeprecationWarning
+    # deprecated in numpy 1.24, to be fixed in scikit-image 0.20:
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`.:DeprecationWarning:skimage.util.dtype.*:
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
## Description
Work around two breaking changes introduced with the release of numpy 1.24.0:
1. New deprecation warning that is breaking test collection; will be fixed with scikit-image/scikit-image#6637 once 0.20 is released.
2. API change in `np.asarray(x)`, requires update to `ipyvolume>=0.6.0a` where numpy 1.24 is supported.