### PR TITLE
Add support for 3D VisPy viewers

### DIFF
--- a/glue_jupyter/app.py
+++ b/glue_jupyter/app.py
@@ -371,7 +371,7 @@ class JupyterApplication(Application):
         view.layers[0].state.update_from_dict(layer_state)
         return view
 
-    def scatter3d(self, *, data=None, x=None, y=None, z=None, show=True):
+    def scatter3d(self, *, data=None, x=None, y=None, z=None, widget='ipyvolume', show=True):
         """
         Open an interactive 3d scatter plot viewer.
 
@@ -387,17 +387,26 @@ class JupyterApplication(Application):
             The attribute to show on the y axis.
         z : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the z axis.
+        widget : {'ipyvolume', 'vispy'}
+            Whether to use ipyvolume or VisPy as the front-end.
         show : bool, optional
             Whether to show the view immediately (`True`) or whether to only
             show it later if the ``show()`` method is called explicitly
             (`False`).
         """
 
-        from .ipyvolume import IpyvolumeScatterView
+        if widget == 'ipyvolume':
+            from .ipyvolume import IpyvolumeScatterView
+            viewer_cls = IpyvolumeScatterView
+        elif widget == 'vispy':
+            from glue_vispy_viewers.scatter.jupyter import JupyterVispyScatterViewer
+            viewer_cls = JupyterVispyScatterViewer
+        else:
+            raise ValueError("widget= should be 'ipyvolume' or 'vispy'")
 
         data = validate_data_argument(self.data_collection, data)
 
-        view = self.new_data_viewer(IpyvolumeScatterView, data=data, show=show)
+        view = self.new_data_viewer(viewer_cls, data=data, show=show)
         if x is not None:
             x = data.id[x]
             view.state.x_att = x
@@ -500,7 +509,7 @@ class JupyterApplication(Application):
 
         return view
 
-    def volshow(self, *, data=None, x=None, y=None, z=None, show=True):
+    def volshow(self, *, data=None, x=None, y=None, z=None, widget='ipyvolume', show=True):
         """
         Open an interactive volume viewer.
 
@@ -519,16 +528,26 @@ class JupyterApplication(Application):
         z : str or `~glue.core.component_id.ComponentID`, optional
             The attribute to show on the z axis. This should be one of the
             pixel axis attributes.
+        widget : {'ipyvolume', 'vispy'}
+            Whether to use ipyvolume or VisPy as the front-end.
         show : bool, optional
             Whether to show the view immediately (`True`) or whether to only
             show it later if the ``show()`` method is called explicitly
             (`False`).
          """
-        from .ipyvolume import IpyvolumeVolumeView
+
+        if widget == 'ipyvolume':
+            from .ipyvolume import IpyvolumeVolumeView
+            viewer_cls = IpyvolumeVolumeView
+        elif widget == 'vispy':
+            from glue_vispy_viewers.volume.jupyter import JupyterVispyVolumeViewer
+            viewer_cls = JupyterVispyVolumeViewer
+        else:
+            raise ValueError("widget= should be 'ipyvolume' or 'vispy'")
 
         data = validate_data_argument(self.data_collection, data)
 
-        view = self.new_data_viewer(IpyvolumeVolumeView, data=data, show=show)
+        view = self.new_data_viewer(viewer_cls, data=data, show=show)
 
         if x is not None:
             x = data.id[x]

--- a/glue_jupyter/conftest.py
+++ b/glue_jupyter/conftest.py
@@ -76,6 +76,9 @@ else:
     SOLARA_INSTALLED = True
 
 
+import vispy  # noqa
+vispy.use('jupyter_rfb')
+
 # Tweak IPython's display to not print out lots of __repr__s for widgets to
 # standard output. However, if we are using solara, we shouldn't do this as
 # it seems to cause issues.

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,8 +87,8 @@ filterwarnings =
     ignore::FutureWarning:traitlets.*:
     # numpy/linalg/linalg.py:2514 (1.21) or numpy/core/_asarray.py:83 (1.19):
     # `x = asarray(x)` - triggered by `example_volume` from `ipv.examples.ball()
-    ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.core.*:
-    ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning:numpy.linalg.*:
+    ignore:Creating an ndarray from ragged nested sequences::numpy.core.*:
+    ignore:Creating an ndarray from ragged nested sequences::numpy.linalg.*:
     ignore:'contextfilter' is renamed to 'pass_context':DeprecationWarning:
     # potentially more serious, but possibly also only erratic - report them, but don't raise
     # ignore:numpy.ndarray size changed:RuntimeWarning:astropy.*:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ setup_requires =
   setuptools_scm
 install_requires =
     glue-core>=1.20.0
-    glue-vispy-viewers>=1.0
+    glue-vispy-viewers[jupyter]>=1.2.1
     notebook>=4.0
     ipympl>=0.3.0
     ipyvolume>=0.5.0


### PR DESCRIPTION
This exposes the vispy viewers as optional widgets for ``scatter3d`` and ``volshow``, as alternatives to ipyvolume.

This requires:

* https://github.com/glue-viz/glue-vispy-viewers/pull/381