### PR TITLE
Support setting step value in glue-float-field

### DIFF
--- a/glue_jupyter/widgets/glue_float_field.vue
+++ b/glue_jupyter/widgets/glue_float_field.vue
@@ -2,6 +2,7 @@
     <v-text-field
             :label="label"
             :suffix="suffix"
+            :step="step"
             v-model="displayValue"
             type="number"
             :rules="[validNumber]"
@@ -13,7 +14,7 @@
        Only when `value` is changed externally, `displayValue` will be update according to the current `value`.
     */
     module.exports = {
-        props: ['value', 'label', 'suffix'],
+        props: ['value', 'label', 'suffix', 'step'],
         data: function() {
             return {
                 // default value is the one that was intially passed


### PR DESCRIPTION
Currently `glue-float-field` doesn't pass `step` along to `text-field`, this PR fixes that.