### PR TITLE
Move register_component_from_file calls back to top level of file

### DIFF
--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -31,6 +31,12 @@ def is_bool(value):
     return isinstance(value, bool)
 
 
+for name in ['glue-float-field', 'glue-throttled-slider']:
+    file = f'{name.replace("-", "_")}.vue'
+    ipyvue.register_component_from_file(
+        None, name, os.path.join(os.path.dirname(__file__), 'widgets', file))
+
+
 class JupyterApplication(Application):
     """
     The main Glue application object for the Jupyter environment.
@@ -53,11 +59,6 @@ class JupyterApplication(Application):
     def __init__(self, data_collection=None, session=None, settings=None):
 
         super(JupyterApplication, self).__init__(data_collection=data_collection, session=session)
-
-        for name in ['glue-float-field', 'glue-throttled-slider']:
-            file = f'{name.replace("-", "_")}.vue'
-            ipyvue.register_component_from_file(
-                None, name, os.path.join(os.path.dirname(__file__), 'widgets', file))
 
         try:
             from glue.main import load_plugins


### PR DESCRIPTION
In #360 I temporarily moved these into the JupyterApplication class to avoid an issue with solara but really this should work as it was before, so reverting the change so we can find a better solution. With this PR, when running the tests with ``tox -e py311-test-visual``, the error is:

```python
____________________________________________________________ ERROR collecting test session ____________________________________________________________
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1206: in _gcd_import
    ???
<frozen importlib._bootstrap>:1178: in _find_and_load
    ???
<frozen importlib._bootstrap>:1128: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1206: in _gcd_import
    ???
<frozen importlib._bootstrap>:1178: in _find_and_load
    ???
<frozen importlib._bootstrap>:1149: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:940: in exec_module
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
../../.tox/py311-test-visual/lib/python3.11/site-packages/glue_jupyter/__init__.py:7: in <module>
    from .app import JupyterApplication  # noqa
../../.tox/py311-test-visual/lib/python3.11/site-packages/glue_jupyter/app.py:36: in <module>
    ipyvue.register_component_from_file(
../../.tox/py311-test-visual/lib/python3.11/site-packages/ipyvue/VueComponentRegistry.py:41: in register_component_from_file
    vue_component_files[os.path.abspath(file_name)] = name
../../.tox/py311-test-visual/lib/python3.11/site-packages/solara/server/patch.py:183: in __setitem__
    self._get_context_dict().__setitem__(key, value)
../../.tox/py311-test-visual/lib/python3.11/site-packages/solara/server/patch.py:209: in _get_context_dict
    context = app.get_current_context()
../../.tox/py311-test-visual/lib/python3.11/site-packages/solara/server/app.py:358: in get_current_context
    raise RuntimeError(
E   RuntimeError: Tried to get the current context for thread MainThread8413806912, but no known context found. This might be a bug in Solara. (known contexts: []
```

This seems like a solara bug potentially - @maartenbreddels any ideas?