### PR TITLE
Remove debug panel in ipyvolume viewers

### DIFF
--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -51,7 +51,7 @@ class IpyvolumeBaseView(IPyWidgetView):
         self.state.add_callback('visible_axes', self._update_axes_visibility)
         self.state.add_callback('native_aspect', self._update_aspect)
 
-        self._figure_widget = ipv.gcc()
+        self._figure_widget = self.figure
 
         self.create_layout()
 

--- a/glue_jupyter/ipyvolume/common/viewer.py
+++ b/glue_jupyter/ipyvolume/common/viewer.py
@@ -25,6 +25,8 @@ class IpyvolumeBaseView(IPyWidgetView):
 
         self.figure = ipv.figure(animation_exponent=1.)
         self.figure.selector = ''
+        self.figure.width = 600
+        self._figure_widget = self.figure
 
         super(IpyvolumeBaseView, self).__init__(*args, **kwargs)
 
@@ -50,8 +52,6 @@ class IpyvolumeBaseView(IPyWidgetView):
 
         self.state.add_callback('visible_axes', self._update_axes_visibility)
         self.state.add_callback('native_aspect', self._update_aspect)
-
-        self._figure_widget = self.figure
 
         self.create_layout()
 


### PR DESCRIPTION
This PR removes the side debug panel in the ipyvolume viewers. Thanks to @maartenbreddels for the tip on how to do this.

This also increases the default size of the figure itself from 400 -> 600px, as I couldn't see the entire bounding box with a 400px width. Happy to increase the size further if desired.