### PR TITLE
Add bqplot-gl to `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     ipyvuetify>=1.2.0,<2
     bqplot-image-gl>=1.4.3
     bqplot>=0.12.17
+    bqplot-gl
     scikit-image
 
 [options.extras_require]


### PR DESCRIPTION
## Description
Follow-up to #302; this will be needed once bqplot 0.13 is out, which is currently in alpha.
As discussed in #377 with the placeholder package bqplot-gl 0.0.0 available, this can be added to the requirements.
If someone has a `bqplot>=0.13.0a0` installed, they will need to manually pick the alpha version or directly install
`'bqplot-gl==0.1.0a0` first.