### PR TITLE
Add entry points for viewer registry

### DIFF
--- a/glue_jupyter/bqplot/histogram/__init__.py
+++ b/glue_jupyter/bqplot/histogram/__init__.py
@@ -1,2 +1,6 @@
 from .layer_artist import *  # noqa
 from .viewer import *  # noqa
+
+
+def setup():
+    from viewer import BqplotHistogramView # noqa

--- a/glue_jupyter/bqplot/image/__init__.py
+++ b/glue_jupyter/bqplot/image/__init__.py
@@ -1,2 +1,6 @@
 from .layer_artist import *  # noqa
 from .viewer import *  # noqa
+
+
+def setup():
+    from viewer import BqplotImageView # noqa

--- a/glue_jupyter/bqplot/profile/__init__.py
+++ b/glue_jupyter/bqplot/profile/__init__.py
@@ -1,2 +1,6 @@
 from .layer_artist import *  # noqa
 from .viewer import *  # noqa
+
+
+def setup():
+    from viewer import BqplotProfileView # noqa

--- a/glue_jupyter/bqplot/scatter/__init__.py
+++ b/glue_jupyter/bqplot/scatter/__init__.py
@@ -1,2 +1,6 @@
 from .layer_artist import *  # noqa
 from .viewer import *  # noqa
+
+
+def setup():
+    from viewer import BqplotScatterView # noqa

--- a/glue_jupyter/ipyvolume/__init__.py
+++ b/glue_jupyter/ipyvolume/__init__.py
@@ -1,2 +1,6 @@
 from .volume.viewer import IpyvolumeVolumeView  # noqa
 from .scatter.viewer import IpyvolumeScatterView  # noqa
+
+
+def setup():
+    from viewer import IpyvolumeVolumeView  # noqa

--- a/glue_jupyter/ipyvolume/scatter/__init__.py
+++ b/glue_jupyter/ipyvolume/scatter/__init__.py
@@ -1,3 +1,7 @@
 from .layer_artist import *  # noqa
 from .layer_style_widget import *  # noqa
 from .viewer import *  # noqa
+
+
+def setup():
+    from viewer import IpyvolumeScatterView  # noqa

--- a/glue_jupyter/ipyvolume/scatter/viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/viewer.py
@@ -1,4 +1,6 @@
 from glue_jupyter.common.state3d import Scatter3DViewerState
+from glue_jupyter.registries import viewer_registry
+
 from .layer_artist import IpyvolumeScatterLayerArtist
 from .layer_style_widget import Scatter3DLayerStateWidget
 from ..common.viewer_options_widget import Viewer3DStateWidget
@@ -7,6 +9,7 @@ from ..common.viewer import IpyvolumeBaseView
 __all__ = ['IpyvolumeScatterView']
 
 
+@viewer_registry("scatter3d")
 class IpyvolumeScatterView(IpyvolumeBaseView):
 
     allow_duplicate_data = False

--- a/glue_jupyter/table/__init__.py
+++ b/glue_jupyter/table/__init__.py
@@ -1,1 +1,5 @@
 from .viewer import TableViewer  # noqa
+
+
+def setup():
+    from viewer import TableViewer  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,16 @@ install_requires =
     bqplot-gl
     scikit-image
 
+[options.entry_points]
+glue.plugins =
+    histogram = glue_jupyter.bqplot.histogram:setup
+    image = glue_jupyter.bqplot.image:setup
+    profile = glue_jupyter.bqplot.profile:setup
+    scatter = glue_jupyter.bqplot.scatter:setup
+    table = glue_jupyter.table:setup
+    scatter3d = glue_jupyter.ipyvolume.scatter:setup
+    volume = glue_jupyter.ipyvolume.volume:setup
+
 [options.extras_require]
 test =
     pytest


### PR DESCRIPTION
# Populate viewer registry for all viewers

## Description

This uses entry points to register all the viewers for glue-jupyter into viewer_registry. This addresses #388 and makes all viewers accessible through the `new_data_viewer()` command in glue-jupyter.  I think this should be compatible with #402, because the viewer registry won't double-populate the same viewers. I have added `IpyvolumeScatterView` as `scatter3d`.

Adding an entry point for glue-wwt will be a separate PR in that repository. 

Not 100% about the names here. 'image' is a convenient name for calling in code, but is less descriptive than something like '2d image'. This is particularly relevant for 'scatter' (unqualified) versus 'scatter3d'.  