### PR TITLE
Updates for ipyvolume viewer issues

### DIFF
--- a/glue_jupyter/common/state3d.py
+++ b/glue_jupyter/common/state3d.py
@@ -85,7 +85,7 @@ class ViewerState3D(ViewerState):
         # TODO: this could be cached based on the limits, but is not urgent
         aspect = np.array([1, 1, 1], dtype=float)
         if self.native_aspect:
-            aspect[0] = 1.
+            aspect[0] = 1.0
             aspect[1] = (self.z_max - self.z_min) / (self.x_max - self.x_min)
             aspect[2] = (self.y_max - self.y_min) / (self.x_max - self.x_min)
             aspect /= aspect.max()

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -86,12 +86,10 @@ class IpyvolumeBaseView(IPyWidgetView):
             self._session.command_stack.do(cmd)
 
     def limits_to_scales(self, *args):
-        if self.state.x_min is not None and self.state.x_max is not None:
-            self.figure.xlim = self.state.y_min, self.state.y_max
         if self.state.y_min is not None and self.state.y_max is not None:
+            self.figure.xlim = self.state.y_min, self.state.y_max
+        if self.state.x_min is not None and self.state.x_max is not None:
             self.figure.zlim = self.state.x_min, self.state.x_max
-        # if self.state.z_min is not None and self.state.z_max is not None:
-        #     self.figure.zlim = self.state.z_min, self.state.z_max
         if hasattr(self.state, 'z_min'):
             if self.state.z_min is not None and self.state.z_max is not None:
                 self.figure.ylim = self.state.z_min, self.state.z_max

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -31,7 +31,7 @@ class IpyvolumeBaseView(IPyWidgetView):
         # FIXME: hack for the movie maker to have access to the figure
         self.state.figure = self.figure
 
-        # note that for ipyvolume, we use axis in the order x, z, y in order to have
+        # note that for ipyvolume, we use axis in the order z, x, y in order to have
         # the z axis of glue pointing up
         def attribute_to_label(attribute):
             return 'null' if attribute is None else attribute.label
@@ -87,9 +87,9 @@ class IpyvolumeBaseView(IPyWidgetView):
 
     def limits_to_scales(self, *args):
         if self.state.x_min is not None and self.state.x_max is not None:
-            self.figure.xlim = self.state.x_min, self.state.x_max
+            self.figure.xlim = self.state.y_min, self.state.y_max
         if self.state.y_min is not None and self.state.y_max is not None:
-            self.figure.zlim = self.state.y_min, self.state.y_max
+            self.figure.zlim = self.state.x_min, self.state.x_max
         # if self.state.z_min is not None and self.state.z_max is not None:
         #     self.figure.zlim = self.state.z_min, self.state.z_max
         if hasattr(self.state, 'z_min'):

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -36,8 +36,8 @@ class IpyvolumeBaseView(IPyWidgetView):
         def attribute_to_label(attribute):
             return 'null' if attribute is None else attribute.label
 
-        dlink((self.state, 'x_att'), (self.figure, 'xlabel'), attribute_to_label)
-        dlink((self.state, 'y_att'), (self.figure, 'zlabel'), attribute_to_label)
+        dlink((self.state, 'x_att'), (self.figure, 'zlabel'), attribute_to_label)
+        dlink((self.state, 'y_att'), (self.figure, 'xlabel'), attribute_to_label)
         dlink((self.state, 'z_att'), (self.figure, 'ylabel'), attribute_to_label)
 
         self.state.add_callback('x_min', self.limits_to_scales)

--- a/glue_jupyter/ipyvolume/scatter/layer_artist.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_artist.py
@@ -94,7 +94,7 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
         if np.issubdtype(arr.dtype, np.floating):
             return arr
 
-        # `itemsize` returns the byte size of the dtype 
+        # `itemsize` returns the byte size of the dtype
         size = 8 * arr.dtype.itemsize
         return arr.astype(f"float{size}")
 
@@ -103,9 +103,12 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
 
     def update(self):
         # we don't use layer, but layer.data to get everything
-        self.scatter.z = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel())
-        self.scatter.y = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel())
-        self.scatter.x = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel())
+        self.scatter.z = self._cast_to_float(
+                ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel())
+        self.scatter.y = self._cast_to_float(
+                ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel())
+        self.scatter.x = self._cast_to_float(
+                ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel())
         self.quiver.x = self.scatter.x
         self.quiver.z = self.scatter.y
         self.quiver.y = self.scatter.z

--- a/glue_jupyter/ipyvolume/scatter/layer_artist.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_artist.py
@@ -90,14 +90,22 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
     def _update_xyz_att(self, *args):
         self.update()
 
+    def _cast_to_float(self, arr):
+        if np.issubdtype(arr.dtype, np.floating):
+            return arr
+
+        # `itemsize` returns the byte size of the dtype 
+        size = 8 * arr.dtype.itemsize
+        return arr.astype(f"float{size}")
+
     def redraw(self):
         pass
 
     def update(self):
         # we don't use layer, but layer.data to get everything
-        self.scatter.z = ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel()
-        self.scatter.y = ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel()
-        self.scatter.x = ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel()
+        self.scatter.z = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel())
+        self.scatter.y = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel())
+        self.scatter.x = self._cast_to_float(ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel())
         self.quiver.x = self.scatter.x
         self.quiver.z = self.scatter.y
         self.quiver.y = self.scatter.z

--- a/glue_jupyter/ipyvolume/scatter/layer_artist.py
+++ b/glue_jupyter/ipyvolume/scatter/layer_artist.py
@@ -95,9 +95,9 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
 
     def update(self):
         # we don't use layer, but layer.data to get everything
-        self.scatter.x = ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel()
-        self.scatter.z = ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel()
+        self.scatter.z = ensure_numerical(self.layer.data[self._viewer_state.x_att]).ravel()
         self.scatter.y = ensure_numerical(self.layer.data[self._viewer_state.z_att]).ravel()
+        self.scatter.x = ensure_numerical(self.layer.data[self._viewer_state.y_att]).ravel()
         self.quiver.x = self.scatter.x
         self.quiver.z = self.scatter.y
         self.quiver.y = self.scatter.z
@@ -123,9 +123,9 @@ class IpyvolumeScatterLayerArtist(LayerArtist):
 
     def _update_quiver(self):
         with self.quiver.hold_sync():
-            self.quiver.vx = self.layer.data[self.state.vx_att].ravel()
-            self.quiver.vz = self.layer.data[self.state.vy_att].ravel()
+            self.quiver.vz = self.layer.data[self.state.vx_att].ravel()
             self.quiver.vy = self.layer.data[self.state.vz_att].ravel()
+            self.quiver.vx = self.layer.data[self.state.vy_att].ravel()
 
     def _update_size(self):
         size = self.state.size

--- a/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
+++ b/glue_jupyter/ipyvolume/scatter/tests/test_viewer.py
@@ -39,15 +39,15 @@ def test_labels(app, dataxyz):
     app.add_data(dataxyz)
     scatter = app.scatter3d(data=dataxyz)
     assert str(scatter.state.x_att) == 'x'
-    assert scatter.figure.xlabel == 'x'
+    assert scatter.figure.zlabel == 'x'
     assert str(scatter.state.y_att) == 'y'
-    assert scatter.figure.zlabel == 'y'
+    assert scatter.figure.xlabel == 'y'
     assert str(scatter.state.z_att) == 'z'
     assert scatter.figure.ylabel == 'z'
 
     scatter.state.x_att = dataxyz.id['y']
-    assert scatter.figure.xlabel == 'y'
+    assert scatter.figure.zlabel == 'y'
     scatter.state.y_att = dataxyz.id['z']
-    assert scatter.figure.zlabel == 'z'
+    assert scatter.figure.xlabel == 'z'
     scatter.state.z_att = dataxyz.id['x']
     assert scatter.figure.ylabel == 'x'

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -36,16 +36,16 @@ def test_scatter3d(app, dataxyz, dataxz):
     assert s.layers[1].layer['y'].tolist() == [4]
     assert s.layers[1].layer['z'].tolist() == [7]
 
-    assert s.layers[1].scatter.x.tolist() == [1, 2, 3]
-    assert s.layers[1].scatter.z.tolist() == [2, 3, 4]
+    assert s.layers[1].scatter.z.tolist() == [1, 2, 3]
+    assert s.layers[1].scatter.x.tolist() == [2, 3, 4]
     assert s.layers[1].scatter.y.tolist() == [5, 6, 7]
     assert s.layers[1].scatter.selected == [2]
 
     s.state.x_att = dataxyz.id['y']
     s.state.y_att = dataxyz.id['z']
     s.state.z_att = dataxyz.id['x']
-    assert s.layers[1].scatter.x.tolist() == [2, 3, 4]
-    assert s.layers[1].scatter.z.tolist() == [5, 6, 7]
+    assert s.layers[1].scatter.z.tolist() == [2, 3, 4]
+    assert s.layers[1].scatter.x.tolist() == [5, 6, 7]
     assert s.layers[1].scatter.y.tolist() == [1, 2, 3]
     assert s.layers[1].scatter.selected == [2]
 

--- a/glue_jupyter/ipyvolume/volume/layer_artist.py
+++ b/glue_jupyter/ipyvolume/volume/layer_artist.py
@@ -106,6 +106,8 @@ class IpyvolumeVolumeLayerArtist(VispyLayerArtist):
             data *= mask
         else:
             data = self.layer[self.state.attribute]
+
+        data = np.transpose(data, (2, 0, 1))
         finite_mask = np.isfinite(data)
         finite_data = data[finite_mask]
         finite_mask_normalized = finite_data - finite_data.min()


### PR DESCRIPTION
While Azmé and I were investigating the aspect ratio issue mentioned in #451, we noticed that currently, the displayed volume rendering in the ipyvolume viewer seems to be wrong (in particular, it doesn't match what's displayed in the vispy volume viewer). I believe this might also be a partial cause of #450.

I think this is an issue with axes. As an example, I looked at the reduced TAN C14 cube used in the astropy FITS cube tutorial [here](https://learn.astropy.org/tutorials/FITS-cubes.html). If I open this in vispy, I get
![Screenshot_2024-07-01_at_1 38 37_AM_optimized](https://github.com/glue-viz/glue-jupyter/assets/14281631/69bd9983-4c08-401f-8f83-b40083d90eb5)


but with the current ipyvolume viewer I get

![Screenshot_2024-07-01_at_1 41 10_AM_optimized](https://github.com/glue-viz/glue-jupyter/assets/14281631/d33c051c-eec3-4d1f-bb03-d49f788035e4)


which is what led me to believe that the data was being passed into the ipyvolume widget incorrectly. After rearranging the axes as is done in this PR (note that `np.transpose` returns a view if possible, so we shouldn't need to worry about data getting copied), we get
![Screenshot_2024-07-01_at_1 39 19_AM_optimized](https://github.com/glue-viz/glue-jupyter/assets/14281631/abdcb9a7-fa5d-4a0e-a358-0dd5fcd7bd4c)

This also fixes #451 for me, in that using the native aspect ratio now behaves the same as it does in vispy.

It's hard to tell how the changes to the ipyvolume viewer code  affect the 3D scatter viewer since as #449 points out, it isn't working right now. Only thing I can check is that with these changes, the x/y/z labels indicate that it has a right-handed z-up coordinate system, so that's good.