### PR TITLE
Expose opacity in profile viewer

### DIFF
--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -7,6 +7,10 @@
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
         <div>
+            <v-subheader class="pl-0 slider-label">opacity</v-subheader>
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
+        </div>
+        <div>
             <v-switch label="Plot as steps" v-model="as_steps" />
         </div>
     </div>


### PR DESCRIPTION
This PR implements another request from last week's meeting, which is to expose the opacity for profile layers to the UI.