### PR TITLE
Use :glueviz: alias instead of :glue-qt: for main glue docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ intersphinx_mapping = {
     'ipywidgets': ('https://ipywidgets.readthedocs.io/en/stable/', None),
     'traitlets': ('https://traitlets.readthedocs.io/en/stable/', None),
     'glue': ('https://glue-core.readthedocs.io/en/latest/', None),
-    'glue-qt': ('https://docs.glueviz.org/en/latest/', None),
+    'glueviz': ('https://docs.glueviz.org/en/latest/', None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/developer_notes.rst
+++ b/docs/developer_notes.rst
@@ -7,7 +7,7 @@ Understanding how the viewers are written
 Glue provides a standard infrastructure for developing custom viewers, which
 follows a common pattern regardless of whether these viewers are for the
 Jupyter platform, Qt, or other front-ends. This infrastructure is described in
-detail in :ref:`glue-qt:state-viewer`, and the different viewers here follow these
+detail in :ref:`glueviz:state-viewer`, and the different viewers here follow these
 guidelines.
 
 Linking custom widgets with glue state objects
@@ -20,7 +20,7 @@ interacting with the data object or the links, you can easily do so.
 As described in :doc:`getting_started`, each viewer and viewer layer has an
 associated state object, where a state object is a collection of properties.
 These properties can have callbacks assigned to them which get called when the
-properties change (see :ref:`glue-qt:state-viewer` for more details).
+properties change (see :ref:`glueviz:state-viewer` for more details).
 
 The `ipywidgets <https://ipywidgets.readthedocs.io/en/stable/>`_ package makes
 use of `traitlets <https://traitlets.readthedocs.io/en/stable/>`_ which provides
@@ -93,9 +93,9 @@ data objects, subsets, links, and many other parts of glue. See the following
 detailed tutorials to find out about the programmatic API for various key
 components of glue:
 
-* :ref:`glue-qt:data_tutorial` - for the data collection, data, and subsets
-* :ref:`glue-qt:linking-framework` - for the data linking framework
-* :ref:`glue-qt:communication` - for the event framework
+* :ref:`glueviz:data_tutorial` - for the data collection, data, and subsets
+* :ref:`glueviz:linking-framework` - for the data linking framework
+* :ref:`glueviz:communication` - for the event framework
 
 Inspecting glue messages being broadcast
 ----------------------------------------
@@ -144,4 +144,4 @@ You can add data to the viewer at creation time::
 
 Currently it is not possible to specific other configuration options
 at viewer creation time for plug-in viewer; they can still be modified
-programmatically (see :ref:`glue-qt:programmatic`)
+programmatically (see :ref:`glueviz:programmatic`)


### PR DESCRIPTION
Minor, but just to avoid referring to Qt