### PR TITLE
Ignore force in BqplotImageViewerState._reference_data_changed

### DIFF
--- a/glue_jupyter/bqplot/image/state.py
+++ b/glue_jupyter/bqplot/image/state.py
@@ -15,6 +15,9 @@ class BqplotImageViewerState(ImageViewerState):
                                                       'to the axes width/height (0 means no '
                                                       'padding)')
 
+    def _reference_data_changed(self, *args, **kwargs):
+        return super()._reference_data_changed(*args, force=False)
+
 
 class BqplotImageLayerState(ImageLayerState):
     c_min = DDCProperty(docstring='The lower level used for the contours')


### PR DESCRIPTION
I need this patch to make Jdaviz (undesirable behavior change seen in spacetelescope/jdaviz#2135) work with `glue-core` v1.9.0 (see https://github.com/glue-viz/glue/commit/da68d1a63adfd6f91aac1e7d2cf864a359c33baa#r107847297), though it looks wrong. Maybe you can tell me what the proper fix is and where the fix should be. Thanks!

cc @rosteen 