### PR TITLE
 Fix subset creation with unit flip

### DIFF
--- a/glue_jupyter/bqplot/profile/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/profile/tests/test_viewer.py
@@ -53,10 +53,12 @@ def test_remove(app, data_image, data_volume):
 class SpectralUnitConverter:
 
     def equivalent_units(self, data, cid, units):
-        return map(str, u.Unit(units).find_equivalent_units(include_prefix_units=True, equivalencies=u.spectral()))
+        return map(str, u.Unit(units).find_equivalent_units(include_prefix_units=True,
+                                                            equivalencies=u.spectral()))
 
     def to_unit(self, data, cid, values, original_units, target_units):
-        return (values * u.Unit(original_units)).to_value(target_units, equivalencies=u.spectral())
+        return (values * u.Unit(original_units)).to_value(target_units,
+                                                          equivalencies=u.spectral())
 
 
 def test_unit_conversion(app):

--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -65,6 +65,10 @@ class BqplotProfileView(BqplotBaseView):
                                      self.state.x_att, np.array([lo, hi]),
                                      self.state.x_display_unit)
 
+        # Sometimes unit conversions can cause the min/max to be swapped
+        if lo > hi:
+            lo, hi = hi, lo
+
         roi_new = RangeROI(min=lo, max=hi, orientation='x')
 
         return roi_to_subset_state(roi_new, x_att=self.state.x_att)


### PR DESCRIPTION
Fix bug that caused subsets to not be created correctly in the profile viewer if unit conversion caused a flip in direction (e.g. wavelength -> frequency)

Similar to https://github.com/glue-viz/glue/pull/2393
