### PR TITLE
TMP: try out OA fork to fix macos images

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -20,7 +20,7 @@ jobs:
 
   tests:
     needs: initial_checks
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: astrofrog/github-actions-workflows/.github/workflows/tox.yml@tox-mac-image
     with:
       coverage: codecov
       libraries: |


### PR DESCRIPTION
Currently py38 and py39 tox jobs fail because they are running on macos-14