### PR TITLE
Set Bqplot*Modes to observe only one `selected` state in BrushSelector

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -141,8 +141,7 @@ class BqplotRectangleMode(BqplotSelectionTool):
             self.update_from_roi(roi)
 
         self.interact.observe(self.update_selection, "brushing")
-        self.interact.observe(self.on_selection_change, "selected_x")
-        self.interact.observe(self.on_selection_change, "selected_y")
+        self.interact.observe(self.on_selection_change, "selected")
         self.finalize_callback = finalize_callback
 
     def update_selection(self, *args):
@@ -219,8 +218,7 @@ class BqplotPolygonMode(BqplotSelectionTool):
 
         self._lasso = False
         self.interact.observe(self.update_selection, "brushing")
-        self.interact.observe(self.on_selection_change, "selected_x")
-        self.interact.observe(self.on_selection_change, "selected_y")
+        self.interact.observe(self.on_selection_change, "selected")
         self.finalize_callback = finalize_callback
 
     def update_selection(self, *args):
@@ -378,8 +376,7 @@ class BqplotCircleMode(BqplotSelectionTool):
             self.update_from_roi(roi)
 
         self.interact.observe(self.update_selection, "brushing")
-        self.interact.observe(self.on_selection_change, "selected_x")
-        self.interact.observe(self.on_selection_change, "selected_y")
+        self.interact.observe(self.on_selection_change, "selected")
         self.finalize_callback = finalize_callback
 
     def update_selection(self, *args):
@@ -481,8 +478,7 @@ class BqplotEllipseMode(BqplotCircleMode):
             self.update_from_roi(roi)
 
         self.interact.observe(self.update_selection, "brushing")
-        self.interact.observe(self.on_selection_change, "selected_x")
-        self.interact.observe(self.on_selection_change, "selected_y")
+        self.interact.observe(self.on_selection_change, "selected")
         self.finalize_callback = finalize_callback
 
 


### PR DESCRIPTION
## Description

Pushing this as a test to avoid possible race conditions in observing both `selected_x` and `selected_y` in the BrushSelector interaction that have been speculated to cause unwanted size changes of the selection in #418.

Since the reported bug is non-deterministic and I have not been able to reproduce it at all, I have no idea if this change will help, just keeping it here for further investigation.