### PR TITLE
fix: use last focused/resized view to determine shape of BqplotImageView

### DIFF
--- a/glue_jupyter/bqplot/image/viewer.py
+++ b/glue_jupyter/bqplot/image/viewer.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from glue.viewers.image.composite_array import CompositeArray
 from bqplot_image_gl.viewlistener import ViewListener
 
@@ -81,9 +83,17 @@ class BqplotImageView(BqplotBaseView):
             self.state.reset_limits()
 
     def _on_view_change(self, *args):
-        views = sorted(self._vl.view_data)
+        # Order view_data by focused_at and then resized_at, latest change first
+        views = sorted(
+            self._vl.view_data.values(),
+            key=lambda x: (
+                datetime.fromisoformat(x['focused_at']),
+                datetime.fromisoformat(x['resized_at'])
+            ),
+            reverse=True
+        )
         if len(views) > 0:
-            first_view = self._vl.view_data[views[0]]
+            first_view = views[0]
             self.shape = (int(first_view['height']), int(first_view['width']))
             self._composite_image.update()
         else:

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,5 +1,5 @@
 {
-  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "94a99faec5500df042edde00e9cdef58e230d68e9a762c1cd0ed0499eb0de83f",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "91fe92465a858548adcfba167b4402c61b927dd4da61dd1ed486f9fed84d5915",
-  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "d3bd7a7ff60cff14154f50bd75c5b8821cbd25009b01600691ca35b568783c43"
+  "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "9d7dfd5526006dd7fcd2aef6370c3b1f704568d79325a1ba6a20a297082ea5f1",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "fbdd9fe2649a0d72813c03e77af6233909df64207cb834f28da479f50b9e7a1d",
+  "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "d843a816a91e37cb0212c7caae913d7563f6c2eb42b49fa18345a5952e093b2f"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ test =
     nbconvert>=6.4.5
 visualtest =
     playwright==1.41.2
-    pytest-playwright
+    pytest-playwright==0.5.2
     pytest-mpl
     solara[pytest]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     ipywidgets>=7.4.0
     ipyvue>=1.2.0,<2
     ipyvuetify>=1.2.0,<2
-    bqplot-image-gl>=1.5.0
+    bqplot-image-gl>=1.6.0
     bqplot>=0.12.17
     bqplot-gl
     scikit-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ visualtest =
     playwright
     pytest-playwright
     pytest-mpl
-    solara[pytest]<1.29
+    solara[pytest]
 docs =
     sphinx
     sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ test =
     pytest-cov
     nbconvert>=6.4.5
 visualtest =
-    playwright
+    playwright==1.41.2
     pytest-playwright
     pytest-mpl
     solara[pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ visualtest =
     playwright==1.41.2
     pytest-playwright==0.5.2
     pytest-mpl
-    solara[pytest]
+    solara[pytest]>=1.44.1
 docs =
     sphinx
     sphinx-automodapi


### PR DESCRIPTION
# Pull Request Template

## Description

Instead of always using the lowest cid view to determine the aspect ratio / shape of a Bqplot image viewer, use the last focused / resized one. `focused_at` describes the time that the window of that view was last focused, while `resized_at` describes when each viewer was last resized, so this way distortion from resizing based on a view in a popout window will be fixed once the original window is brought into focus.

Needs https://github.com/glue-viz/bqplot-image-gl/pull/112 to work. Let me know if you need this to use the old behaviour as a fallback with previous versions of bqplot-image-gl.

TODO:
- [x] Bump `bqplot-image-gl` in the dependencies once https://github.com/glue-viz/bqplot-image-gl/pull/112 is released.