### PR TITLE
Circle draw tool must produce circle

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -30,7 +30,7 @@ class BqplotImageView(BqplotBaseView):
     _state_cls = BqplotImageViewerState
     _options_cls = ImageViewerStateWidget
 
-    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle']
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle', 'bqplot:ellipse']
 
     def __init__(self, session):
 

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from nbconvert.preprocessors import ExecutePreprocessor
 from glue.core import Data
-from glue.core.roi import EllipticalROI
+from glue.core.roi import CircularROI, EllipticalROI
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -271,6 +271,24 @@ def test_imshow_circular_brush(app, data_image):
     v.state.aspect = 'auto'
 
     tool = v.toolbar.tools['bqplot:circle']
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [(1.5, 3.5), (300.5, 550)]
+    tool.interact.brushing = False
+
+    roi = data_image.subsets[0].subset_state.roi
+    assert isinstance(roi, CircularROI)
+    assert_allclose(roi.xc, 151.00)
+    assert_allclose(roi.yc, 276.75)
+    assert_allclose(roi.radius, 211.375)
+
+
+def test_imshow_elliptical_brush(app, data_image):
+
+    v = app.imshow(data=data_image)
+    v.state.aspect = 'auto'
+
+    tool = v.toolbar.tools['bqplot:ellipse']
     tool.activate()
     tool.interact.brushing = True
     tool.interact.selected = [(1.5, 3.5), (300.5, 550)]


### PR DESCRIPTION
User was confused on why they get back elliptical region when they used the circular draw tool on their image. You can basically reproduce this behavior using https://github.com/spacetelescope/jdaviz/issues/697 even though I think @camipacifici reported a different workflow.

With this patch, even though the circle tool obviously produced something that does not look circular in Lab, it still gives a circle.

![Screenshot 2023-07-05 173720](https://github.com/glue-viz/glue-jupyter/assets/2090236/05174ac0-fb8a-4062-8f4e-f868de9a361c)

~I don't see the affected code tested anywhere in this repo, so I am unable to add new tests.~

[🐱](https://jira.stsci.edu/browse/JDAT-3545)