### PR TITLE
Don't set large data limits since the warning appears too late anyway

### DIFF
--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -15,7 +15,6 @@ class BqplotHistogramView(BqplotBaseView):
 
     allow_duplicate_data = False
     allow_duplicate_subset = False
-    large_data_size = 1e5
     is2d = False
 
     _state_cls = HistogramViewerState

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -22,7 +22,6 @@ class BqplotImageView(BqplotBaseView):
 
     allow_duplicate_data = False
     allow_duplicate_subset = False
-    large_data_size = 2e7
 
     _layer_style_widget_cls = {BqplotImageLayerArtist: ImageLayerStateWidget,
                                BqplotImageSubsetLayerArtist: ImageSubsetLayerStateWidget,

--- a/glue_jupyter/bqplot/scatter/viewer.py
+++ b/glue_jupyter/bqplot/scatter/viewer.py
@@ -17,7 +17,6 @@ class BqplotScatterView(BqplotBaseView):
 
     allow_duplicate_data = False
     allow_duplicate_subset = False
-    large_data_size = 1e7
 
     _state_cls = ScatterViewerState
     _options_cls = ScatterViewerStateWidget

--- a/glue_jupyter/ipyvolume/scatter/viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/viewer.py
@@ -11,7 +11,6 @@ class IpyvolumeScatterView(IpyvolumeBaseView):
 
     allow_duplicate_data = False
     allow_duplicate_subset = False
-    large_data_size = 1e7
 
     _state_cls = Scatter3DViewerState
     _options_cls = Viewer3DStateWidget

--- a/glue_jupyter/ipyvolume/volume/viewer.py
+++ b/glue_jupyter/ipyvolume/volume/viewer.py
@@ -14,8 +14,6 @@ __all__ = ['IpyvolumeVolumeView']
 
 class IpyvolumeVolumeView(IpyvolumeBaseView):
 
-    large_data_size = 1e8
-
     _state_cls = VolumeViewerState
     _options_cls = Viewer3DStateWidget
     _data_artist_cls = IpyvolumeVolumeLayerArtist

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -211,7 +211,6 @@ class TableViewerStateWidget(widgets.VBox):
 class TableViewer(IPyWidgetView):
     allow_duplicate_data = False
     allow_duplicate_subset = False
-    large_data_size = 1e100  # Basically infinite (a googol)
 
     _state_cls = TableState
     _options_cls = TableViewerStateWidget


### PR DESCRIPTION
This will stop the following warnings:

```
/Users/tom/Dropbox/Code/Glue/glue/glue/viewers/common/viewer.py:188: UserWarning: Add large data set?
  warnings.warn(message)
```

which appeared too late anyway and were not a real prompt. In future we could always choose to add a UI prompt in Jupyter and re-enable this.