### PR TITLE
Make bqplot linear scatter sizes more closely match matplotlib viewer

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -91,11 +91,9 @@ class BqplotScatterLayerArtist(LayerArtist):
 
         # Scatter points
 
-        self.scale_size_scatter = bqplot.LinearScale()
         self.scale_color_scatter = bqplot.ColorScale()
         self.scales_scatter = dict(
             self.view.scales,
-            size=self.scale_size_scatter,
             color=self.scale_color_scatter,
         )
 
@@ -270,15 +268,15 @@ class BqplotScatterLayerArtist(LayerArtist):
                             self.state.size * self.state.size_scaling,
                         )
                         self.scatter_mark.size = None
-                        self.scale_size_scatter.min = 0
-                        self.scale_size_scatter.max = 1
                     else:
-                        self.scatter_mark.default_size = int(self.state.size_scaling * 25)
-                        self.scatter_mark.size = ensure_numerical(
-                            self.layer[self.state.size_att].ravel()
-                        )
-                        self.scale_size_scatter.min = float_or_none(self.state.size_vmin)
-                        self.scale_size_scatter.max = float_or_none(self.state.size_vmax)
+                        self.scatter_mark.default_size = int(self.state.size_scaling * 7)
+                        s = ensure_numerical(self.layer[self.state.size_att].ravel())
+                        s = (s - self.state.size_vmin) / (self.state.size_vmax - self.state.size_vmin)
+                        np.clip(s, 0, 1, out=s)
+                        s *= 0.95
+                        s += 0.05
+                        s *= self.scatter_mark.default_size
+                        self.scatter_mark.size = s ** 2
 
         if (
             self.state.vector_visible

--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -271,7 +271,8 @@ class BqplotScatterLayerArtist(LayerArtist):
                     else:
                         self.scatter_mark.default_size = int(self.state.size_scaling * 7)
                         s = ensure_numerical(self.layer[self.state.size_att].ravel())
-                        s = (s - self.state.size_vmin) / (self.state.size_vmax - self.state.size_vmin)
+                        s = ((s - self.state.size_vmin) /
+                             (self.state.size_vmax - self.state.size_vmin))
                         np.clip(s, 0, 1, out=s)
                         s *= 0.95
                         s += 0.05

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,4 +1,4 @@
 {
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "3fe576be80889cc20063dd9e17f39899b2e40fb9a779eaa02e19b01181b332aa",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "f09681c1d9aea95612e4a268ab9ada15f5cb7c0158bfc5b13ccb0c890779feb2"
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "edd4e65c87369bc6e403f45e87d914223bc13f42c2f90a55535614923e233c00",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "60f38b822f89603874cd508e0c320db92185129631dd89a58624dd667eb8a5a7"
 }


### PR DESCRIPTION
This PR aims to resolve #392 by making the linear size scaling behave more similarly to that of the matplotlib viewer. To do this, I ended up not using the size scales for the layer, but rather following the matplotlib viewer's example and capping the size.

FWIW, my initial thought was to do something like
```
s = ensure_numerical(self.layer[self.state.size_att].ravel())
s = (s - self.state.size_vmin) / (self.state.size_vmax - self.state.size_vmin)
np.clip(s, self.state.size_vmin, self.state.size_vmax, out=s)
s *= 0.95
s += 0.05 * (self.state.size_vmax - self.state.size_vmin)
s *= self.scatter_mark.default_size
self.scatter_mark.size = s ** 2

self.scale_size_scatter.min = float_or_none(self.state.size_vmin ** 2)
self.scale_size_scatter.max = float_or_none(self.state.size_vmax ** 2)
```

but that gave results that differed from the matplotlib implementation when `size_vmin` was nonzero (like e.g. the example data in #392).