### PR TITLE
Fix compatibility with future glue-core changes

### DIFF
--- a/glue_jupyter/__init__.py
+++ b/glue_jupyter/__init__.py
@@ -50,7 +50,11 @@ def jglue(*args, settings=None, show=False, links=None, **kwargs):
     for that class for more details.
     """
 
-    from glue.qglue import parse_data, parse_links
+    try:
+        from glue.core.parsers import parse_data, parse_links
+    except ImportError:  # older versions of glue
+        from glue.qglue import parse_data, parse_links
+
     from glue.core.data_factories import load_data
 
     japp = JupyterApplication(settings=settings)

--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -90,7 +90,10 @@ class JupyterApplication(Application):
         """
         Parse and add links.
         """
-        from glue.qglue import parse_links
+        try:
+            from glue.core.parsers import parse_links
+        except ImportError:  # older versions of glue
+            from glue.qglue import parse_links
         self.data_collection.add_link(parse_links(self.data_collection, links))
 
     def add_link(self, data1, attribute1, data2, attribute2):


### PR DESCRIPTION
Companion to https://github.com/glue-viz/glue/pull/2432 - this keeps compatibility with the older versions of glue-core but uses the new import if possible.