### PR TITLE
Don't overload _update_data in image viewer layer artist

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -65,13 +65,6 @@ class BqplotImageView(BqplotBaseView):
                                 css_selector=".plotarea_events")
         self._vl.observe(self._on_view_change, names=['view_data'])
 
-    def _update_data(self, *args, **kwargs):
-        super()._update_data(*args, **kwargs)
-        try:
-            self.state._reference_data_changed(force=True)
-        except TypeError:  # older glue-core versions did not have force=True
-            self.state._reference_data_changed()
-
     def _reset_limits(self, old, new):
         if new is not old:
             self.state.reset_limits()


### PR DESCRIPTION
This was causing ``_reference_data_changed`` to be called with ``force=True`` in situations where it didn't need to be - instead we now specifically catch the case of the numerical data changing in glue-core and call a dedicated method for this, see https://github.com/glue-viz/glue/pull/2385

Once CI passes we can merge this and do a new release without waiting for glue-core - this is equivalent to simply reverting https://github.com/glue-viz/glue-jupyter/pull/339 and glue-jupyter will work fine without - for the case of a BaseCartesianData instance that has numerical data values changing, things will work correctly once the glue-core fix is merged and released.