### PR TITLE
Remove runipy from test requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
 test =
     pytest
     pytest-cov
-    runipy
     nbconvert>=6.4.5
     glue-core!=1.2.4; python_version == '3.10'
 visualtest =


### PR DESCRIPTION
## Description
runipy is deprecated and broken on Python 3.12; as I don't see it directly called anywhere, just trying to remove it right away.
Fixes #413