### PR TITLE
Choose 'png' image compression in BqplotImageView by default

### DIFF
--- a/glue_jupyter/bqplot/image/frb_mark.py
+++ b/glue_jupyter/bqplot/image/frb_mark.py
@@ -17,7 +17,7 @@ EMPTY_IMAGE = np.zeros((10, 10, 4), dtype=np.uint8)
 
 class FRBImage(ImageGL):
 
-    def __init__(self, viewer, array_maker):
+    def __init__(self, viewer, array_maker, compression='png'):
 
         # FIXME: need to use weakref to avoid circular references
         self.viewer = viewer
@@ -29,7 +29,7 @@ class FRBImage(ImageGL):
                        'y': self.viewer.scale_y,
                        'image': self.scale_image}
 
-        super().__init__(image=EMPTY_IMAGE, scales=self.scales)
+        super().__init__(image=EMPTY_IMAGE, scales=self.scales, compression=compression)
 
         self.array_maker = array_maker
 

--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -34,14 +34,14 @@ class BqplotImageView(BqplotBaseView):
     tools = ['bqplot:home', 'bqplot:panzoom', 'bqplot:rectangle', 'bqplot:circle',
              'bqplot:ellipse', 'bqplot:polygon', 'bqplot:lasso']
 
-    def __init__(self, session):
+    def __init__(self, session, compression='png'):
 
         super(BqplotImageView, self).__init__(session)
 
         self.shape = None
 
         self._composite = CompositeArray()
-        self._composite_image = FRBImage(self, self._composite)
+        self._composite_image = FRBImage(self, self._composite, compression=compression)
         self.figure.marks = list(self.figure.marks) + [self._composite_image]
         self.state.add_callback('reference_data', self._reset_limits, echo_old=True)
         self.state.add_callback('x_att', self._reset_limits, echo_old=True)

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,5 +1,5 @@
 {
-  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "53ed6a698cd0fe879f92a7c428e14878e80b2640a8e09d69bb82c3847041bfb9",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "91fe92465a858548adcfba167b4402c61b927dd4da61dd1ed486f9fed84d5915",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "d3bd7a7ff60cff14154f50bd75c5b8821cbd25009b01600691ca35b568783c43"
+  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "19517fbbea156e9569a2e6367e926e9f301bb27e8d2f600b42cf4577aa9064d4",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "d8cd6c7f5d85975aaea515c0b0fd1c715ed0823ddd8e85d05d69255eefee0a0a",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "da3864b8e513e7a7b43d58172ae85a6a56180a91c1f5e0de9545ca56ac6d6cfe"
 }

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,5 +1,5 @@
 {
   "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "19517fbbea156e9569a2e6367e926e9f301bb27e8d2f600b42cf4577aa9064d4",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "d8cd6c7f5d85975aaea515c0b0fd1c715ed0823ddd8e85d05d69255eefee0a0a",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "da3864b8e513e7a7b43d58172ae85a6a56180a91c1f5e0de9545ca56ac6d6cfe"
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "91fe92465a858548adcfba167b4402c61b927dd4da61dd1ed486f9fed84d5915",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "d3bd7a7ff60cff14154f50bd75c5b8821cbd25009b01600691ca35b568783c43"
 }

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,5 +1,5 @@
 {
-  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "19517fbbea156e9569a2e6367e926e9f301bb27e8d2f600b42cf4577aa9064d4",
+  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "94a99faec5500df042edde00e9cdef58e230d68e9a762c1cd0ed0499eb0de83f",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "91fe92465a858548adcfba167b4402c61b927dd4da61dd1ed486f9fed84d5915",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "d3bd7a7ff60cff14154f50bd75c5b8821cbd25009b01600691ca35b568783c43"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=1.4.3
+    bqplot-image-gl>=1.5.0
     bqplot>=0.12.17
     bqplot-gl
     scikit-image


### PR DESCRIPTION
## Description

Allow users to take advantage of PNG compression via `ImageGL` from https://github.com/glue-viz/bqplot-image-gl/pull/109. Bumping pin for `bqplot-image-gl`.