### PR TITLE
EXP: Attempt to run ViewListener inside a thread

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -1,3 +1,5 @@
+from threading import Thread
+
 from glue.viewers.image.composite_array import CompositeArray
 from bqplot_image_gl.viewlistener import ViewListener
 
@@ -49,7 +51,8 @@ class BqplotImageView(BqplotBaseView):
         self.state.add_callback('x_att_world', self._update_axes)
         self.state.add_callback('y_att_world', self._update_axes)
 
-        self._setup_view_listener()
+        t = Thread(target = self._setup_view_listener)
+        t.start()
 
         on_change([(self.state, 'aspect')])(self._sync_figure_aspect)
         self._sync_figure_aspect()


### PR DESCRIPTION
This is an experiment to see what happens when we try and use threads in glue-jupyter. This PR is trying to solve the issue mentioned in #472, specifically that:

```
app.imshow()
time.sleep(10)
```

would not show any image until after the sleep, because the callback from the ``ViewListener`` is not executed until then. I naively thought that doing something like in this PR would help - setting up and running the ``ViewListener`` inside a thread, but this does not help - the ``_on_view_change`` method is still only called after the rest of the cell has run.

@maartenbreddels  - do you understand what might be going on and why this does not work?