### PR TITLE
Fix deprecated configuration key for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 
 sphinx:
   builder: html
@@ -9,7 +11,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Description
> The configuration key "build.image" is deprecated.

Unfortunately the replacement `os` only accepts a specific version and is also non-optional, so I see this break again whenever ubuntu-22.04 should be no longer available.