### PR TITLE
Make limits cache private for serialization

### DIFF
--- a/glue_jupyter/common/state3d.py
+++ b/glue_jupyter/common/state3d.py
@@ -34,7 +34,7 @@ class ViewerState3D(ViewerState):
     # clip_data = CallbackProperty(False)
     native_aspect = CallbackProperty(False)
 
-    limits_cache = CallbackProperty()
+    _limits_cache = CallbackProperty()
 
     # def _update_priority(self, name):
     #     if name == 'layers':
@@ -48,34 +48,34 @@ class ViewerState3D(ViewerState):
 
         super(ViewerState3D, self).__init__(**kwargs)
 
-        if self.limits_cache is None:
-            self.limits_cache = {}
+        if self._limits_cache is None:
+            self._limits_cache = {}
 
         self.x_lim_helper = StateAttributeLimitsHelper(self, attribute='x_att',
                                                        lower='x_min', upper='x_max',
-                                                       cache=self.limits_cache)
+                                                       cache=self._limits_cache)
 
         self.y_lim_helper = StateAttributeLimitsHelper(self, attribute='y_att',
                                                        lower='y_min', upper='y_max',
-                                                       cache=self.limits_cache)
+                                                       cache=self._limits_cache)
 
         self.z_lim_helper = StateAttributeLimitsHelper(self, attribute='z_att',
                                                        lower='z_min', upper='z_max',
-                                                       cache=self.limits_cache)
+                                                       cache=self._limits_cache)
 
-        # TODO: if limits_cache is re-assigned to a different object, we need to
-        # update the attribute helpers. However if in future we make limits_cache
+        # TODO: if _limits_cache is re-assigned to a different object, we need to
+        # update the attribute helpers. However if in future we make _limits_cache
         # into a smart dictionary that can call callbacks when elements are
         # changed then we shouldn't always call this. It'd also be nice to
         # avoid this altogether and make it more clean.
-        self.add_callback('limits_cache', nonpartial(self._update_limits_cache))
+        self.add_callback('_limits_cache', nonpartial(self._update_limits_cache))
 
     def _update_limits_cache(self):
-        self.x_lim_helper._cache = self.limits_cache
+        self.x_lim_helper._cache = self._limits_cache
         self.x_lim_helper._update_attribute()
-        self.y_lim_helper._cache = self.limits_cache
+        self.y_lim_helper._cache = self._limits_cache
         self.y_lim_helper._update_attribute()
-        self.z_lim_helper._cache = self.limits_cache
+        self.z_lim_helper._cache = self._limits_cache
         self.z_lim_helper._update_attribute()
 
     @property

--- a/glue_jupyter/common/tests/test_state3d.py
+++ b/glue_jupyter/common/tests/test_state3d.py
@@ -1,0 +1,35 @@
+import traitlets
+
+from glue_jupyter.state_traitlets_helpers import GlueState
+from glue_jupyter.common.state3d import ViewerState3D
+
+
+class Widget(traitlets.HasTraits):
+
+    state = GlueState()
+
+    latest_json = None
+
+    # The following two methods mimic the behavior of ipywidgets
+
+    @traitlets.observe('state')
+    def on_state_change(self, change):
+        to_json = self.trait_metadata('state', 'to_json')
+        self.latest_json = to_json(self.state, self)
+
+    def set_state_from_json(self, json):
+        from_json = self.trait_metadata('state', 'from_json')
+        from_json(json, self)
+
+
+def test_json_serializable():
+    widget = Widget()
+    assert widget.latest_json is None
+    widget.state = ViewerState3D()
+    assert widget.latest_json == {
+        "x_att": None, "x_min": 0, "x_max": 1,
+        "y_att": None, "y_min": 0, "y_max": 1,
+        "z_att": None, "z_min": 0, "z_max": 1,
+        "visible_axes": True, "native_aspect": False,
+        "layers": [], "title": None,
+    }


### PR DESCRIPTION
This PR resolves #471 by using the first approach mentioned in that issue - changing `limits_cache` -> `_limits_cache` so that it isn't serialized. As mentioned in #471, this matches the structure of the VisPy viewer states.

I suppose this is a breaking change as it's changing the name of the class member. I would imagine that there aren't any clients directly manipulating the limits cache, but if there are I'm happy to use the second approach mentioned in the issue instead.