### PR TITLE
Implement support for showing world labels in profile viewer when in pixel space

### DIFF
--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -9,6 +9,10 @@ from ..common.viewer import BqplotBaseView
 
 from .layer_artist import BqplotProfileLayerArtist
 
+from astropy import units as u
+from astropy.visualization.wcsaxes.formatter_locator import ScalarFormatterLocator
+
+from glue.core.component_id import PixelComponentID
 from glue_jupyter.common.state_widgets.layer_profile import ProfileLayerStateWidget
 from glue_jupyter.common.state_widgets.viewer_profile import ProfileViewerStateWidget
 
@@ -31,12 +35,63 @@ class BqplotProfileView(BqplotBaseView):
              'bqplot:xrange']
 
     def __init__(self, *args, **kwargs):
+
         super().__init__(*args, **kwargs)
+
         self.state.add_callback('x_att', self._update_axes)
         self.state.add_callback('normalize', self._update_axes)
         self.state.add_callback('x_display_unit', self._update_axes)
         self.state.add_callback('y_display_unit', self._update_axes)
         self._update_axes()
+
+        self.formatter_locator = ScalarFormatterLocator(number=5, unit=u.one, format='%.3g')
+        self.scale_x.observe(self._update_labels, names=['min', 'max'])
+        self.scale_y.observe(self._update_labels, names=['min', 'max'])
+
+    def _update_labels(self, *args):
+
+        if not isinstance(self.state.x_att, PixelComponentID):
+            self.axis_x.tick_values = None
+            self.axis_x.tick_labels = None
+            return
+
+        # Get WCS to use to convert pixel coordinates to world coordinates
+        # TODO: slice WCS with >1 dimensions
+        wcs_sub = self.state.reference_data.coords
+
+        # TODO: make sure we deal correctly with units when non-standard unit is given
+
+        # As we can't trust that the lower and upper values will be defined,
+        # we need to sample the axis at a number of points to determine the
+        # lower and upper values to use
+        x = np.linspace(self.scale_x.min, self.scale_x.max, 100)
+        w = wcs_sub.pixel_to_world_values(x)
+
+        # Filter out NaN and Inf values
+        w = w[np.isfinite(w)]
+        lower = np.min(w)
+        upper = np.max(w)
+
+        # Find the tick positions
+        tick_values_world, spacing = self.formatter_locator.locator(lower, upper)
+
+        # Convert back to pixel coordinates
+        tick_values = wcs_sub.world_to_pixel_values(tick_values_world)
+
+        # Round tick_values to nearest int to avoid issues with dict lookup of
+        # labels.
+        # TODO: can we avoid this and make tick_labels more robust?
+        tick_values = np.round(tick_values).astype(int)
+
+        # Determine custom labels
+        # TODO: determine how to do pretty formatting for exponential notation
+        tick_labels = self.formatter_locator.formatter(tick_values_world, spacing)
+
+        # Construct tick_labels dictionary
+        tick_labels = dict(zip(tick_values, tick_labels))
+
+        self.axis_x.tick_values = tick_values
+        self.axis_x.tick_labels = tick_labels
 
     def _update_axes(self, *args):
 

--- a/notebooks/Experimental/Profile viewer world labelling in pixels.ipynb
+++ b/notebooks/Experimental/Profile viewer world labelling in pixels.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10603e01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.wcs import WCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51dcf536",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs = WCS(naxis=1)\n",
+    "wcs.wcs.ctype = 'FREQ-LOG',\n",
+    "wcs.wcs.crval = 1e9,\n",
+    "wcs.wcs.crpix = 50,\n",
+    "wcs.wcs.cdelt = 5e7,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a28d61ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb4562dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f580306d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(100)\n",
+    "y = np.exp(-(x - 50) ** 2 / 40)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b24a8670",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.subplot(1, 2, 1)\n",
+    "plt.plot(x, wcs.pixel_to_world(x))\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.plot(wcs.pixel_to_world(x), y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fdfa807",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glue.core import Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7280b32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = Data(y=y, coords=wcs, label='Test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29a1c28c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glue_jupyter import jglue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6547691",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = jglue()\n",
+    "app.add_data(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6204c60c",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "p = app.profile1d()\n",
+    "p.state.x_att = data.pixel_component_ids[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a feature that has been requested for jdaviz but is a generically useful feature - similar to what we do for images where we show images in pixel space and show the tick values/labels in world space, this PR implements something similar for the profile viewer in glue-jupyter (and we could in principle also extend this to the image viewer in glue-jupyter too).

![Screenshot from 2023-02-20 11-53-51](https://user-images.githubusercontent.com/314716/220099381-46fd4e6f-f17c-420e-8493-e59096579d90.png)

Currently this needs https://github.com/bqplot/bqplot/pull/1541 rebased on the bqplot v0.12.x branch.

This is very incomplete but already mostly works with a simple example (notebook included). The main things to still do are:

* [ ] Investigate and fix issue with labels sometimes updating sometimes not (race condition in bqplot?). More details in a follow-up comment below
* [ ] Support cases where the data has more than one dimension
* [ ] Properly deal with display units (for now just works with original WCS units)
* [ ] Determine how to do 'pretty' exponential notation
* [ ] Add a callback property on the state to determine whether or not to show world coordinates when in pixel space
* [ ] Add tests