### PR TITLE
Disable scatter viewer density map image broadcast when not visible

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -146,6 +146,7 @@ class BqplotScatterLayerArtist(LayerArtist):
             vmin=self.density_auto_limits.min,
             vmax=self.density_auto_limits.max,
             histogram2d_func=self.compute_density_map,
+            visible=False
         )
 
         self.view.figure.marks = list(self.view.figure.marks) + [

--- a/glue_jupyter/bqplot/scatter/scatter_density_mark.py
+++ b/glue_jupyter/bqplot/scatter/scatter_density_mark.py
@@ -108,6 +108,7 @@ class GenericDensityMark(ImageGL):
         self.observe(self._update_rendered_image, "vmin")
         self.observe(self._update_rendered_image, "vmax")
         self.observe(self._update_rendered_image, "stretch")
+        self.observe(self._update_rendered_image, "visible")
 
         self._scale_image = ColorScale()
         self._scales = {

--- a/glue_jupyter/bqplot/scatter/scatter_density_mark.py
+++ b/glue_jupyter/bqplot/scatter/scatter_density_mark.py
@@ -69,6 +69,7 @@ class GenericDensityMark(ImageGL):
         stretch=None,
         dpi=None,
         external_padding=None,
+        visible=True,
     ):
 
         # FIXME: need to use weakref to avoid circular references
@@ -91,6 +92,7 @@ class GenericDensityMark(ImageGL):
         self.vmin = vmin
         self.vmax = vmax
         self.stretch = stretch
+        self.visible = visible
 
         if dpi is not None:
             self.dpi = dpi
@@ -194,7 +196,7 @@ class GenericDensityMark(ImageGL):
 
     def _update_rendered_image(self, *args, **kwargs):
 
-        if self._counts is None:
+        if self._counts is None or not self.visible:
             self.image = EMPTY_IMAGE
             return
 


### PR DESCRIPTION
This PR prevents glue from broadcasting a large binary image for scatter viewers when the density map is not in use.

This still needs testing to ensure that density maps still continue to function as designed.
