### PR TITLE
Allow using non-SVG icons in toolbar

### DIFF
--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -70,14 +70,17 @@ class BasicJupyterToolbar(v.VuetifyTemplate):
     def add_tool(self, tool):
         self.tools[tool.tool_id] = tool
         # TODO: we should ideally just incorporate this check into icon_path directly.
+        ext = os.path.splitext(tool.icon)[1][1:] or "svg"
         if os.path.exists(tool.icon):
             path = tool.icon
         else:
-            path = icon_path(tool.icon, icon_format='svg')
+            path = icon_path(tool.icon, icon_format=ext)
+
+        format = "svg+xml" if ext == "svg" else ext
         self.tools_data = {
             **self.tools_data,
             tool.tool_id: {
                 'tooltip': tool.tool_tip,
-                'img': read_icon(path, 'svg+xml')
+                'img': read_icon(path, format)
             }
         }

--- a/glue_jupyter/common/toolbar_vuetify.py
+++ b/glue_jupyter/common/toolbar_vuetify.py
@@ -1,3 +1,4 @@
+from mimetypes import guess_type
 import os
 import ipyvuetify as v
 import traitlets
@@ -76,7 +77,11 @@ class BasicJupyterToolbar(v.VuetifyTemplate):
         else:
             path = icon_path(tool.icon, icon_format=ext)
 
-        format = "svg+xml" if ext == "svg" else ext
+        format = guess_type(path)[0]
+        image_prefix = "image/"
+        if format is None or not format.startswith(image_prefix):
+            raise ValueError(f"Invalid or unknown image MIME type for: {path}")
+        format = format[len(image_prefix):]
         self.tools_data = {
             **self.tools_data,
             tool.tool_id: {


### PR DESCRIPTION
Currently the way the Jupyter toolbar is set up, we can only use SVG icons. This is usually fine, as most of our glue-core icons are available as both png or svg. However, there are some icons (the rotation icon in the vispy viewers, for example) for which we only have pngs.

This PR updates the format that gets passed to `icon_path` to depend on the path for the icon. If a valid image MIME type can't be determined, then it raises an error.