### PR TITLE
Set `InteractCheckableTool._roi` to `None` on `deactivate`

### DIFF
--- a/glue_jupyter/bqplot/common/tools.py
+++ b/glue_jupyter/bqplot/common/tools.py
@@ -48,6 +48,8 @@ class InteractCheckableTool(CheckableTool):
 
     def deactivate(self):
         self.viewer._mouse_interact.next = None
+        if hasattr(self, '_roi'):
+            self._roi = None
 
 
 class BqplotSelectionTool(InteractCheckableTool):


### PR DESCRIPTION
## Description
Reset any `_roi` in an `InteractCheckableTool` when calling `deactivate`.
This is to avoid inheriting changed attributes like rotation angle from previously created selections. It will not reset the attributes when creating new ROIs with the same (left open) tool instance.