### PR TITLE
Prevent destruction of `CircularAnnulusROI` by resizing below `inner_radius`

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -441,7 +441,8 @@ class BqplotCircularAnnulusMode(BqplotCircleMode):
                 if self._roi is None:
                     inner_r = outer_r * 0.5  # Hardcoded for now, user can edit later.
                 else:
-                    inner_r = self._roi.inner_radius
+                    # Resizing only changes outer r, avoid having inner_r >= outer_r afterwards.
+                    inner_r = min(self._roi.inner_radius, outer_r * 0.999999)
 
                 roi = CircularAnnulusROI(xc=xc, yc=yc, inner_radius=inner_r, outer_radius=outer_r)
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -31,7 +31,7 @@ class BqplotImageView(BqplotBaseView):
     _options_cls = ImageViewerStateWidget
 
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle', 'bqplot:polygon',
-             'bqplot:ellipse', 'bqplot:truecircle']
+             'bqplot:ellipse', 'bqplot:truecircle', 'bqplot:circannulus']
 
     def __init__(self, session):
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -30,8 +30,8 @@ class BqplotImageView(BqplotBaseView):
     _state_cls = BqplotImageViewerState
     _options_cls = ImageViewerStateWidget
 
-    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle', 'bqplot:polygon',
-             'bqplot:ellipse', 'bqplot:truecircle', 'bqplot:circannulus']
+    tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle',
+             'bqplot:ellipse', 'bqplot:polygon']
 
     def __init__(self, session):
 

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from nbconvert.preprocessors import ExecutePreprocessor
 from glue.core import Data
-from glue.core.roi import EllipticalROI
+from glue.core.roi import CircularAnnulusROI, EllipticalROI
 from ..common.tools import TrueCircularROI
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
@@ -303,6 +303,35 @@ def test_imshow_elliptical_brush(app, data_image):
     assert isinstance(roi, EllipticalROI)
     assert_allclose(roi.xc, 151.00)
     assert_allclose(roi.yc, 276.75)
+
+
+def test_imshow_circular_annulus_brush(app, data_image):
+
+    v = app.imshow(data=data_image)
+    v.state.aspect = 'auto'
+
+    tool = v.toolbar.tools['bqplot:circannulus']
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [(1.5, 3.5), (300.5, 550)]
+    tool.interact.brushing = False
+
+    roi = data_image.subsets[0].subset_state.roi
+    assert isinstance(roi, CircularAnnulusROI)
+    assert_allclose(roi.xc, 151.00)
+    assert_allclose(roi.yc, 276.75)
+    assert_allclose(roi.outer_radius, 211.375)
+    assert_allclose(roi.inner_radius, 105.6875)
+
+    tool.interact.brushing = True
+    tool.interact.selected = [(150.0, 400.0), (150.0, 450.0)]
+    tool.interact.brushing = False
+
+    # roi = data_image.subsets[0].subset_state.roi
+    assert_allclose(roi.xc, 151.00)
+    # assert_allclose(roi.yc, 326.75)  # trying to use `move`, but this is not how it works...
+    assert_allclose(roi.outer_radius, 211.375)
+    assert_allclose(roi.inner_radius, 105.6875)
 
 
 def test_imshow_equal_aspect(app, data_image):

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -3,6 +3,7 @@ import nbformat
 import numpy as np
 from numpy.testing import assert_allclose
 from nbconvert.preprocessors import ExecutePreprocessor
+from glue.config import viewer_tool
 from glue.core import Data
 from glue.core.roi import CircularAnnulusROI, EllipticalROI
 from ..common.tools import TrueCircularROI
@@ -271,24 +272,6 @@ def test_imshow_circular_brush(app, data_image):
     assert_allclose(roi.radius_y, 273.25)
 
 
-def test_imshow_true_circular_brush(app, data_image):
-
-    v = app.imshow(data=data_image)
-    v.state.aspect = 'auto'
-
-    tool = v.toolbar.tools['bqplot:truecircle']
-    tool.activate()
-    tool.interact.brushing = True
-    tool.interact.selected = [(1.5, 3.5), (300.5, 550)]
-    tool.interact.brushing = False
-
-    roi = data_image.subsets[0].subset_state.roi
-    assert isinstance(roi, TrueCircularROI)
-    assert_allclose(roi.xc, 151.00)
-    assert_allclose(roi.yc, 276.75)
-    assert_allclose(roi.radius, 220.2451)
-
-
 def test_imshow_elliptical_brush(app, data_image):
     v = app.imshow(data=data_image)
     v.state.aspect = 'auto'
@@ -305,12 +288,39 @@ def test_imshow_elliptical_brush(app, data_image):
     assert_allclose(roi.yc, 276.75)
 
 
+# Tools that are not part of the default set of BqplotImageView; manually added for testing
+def test_imshow_true_circular_brush(app, data_image):
+
+    v = app.imshow(data=data_image)
+    v.state.aspect = 'auto'
+
+    tool_id = 'bqplot:truecircle'
+    mode_cls = viewer_tool.members[tool_id]
+    v.toolbar.add_tool(mode_cls(v))
+
+    tool = v.toolbar.tools[tool_id]
+    tool.activate()
+    tool.interact.brushing = True
+    tool.interact.selected = [(1.5, 3.5), (300.5, 550)]
+    tool.interact.brushing = False
+
+    roi = data_image.subsets[0].subset_state.roi
+    assert isinstance(roi, TrueCircularROI)
+    assert_allclose(roi.xc, 151.00)
+    assert_allclose(roi.yc, 276.75)
+    assert_allclose(roi.radius, 220.2451)
+
+
 def test_imshow_circular_annulus_brush(app, data_image):
 
     v = app.imshow(data=data_image)
     v.state.aspect = 'auto'
 
-    tool = v.toolbar.tools['bqplot:circannulus']
+    tool_id = 'bqplot:circannulus'
+    mode_cls = viewer_tool.members[tool_id]
+    v.toolbar.add_tool(mode_cls(v))
+
+    tool = v.toolbar.tools[tool_id]
     tool.activate()
     tool.interact.brushing = True
     tool.interact.selected = [(1.5, 3.5), (300.5, 550)]

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -323,15 +323,8 @@ def test_imshow_circular_annulus_brush(app, data_image):
     assert_allclose(roi.outer_radius, 211.375)
     assert_allclose(roi.inner_radius, 105.6875)
 
-    tool.interact.brushing = True
-    tool.interact.selected = [(150.0, 400.0), (150.0, 450.0)]
-    tool.interact.brushing = False
-
-    # roi = data_image.subsets[0].subset_state.roi
-    assert_allclose(roi.xc, 151.00)
-    # assert_allclose(roi.yc, 326.75)  # trying to use `move`, but this is not how it works...
-    assert_allclose(roi.outer_radius, 211.375)
-    assert_allclose(roi.inner_radius, 105.6875)
+    # should try to test `move` and `resize` as well, but this probably
+    # needs to go through `update_selection` directly
 
 
 def test_imshow_equal_aspect(app, data_image):


### PR DESCRIPTION
## Description
https://github.com/glue-viz/glue-jupyter/pull/376#issuecomment-1664217504 brought to light an issue with the little-documented **resize** functionality of the bqplot brush tool when modifying `BqplotCircularAnnulusMode`: since the update from the modified `self._roi` only changes the outer and not the inner radius, it is possible to decrease the former below an invalid value `outer_radius <= inner_radius`, as a result destroying the subregion. This PR prevents this by keeping `inner_radius` just below `outer_radius`.
Such a minimal-width circular annulus will typically become impossible to manipulate interactively, but it still exists and can e.g. be restored to some sensible inner radius via the menu.

<img width="906" alt="Screenshot 2023-08-12 at 4 54 29 pm" src="https://github.com/glue-viz/glue-jupyter/assets/709020/025e14f7-092e-43bb-9489-d91491bbbc91">

![Screenshot 2023-08-12 at 5 01 40 pm](https://github.com/glue-viz/glue-jupyter/assets/709020/2b9de5a0-2be3-44f8-bc15-425ca8aae8f4)

I have added a basic test for creating this subset type, but was unable to emulate even the `move` operation this way, let alone resizing – pointers how to do this with `tool.interact` welcome.