### PR TITLE
Fix issues with adjusting min/max values for size and cmap

### DIFF
--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -9,10 +9,10 @@
                 <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
             <div>
-                <v-text-field label="min" v-model="glue_state.cmap_vmin" hide-details></v-text-field>
+                <glue-float-field label="min" :value.sync="glue_state.cmap_vmin" />
             </div>
             <div>
-                <v-text-field label="max" v-model="glue_state.cmap_vmax" hide-details></v-text-field>
+                <glue-float-field label="max" :value.sync="glue_state.cmap_vmax" />
             </div>
             <div>
                 <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
@@ -39,10 +39,10 @@
                     <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
                 <div>
-                    <v-text-field label="min" v-model="glue_state.size_vmin" hide-details></v-text-field>
+                    <glue-float-field label="min" :value.sync="glue_state.size_vmin" />
                 </div>
                 <div>
-                    <v-text-field label="max" v-model="glue_state.size_vmax" hide-details></v-text-field>
+                    <glue-float-field label="max" :value.sync="glue_state.size_vmax" />
                 </div>
             </template>
             <template v-if="glue_state.density_map">

--- a/glue_jupyter/state_traitlets_helpers.py
+++ b/glue_jupyter/state_traitlets_helpers.py
@@ -72,7 +72,7 @@ def update_state_from_dict(state, changes):
                                 callback_dict[k] = changes[name][k]
             else:
                 if changes[name] != MAGIC_IGNORE and getattr(state, name) != changes[name]:
-                    if 'cmap' in name:
+                    if name == 'cmap':
                         if changes[name] != state.cmap.name:
                             setattr(state, name, get_cmap(changes[name]))
                     else:


### PR DESCRIPTION
Currently there are two issues with adjusting values for scatter layer options, both of which this PR fixes:
* In linear (colormap) mode, the min and max values for the cmap can't be set from the widget. If the values are updated externally, the widget will update, but changing values from the widget has no effect (that is, the value in the state is not updated). The reason for this is that the deserialization line [here](https://github.com/glue-viz/glue-jupyter/blob/main/glue_jupyter/state_traitlets_helpers.py#L75) catches `cmap_vmin` and `cmap_vmax` as well as `cmap`.
* The text fields used for the min/max size values in linear size mode (and those for the colormap after the above issue is fixed) update the state values to be strings rather than numbers. I think the correct fix for this (which this PR applies) is to use the `glue-float-field` component for handling these values.