### PR TITLE
Allow cmap and size to take cateogricals

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -1,16 +1,15 @@
-import numpy as np
 import bqplot
-from ..compatibility import ScatterGL, ImageGL
-
+import numpy as np
+from echo import CallbackProperty
 from glue.core.data import Subset
-from glue.viewers.scatter.state import ScatterLayerState
 from glue.core.exceptions import IncompatibleAttribute
+from glue.utils import color2hex, ensure_numerical
 from glue.viewers.common.layer_artist import LayerArtist
+from glue.viewers.scatter.state import ScatterLayerState
 
 from ...link import dlink, on_change
 from ...utils import colormap_to_hexlist, debounced, float_or_none
-from echo import CallbackProperty
-from glue.utils import ensure_numerical, color2hex
+from ..compatibility import ImageGL, ScatterGL
 
 __all__ = ['BqplotScatterLayerState', 'BqplotScatterLayerArtist']
 EMPTY_IMAGE = np.zeros((10, 10, 4), dtype=np.uint8)
@@ -106,7 +105,8 @@ class BqplotScatterLayerArtist(LayerArtist):
 
     def _on_change_cmap_mode_or_att(self, ignore=None):
         if self.state.cmap_mode == 'Linear' and self.state.cmap_att is not None:
-            self.scatter.color = self.layer.data[self.state.cmap_att].astype(np.float32).ravel()
+            self.scatter.color = (ensure_numerical(self.layer.data[self.state.cmap_att])
+                                  .astype(np.float32).ravel())
         else:
             self.scatter.color = None
 
@@ -244,7 +244,7 @@ class BqplotScatterLayerArtist(LayerArtist):
         scale = self.state.size_scaling
         if self.state.size_mode == 'Linear' and self.state.size_att is not None:
             self.scatter.default_size = int(scale * 25)
-            self.scatter.size = self.layer.data[self.state.size_att].ravel()
+            self.scatter.size = ensure_numerical(self.layer.data[self.state.size_att].ravel())
             self.scale_size.min = float_or_none(self.state.size_vmin)
             self.scale_size.max = float_or_none(self.state.size_vmax)
             self._workaround_unselected_style()

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -1,10 +1,11 @@
 import os
+
 import nbformat
 import numpy as np
-from numpy.testing import assert_allclose
-from nbconvert.preprocessors import ExecutePreprocessor
 from glue.core import Data
 from glue.core.roi import EllipticalROI
+from nbconvert.preprocessors import ExecutePreprocessor
+from numpy.testing import assert_allclose
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -227,6 +228,17 @@ def test_scatter2d_cmap_mode(app, dataxyz):
 
     assert l1.scatter.color is None
     l1.state.cmap_att = 'x'
+    l1.state.cmap_mode = 'Linear'
+    assert l1.state.cmap_name == 'Gray'
+    l1.state.cmap_vmin = 0
+    l1.state.cmap_vmax = 10
+    assert l1.scatter.color is not None
+
+
+def test_scatter2d_cmap_mode_categorical(app, datacat):
+    s = app.scatter2d(a='a', a='b', data=datacat)
+    l1 = s.layers[0]
+    l1.state.cmap_att = 'a'
     l1.state.cmap_mode = 'Linear'
     assert l1.state.cmap_name == 'Gray'
     l1.state.cmap_vmin = 0


### PR DESCRIPTION
# Allow Linear scaling on cmap and size from categorical component

## Description

This just calls ensure_numerical on components that are passed to cmap and size. Required if we allow categoricals to set these scalings (as in https://github.com/glue-viz/glue/pull/2317), but a fine idea anyway.