### PR TITLE
Preserve rotation angle under dragging for ellipse and rectangle selection tools

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -170,6 +170,9 @@ class BqplotRectangleMode(BqplotSelectionTool):
                 self.interact.selected_y = [np.min(roi.vy), np.max(roi.vy)]
             else:
                 raise TypeError(f'Cannot initialize a BqplotRectangleMode from a {type(roi)}')
+            # FIXME: the brush selector does not actually update unless the
+            # widget is resized/refreshed, see
+            # https://github.com/bloomberg/bqplot/issues/1067
 
     def on_selection_change(self, *args):
         if self.interact.selected_x is None or self.interact.selected_y is None:


### PR DESCRIPTION
In Jdaviz, you can rotate ellipse and rectangle ROIs using Subset Tools plugin. After that is done, and user wants to click and drag the shape, without this patch, the rotation resets. This patch preserves any existing rotation. Since I really don't want to implement theta support in JS (e.g., https://github.com/glue-viz/bqplot-image-gl/blob/main/js/lib/BrushEllipseSelector.js), during the dragging phase, the gray shape has no rotation, but the rotation comes back when you finalize the drag.

cc @astrofrog and @dhomeier 

[🐱](https://jira.stsci.edu/browse/JDAT-3717)