### PR TITLE
Try and improve responsiveness when debounced isn't really needed

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -54,6 +54,15 @@ class BqplotImageView(BqplotBaseView):
         on_change([(self.state, 'aspect')])(self._sync_figure_aspect)
         self._sync_figure_aspect()
 
+    def _update_bqplot_limits(self, *args, **kwargs):
+        # When the user explicitly changes the limits, we want the update to
+        # be immediate - debouncing should be ideally used mostly for preventing
+        # many successive updates from the front-end, e.g. when panning, but
+        # programmatically changing things should be immediate.
+        super()._update_bqplot_limits(*args, **kwargs)
+        if hasattr(self, '_composite_image'):
+            self._composite_image.update()
+
     def _update_axes(self, *args):
 
         if self.state.x_att_world is not None:


### PR DESCRIPTION
The main motivation for ``@debounced`` is to avoid many repeated updates when e.g. panning/zooming or doing other front-end changes. However, currently, there are cases where relying on debounced is not desirable, e.g.:

```
image.state.reset_limits()
time.sleep(3)
```

In this case, if this code is in a cell, the figure won't be updated until after the sleep because the callback for the debounced update is not in a separate thread. The long-term fix would be to try and make sure glue and glue-jupyter are thread-safe and use a thread in this case, but for now, a simple fix is to simply treat updates in limits similarly to e.g. updates in ``percentile``, ``cmap`` and so on, and make sure those changes result in an immediate update in the figure.

This PR also adds a check to avoid unnecessary repeated updates in ``.update()``