### PR TITLE
Keep subset menu open when deleting a subset

### DIFF
--- a/glue_jupyter/widgets/subset_select.vue
+++ b/glue_jupyter/widgets/subset_select.vue
@@ -44,7 +44,7 @@
                 <v-list-item-content>
                     <v-list-item-title>
                         <span style="line-height: 2.2">{{ subset.label }}</span>
-                        <v-btn icon @click="remove_subset(index)" class="float-right">
+                        <v-btn icon @click.stop="remove_subset(index); toggleSubset(index)" class="float-right">
                             <v-icon>mdi-delete</v-icon>
                         </v-btn>
                     </v-list-item-title>


### PR DESCRIPTION
## Description

This PR prevents the subset menu from closing when clicking on the "delete" icon for a subset, to enable deleting multiple subsets without having to repeatedly re-open the menu manually.  This retains the behavior that the menu should close when selecting a subset when multiple selections are disabled.

Calling `toggleSubset(index)` seems to be necessary in order for internal bookkeeping to remove the entry from the menu (which used to be called via event propagation, but is not prevented with the `@click.stop`).