### PR TITLE
Keep `scatter_mark.fill` updated from `self.state.fill`

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -253,10 +253,12 @@ class BqplotScatterLayerArtist(LayerArtist):
                     if force or "color" in changed or "cmap_mode" in changed or "fill" in changed:
                         self.scatter_mark.color = None
                         self.scatter_mark.colors = [color2hex(self.state.color)]
+                        self.scatter_mark.fill = self.state.fill
                 elif force or any(prop in changed for prop in CMAP_PROPERTIES) or "fill" in changed:
                     self.scatter_mark.color = ensure_numerical(
                         self.layer[self.state.cmap_att].ravel(),
                     )
+                    self.scatter_mark.fill = self.state.fill
                     self.scale_color_scatter.colors = colormap_to_hexlist(
                         self.state.cmap,
                     )


### PR DESCRIPTION
## Description
Fixes #382 – the link to `scatter_mark.fill` was apparently missed in #363. Not sure if the second `"fill" in changed` case is required, unsetting _fill markers_ worked as desired already with the first one.