### PR TITLE
Allow native aspect ratio in ipyvolume viewers

### DIFF
--- a/glue_jupyter/common/state3d.py
+++ b/glue_jupyter/common/state3d.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from glue.viewers.common.state import ViewerState
 from echo import (CallbackProperty, SelectionCallbackProperty)
 from glue.core.data_combo_helper import ComponentIDComboHelper
@@ -30,7 +32,7 @@ class ViewerState3D(ViewerState):
     visible_axes = CallbackProperty(True)
     # perspective_view = CallbackProperty(False)
     # clip_data = CallbackProperty(False)
-    # native_aspect = CallbackProperty(False)
+    native_aspect = CallbackProperty(False)
 
     limits_cache = CallbackProperty()
 
@@ -76,16 +78,18 @@ class ViewerState3D(ViewerState):
         self.z_lim_helper._cache = self.limits_cache
         self.z_lim_helper._update_attribute()
 
-    # @property
-    # def aspect(self):
-    #     # TODO: this could be cached based on the limits, but is not urgent
-    #     aspect = np.array([1, 1, 1], dtype=float)
-    #     if self.native_aspect:
-    #         aspect[0] = 1.
-    #         aspect[1] = (self.y_max - self.y_min) / (self.x_max - self.x_min)
-    #         aspect[2] = (self.z_max - self.z_min) / (self.x_max - self.x_min)
-    #         aspect /= aspect.max()
-    #     return aspect
+    @property
+    def aspect(self):
+        # note that for ipyvolume, we use axis in the order x, z, y in order to have
+        # the z axis of glue pointing up
+        # TODO: this could be cached based on the limits, but is not urgent
+        aspect = np.array([1, 1, 1], dtype=float)
+        if self.native_aspect:
+            aspect[0] = 1.
+            aspect[1] = (self.z_max - self.z_min) / (self.x_max - self.x_min)
+            aspect[2] = (self.y_max - self.y_min) / (self.x_max - self.x_min)
+            aspect /= aspect.max()
+        return aspect
 
     # def reset(self):
     #     pass

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -49,6 +49,7 @@ class IpyvolumeBaseView(IPyWidgetView):
             self.state.add_callback('z_max', self.limits_to_scales)
 
         self.state.add_callback('visible_axes', self._update_axes_visibility)
+        self.state.add_callback('native_aspect', self._update_aspect)
 
         self._figure_widget = ipv.gcc()
 
@@ -62,6 +63,9 @@ class IpyvolumeBaseView(IPyWidgetView):
             else:
                 ipv.style.axes_off()
                 ipv.style.box_off()
+
+    def _update_aspect(self, *args):
+        self.figure.box_size = self.state.aspect.tolist()
 
     @property
     def figure_widget(self):

--- a/glue_jupyter/ipyvolume/common/viewer_options_widget.py
+++ b/glue_jupyter/ipyvolume/common/viewer_options_widget.py
@@ -18,13 +18,16 @@ class Viewer3DStateWidget(VBox):
         self.widget_show_axes = Checkbox(value=False, description="Show axes")
         link((self.state, 'visible_axes'), (self.widget_show_axes, 'value'))
 
+        self.widget_native_aspect = Checkbox(value=False, description="Native aspect ratio")
+        link((self.state, 'native_aspect'), (self.widget_native_aspect, 'value'))
+
         self.widgets_axis = []
         for i, axis_name in enumerate('xyz'):
             widget_axis = LinkedDropdown(self.state, axis_name + '_att',
                                          label=axis_name + ' axis')
             self.widgets_axis.append(widget_axis)
 
-        super().__init__([self.widget_show_axes] + self.widgets_axis)
+        super().__init__([self.widget_show_axes, self.widget_native_aspect] + self.widgets_axis)
 
         if hasattr(self.state, 'figure'):
             self.widget_show_movie_maker = ToggleButton(value=False, description="Show movie maker")


### PR DESCRIPTION
Something that was requested during the last glue meeting was to expose an option to use the native aspect ratio in the ipyvolume viewers. This PR does that.

The only subtlety here is that we have to calculate the aspect in terms of x, z, y coordinates to account for the order in which we're using the ipyvolume axes in glue.