### PR TITLE
Ensure that layer widget color is a hex value

### DIFF
--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -8,7 +8,7 @@ import traitlets
 import ipywidgets as widgets
 from glue.core import message as msg
 from glue.core.hub import HubListener
-from glue.utils import avoid_circular
+from glue.utils import avoid_circular, color2hex
 
 from ..vuetify_helpers import WidgetCache
 
@@ -59,7 +59,7 @@ class LayerOptionsWidget(v.VuetifyTemplate, HubListener):
             label = layer_artist.state.layer.label
 
         return {
-            'color': getattr(layer_artist.state, 'color', ''),
+            'color': color2hex(getattr(layer_artist.state, 'color', '')),
             'label': label,
             'visible': layer_artist.state.visible,
         }

--- a/glue_jupyter/widgets/layer_options.py
+++ b/glue_jupyter/widgets/layer_options.py
@@ -58,8 +58,12 @@ class LayerOptionsWidget(v.VuetifyTemplate, HubListener):
         else:
             label = layer_artist.state.layer.label
 
+        color = getattr(layer_artist.state, 'color', '')
+        if color:
+            color = color2hex(color)
+
         return {
-            'color': color2hex(getattr(layer_artist.state, 'color', '')),
+            'color': color,
             'label': label,
             'visible': layer_artist.state.visible,
         }


### PR DESCRIPTION
The layer options widget currently has an issue with grayscale color strings, which are often used as the default data color (coming e.g. from [here](https://github.com/glue-viz/glue-qt/blob/main/glue_qt/app/preferences.py#L131)). This can lead to the widget for the layer incorrectly showing the layer as white, or incorrectly showing the color as that of another layer after changing the selected layer or adjusting the z-order.

This happens because grayscale colors are not valid CSS color values, and thus the Vue template can't handle them. This PR fixes this issue by converting the grayscale string to a hex value. This is the same approach used elsewhere (e.g. [here](https://github.com/glue-viz/glue-jupyter/blob/main/glue_jupyter/bqplot/scatter/layer_artist.py#L253)).