### PR TITLE
Improve layout of density scatter

### DIFF
--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -1,32 +1,28 @@
 <template>
-    <div>
-        <div class="text-subtitle-2 mt-4 mb-2 font-weight-bold">Color</div>
+    <div class="glue-layer-scatter">
+        <div class="text-subtitle-2 font-weight-bold">Color</div>
         <div>
             <v-select label="color" :items="cmap_mode_items" v-model="cmap_mode_selected" hide-details />
         </div>
         <template v-if="glue_state.cmap_mode === 'Linear'">
             <div>
-                <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details
-                    class="margin-bottom: 16px" />
+                <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
             <div>
-                <v-text-field label="min" v-model="glue_state.cmap_vmin" hide-details
-                    class="margin-bottom: 16px"></v-text-field>
+                <v-text-field label="min" v-model="glue_state.cmap_vmin" hide-details></v-text-field>
             </div>
             <div>
-                <v-text-field label="max" v-model="glue_state.cmap_vmax" hide-details
-                    class="margin-bottom: 16px"></v-text-field>
+                <v-text-field label="max" v-model="glue_state.cmap_vmax" hide-details></v-text-field>
             </div>
             <div>
-                <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details
-                    class="margin-bottom: 16px" />
+                <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
             </div>
         </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
             <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
         </div>
-        <div class="text-subtitle-2 mt-4 mb-2 font-weight-bold">Points</div>
+        <div class="text-subtitle-2 font-weight-bold">Points</div>
         <div>
             <v-subheader class="pl-0 slider-label">show points</v-subheader>
             <v-switch v-model="glue_state.markers_visible" hide-details style="margin-top: 0" />
@@ -40,16 +36,13 @@
             </div>
             <template v-if="glue_state.size_mode === 'Linear'">
                 <div>
-                    <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details
-                        class="margin-bottom: 16px" />
+                    <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
                 <div>
-                    <v-text-field label="min" v-model="glue_state.size_vmin" hide-details
-                        class="margin-bottom: 16px"></v-text-field>
+                    <v-text-field label="min" v-model="glue_state.size_vmin" hide-details></v-text-field>
                 </div>
                 <div>
-                    <v-text-field label="max" v-model="glue_state.size_vmax" hide-details
-                        class="margin-bottom: 16px"></v-text-field>
+                    <v-text-field label="max" v-model="glue_state.size_vmax" hide-details></v-text-field>
                 </div>
             </template>
             <template v-if="glue_state.density_map">
@@ -75,17 +68,17 @@
                 </div>
             </template>
         </template>
-        <div class="text-subtitle-2 mt-4 mb-2 font-weight-bold">Vectors</div>
+        <div class="text-subtitle-2 font-weight-bold" :style="glue_state.markers_visible ? {} : {marginTop: '6px'}">Vectors</div>
         <div>
             <v-subheader class="pl-0 slider-label">show vectors</v-subheader>
-            <v-switch v-model="glue_state.vector_visible" hide-details />
+            <v-switch v-model="glue_state.vector_visible" hide-details style="margin-top: 0"/>
         </div>
         <template v-if="glue_state.vector_visible">
             <div>
                 <v-select label="vx" :items="vx_att_items" v-model="vx_att_selected" hide-details />
             </div>
             <div>
-                <v-select label="vy" :items="vy_att_items" v-model="vy_att_selected" hide-details style="margin-bottom: 16px" />
+                <v-select label="vy" :items="vy_att_items" v-model="vy_att_selected" hide-details />
             </div>
         </template>
     </div>
@@ -93,8 +86,9 @@
 <script>
 </script>
 <style id="layer_scatter">
-.v-subheader.slider-label {
+.glue-layer-scatter .v-subheader.slider-label {
     font-size: 12px;
     height: 16px;
+    margin-top: 6px;
 }
 </style>

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -4,22 +4,24 @@
         <div>
             <v-select label="color" :items="cmap_mode_items" v-model="cmap_mode_selected" hide-details />
         </div>
-        <div v-if="glue_state.cmap_mode === 'Linear'">
-            <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details
-                class="margin-bottom: 16px" />
-        </div>
-        <div v-if="glue_state.cmap_mode === 'Linear'">
-            <v-text-field label="min" v-model="glue_state.cmap_vmin" hide-details
-                class="margin-bottom: 16px"></v-text-field>
-        </div>
-        <div v-if="glue_state.cmap_mode === 'Linear'">
-            <v-text-field label="max" v-model="glue_state.cmap_vmax" hide-details
-                class="margin-bottom: 16px"></v-text-field>
-        </div>
-        <div v-if="glue_state.cmap_mode === 'Linear'">
-            <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details
-                class="margin-bottom: 16px" />
-        </div>
+        <template v-if="glue_state.cmap_mode === 'Linear'">
+            <div>
+                <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details
+                    class="margin-bottom: 16px" />
+            </div>
+            <div>
+                <v-text-field label="min" v-model="glue_state.cmap_vmin" hide-details
+                    class="margin-bottom: 16px"></v-text-field>
+            </div>
+            <div>
+                <v-text-field label="max" v-model="glue_state.cmap_vmax" hide-details
+                    class="margin-bottom: 16px"></v-text-field>
+            </div>
+            <div>
+                <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details
+                    class="margin-bottom: 16px" />
+            </div>
+        </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
             <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
@@ -29,53 +31,63 @@
             <v-subheader class="pl-0 slider-label">show points</v-subheader>
             <v-switch v-model="glue_state.markers_visible" hide-details style="margin-top: 0" />
         </div>
-        <div v-if="glue_state.markers_visible">
-            <v-select label="type" :items="points_mode_items" v-model="points_mode_selected" hide-details />
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.density_map === false">
-            <v-select label="size" :items="size_mode_items" v-model="size_mode_selected" hide-details />
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.size_mode === 'Linear'">
-            <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details
-                class="margin-bottom: 16px" />
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.size_mode === 'Linear'">
-            <v-text-field label="min" v-model="glue_state.size_vmin" hide-details
-                class="margin-bottom: 16px"></v-text-field>
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.size_mode === 'Linear'">
-            <v-text-field label="max" v-model="glue_state.size_vmax" hide-details
-                class="margin-bottom: 16px"></v-text-field>
-        </div>
-        <div v-if="glue_state.markers_visible && !glue_state.density_map">
-            <v-subheader class="pl-0 slider-label">fill markers</v-subheader>
-            <v-switch v-model="glue_state.fill" hide-details style="margin-top: 0" />
-        </div>
-        <div v-if="glue_state.markers_visible && !glue_state.density_map">
-            <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
-            <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="glue_state.size_scaling"
-                hide-details />
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.density_map">
-            <v-subheader class="pl-0 slider-label">dpi</v-subheader>
-            <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" hide-details />
-        </div>
-        <div v-if="glue_state.markers_visible && glue_state.density_map">
-            <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.density_contrast"
-                hide-details />
-        </div>
+        <template v-if="glue_state.markers_visible">
+            <div>
+                <v-select label="type" :items="points_mode_items" v-model="points_mode_selected" hide-details />
+            </div>
+            <div v-if="glue_state.density_map === false">
+                <v-select label="size" :items="size_mode_items" v-model="size_mode_selected" hide-details />
+            </div>
+            <template v-if="glue_state.size_mode === 'Linear'">
+                <div>
+                    <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details
+                        class="margin-bottom: 16px" />
+                </div>
+                <div>
+                    <v-text-field label="min" v-model="glue_state.size_vmin" hide-details
+                        class="margin-bottom: 16px"></v-text-field>
+                </div>
+                <div>
+                    <v-text-field label="max" v-model="glue_state.size_vmax" hide-details
+                        class="margin-bottom: 16px"></v-text-field>
+                </div>
+            </template>
+            <template v-if="glue_state.density_map">
+                <div>
+                    <v-subheader class="pl-0 slider-label">dpi</v-subheader>
+                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" hide-details />
+                </div>
+                <div>
+                    <v-subheader class="pl-0 slider-label">contrast</v-subheader>
+                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.density_contrast"
+                                         hide-details />
+                </div>
+            </template>
+            <template v-else>
+                <div>
+                    <v-subheader class="pl-0 slider-label">fill markers</v-subheader>
+                    <v-switch v-model="glue_state.fill" hide-details style="margin-top: 0" />
+                </div>
+                <div>
+                    <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
+                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="glue_state.size_scaling"
+                        hide-details />
+                </div>
+            </template>
+        </template>
         <div class="text-subtitle-2 mt-4 mb-2 font-weight-bold">Vectors</div>
         <div>
             <v-subheader class="pl-0 slider-label">show vectors</v-subheader>
             <v-switch v-model="glue_state.vector_visible" hide-details />
         </div>
-        <div v-if="glue_state.vector_visible">
-            <v-select label="vx" :items="vx_att_items" v-model="vx_att_selected" hide-details />
-        </div>
-        <div v-if="glue_state.vector_visible">
-            <v-select label="vy" :items="vy_att_items" v-model="vy_att_selected" hide-details style="margin-bottom: 16px" />
-        </div>
+        <template v-if="glue_state.vector_visible">
+            <div>
+                <v-select label="vx" :items="vx_att_items" v-model="vx_att_selected" hide-details />
+            </div>
+            <div>
+                <v-select label="vy" :items="vy_att_items" v-model="vy_att_selected" hide-details style="margin-bottom: 16px" />
+            </div>
+        </template>
     </div>
 </template>
 <script>

--- a/glue_jupyter/common/state_widgets/viewer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/viewer_scatter.vue
@@ -4,25 +4,19 @@
             <v-select label="x axis" :items="x_att_items" v-model="x_att_selected" hide-details />
         </div>
         <div>
-            <v-select label="y axis" :items="y_att_items" v-model="y_att_selected" hide-details style="margin-bottom: 16px" />
+            <v-select label="y axis" :items="y_att_items" v-model="y_att_selected" hide-details />
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">show axes</v-subheader>
-                <v-switch v-model="glue_state.show_axes" hide-details style="margin-top: 0"/>
+            <v-switch v-model="glue_state.show_axes" hide-details style="margin-top: 0"/>
         </div>
     </div>
 </template>
 
 <style id="viewer_image">
-    .glue-viewer-scatter {
-        width: 100%;
-    }
-    .glue-viewer-scatter-switches {
-        display: flex;
-        flex-direction: row;
-    }
-    .v-subheader.slider-label {
+    .glue-viewer-scatter .v-subheader.slider-label {
         font-size: 12px;
         height: 16px;
+        margin-top: 6px;
     }
 </style>

--- a/glue_jupyter/widgets/glue_throttled_slider.vue
+++ b/glue_jupyter/widgets/glue_throttled_slider.vue
@@ -4,7 +4,7 @@
             @input="throttledSetValue"
             :max="max"
             :step="step"
-            :hide="hideDetails" />
+            :hide-details="hideDetails" />
 </template>
 
 <script>


### PR DESCRIPTION
# Pull Request Template

## Description

Improve the layout of density scatter:

- group v-if's
- normalize spacing between elements
- make layout more compact

See: #363
<img width="1050" alt="Screenshot 2023-07-18 at 11 05 51" src="https://github.com/glue-viz/glue-jupyter/assets/46192475/06698699-703e-4a67-b49d-75e1bc22c062">

<img width="1024" alt="Screenshot 2023-07-18 at 11 06 10" src="https://github.com/glue-viz/glue-jupyter/assets/46192475/a07250bf-b859-4d29-b877-fc015ee38ad4">
