### PR TITLE
Fix duplicate xrange region bug when operators are used on existing regions

### DIFF
--- a/glue_jupyter/bqplot/profile/viewer.py
+++ b/glue_jupyter/bqplot/profile/viewer.py
@@ -28,7 +28,7 @@ class BqplotProfileView(BqplotBaseView):
     _layer_style_widget_cls = ProfileLayerStateWidget
 
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:panzoom_x', 'bqplot:panzoom_y',
-             'bqplot:xrange']
+             'bqplot:xrange', 'bqplot:yrange']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
@javerbukh had been battling duplicate sub-regions appearing in his work over at https://github.com/spacetelescope/jdaviz/pull/2237 .

Here is a workflow to reproduce the bug:

1. Draw a xrange region.
2. Select the Subset generated from Step 1.
3. Select XOR tool.
4. Select another region. This would turn Subset 1 into composite subset.

What I noticed with this bug is, the composition went a level deeper than it should have:

```
AND
|__ AND
|   |__ Range
|   |__ INV
|       |__ Range
|__ INV
    |__ Range
```

When it should be much simpler like this:

```
AND
|__ Range
|__ INV
    |__ Range
```

Since we never heard back from SMEs about this, I decided to have a look. I asked myself why are we not seeing this on spatial subsets but it appears always on spectral subset? Then I noticed that the tools logic for spatial region has more stuff to it than the xrange tool, so I decided to copy stuff over, and that appears to have fixed the bug, but I would need @javerbukh to confirm for sure.

Fix https://github.com/spacetelescope/jdaviz/issues/2061

[🐱](https://jira.stsci.edu/browse/JDAT-3138)