### PR TITLE
Add colormaps and stretches to ipyvolume viewer

### DIFF
--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -184,13 +184,13 @@ def test_volshow_multiple_subsets(app, data_unlinked, data_volume):
 
 
 def test_volshow_cmap_mode(app, data_volume):
-    
+
     assert data_volume in app.data_collection
     v = app.volshow(data=data_volume)
 
     layer = v.layers[0]
     layer_widget = v.layer_options.layers[-1]['layer_panel']
-    
+
     assert layer.state.color_mode == 'Fixed'
     assert layer.state.cmap.name == 'gray'
 
@@ -207,15 +207,16 @@ def test_volshow_cmap_mode(app, data_volume):
 
 
 def test_volshow_stretch(app, data_volume):
-    
+
     assert data_volume in app.data_collection
     v = app.volshow(data=data_volume)
 
     layer = v.layers[0]
     layer_widget = v.layer_options.layers[-1]['layer_panel']
-    
+
     assert layer.state.stretch == 'linear'
-    assert [item[1] for item in layer_widget.widget_stretch.options] == [item for item in stretches.members]
+    assert [item[1] for item in layer_widget.widget_stretch.options] == \
+           [item for item in stretches.members]
     assert layer_widget.widget_stretch.value == 'linear'
 
     layer.state.stretch = 'log'

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -190,7 +190,7 @@ def test_volshow_cmap_mode(app, data_volume):
     assert layer.state.cmap.name == 'gray'
 
     layer.state.color_mode = 'Linear'
-    assert layer_widget.widget_color.widget_cmap_mode.label == 'Linear'
+    assert layer_widget.widget_color.widget_color_mode.label == 'Linear'
     assert layer_widget.widget_color.widget_cmap.label == 'Gray'
     assert layer.state.cmap.name == 'gray'
 

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -1,8 +1,15 @@
 import os
 
 import numpy as np
+<<<<<<< HEAD
 import pytest
 from glue.core.roi import PolygonalROI, Projected3dROI
+=======
+from glue.config import stretches
+from glue.core.roi import PolygonalROI, Projected3dROI
+from matplotlib import colormaps
+from nbconvert.preprocessors import ExecutePreprocessor
+>>>>>>> 3f0ddc7 (Add tests of volume colormap mode and stretch widgets.)
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -174,6 +181,48 @@ def test_volshow_multiple_subsets(app, data_unlinked, data_volume):
     assert viewer.layers[0].enabled
     assert viewer.layers[1].enabled
     assert not viewer.layers[2].enabled
+
+
+def test_volshow_cmap_mode(app, data_volume):
+    
+    assert data_volume in app.data_collection
+    v = app.volshow(data=data_volume)
+
+    layer = v.layers[0]
+    layer_widget = v.layer_options.layers[-1]['layer_panel']
+    
+    assert layer.state.color_mode == 'Fixed'
+    assert layer.state.cmap.name == 'gray'
+
+    layer.state.color_mode = 'Linear'
+    assert layer_widget.widget_color.widget_cmap_mode.label == 'Linear'
+    assert layer_widget.widget_color.widget_cmap.label == 'Gray'
+    assert layer.state.cmap.name == 'gray'
+
+    layer.state.cmap = colormaps['viridis']
+    assert layer_widget.widget_color.widget_cmap.label == 'Viridis'
+
+    layer_widget.widget_color.widget_cmap.label = 'Hot'
+    assert layer.state.cmap == colormaps['hot']
+
+
+def test_volshow_stretch(app, data_volume):
+    
+    assert data_volume in app.data_collection
+    v = app.volshow(data=data_volume)
+
+    layer = v.layers[0]
+    layer_widget = v.layer_options.layers[-1]['layer_panel']
+    
+    assert layer.state.stretch == 'linear'
+    assert [item[1] for item in layer_widget.widget_stretch.options] == [item for item in stretches.members]
+    assert layer_widget.widget_stretch.value == 'linear'
+
+    layer.state.stretch = 'log'
+    assert layer_widget.widget_stretch.value == 'log'
+
+    layer_widget.widget_stretch.value = 'sqrt'
+    assert layer.state.stretch == 'sqrt'
 
 
 @pytest.mark.notebook

--- a/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
+++ b/glue_jupyter/ipyvolume/tests/test_ipyvolume.py
@@ -1,15 +1,10 @@
 import os
 
 import numpy as np
-<<<<<<< HEAD
 import pytest
-from glue.core.roi import PolygonalROI, Projected3dROI
-=======
 from glue.config import stretches
 from glue.core.roi import PolygonalROI, Projected3dROI
 from matplotlib import colormaps
-from nbconvert.preprocessors import ExecutePreprocessor
->>>>>>> 3f0ddc7 (Add tests of volume colormap mode and stretch widgets.)
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/glue_jupyter/ipyvolume/volume/layer_artist.py
+++ b/glue_jupyter/ipyvolume/volume/layer_artist.py
@@ -22,6 +22,15 @@ def _transfer_func_rgba(color, N=256, max_opacity=1):
     data[..., 3] = ramp*max_opacity
     return data
 
+def _transfer_func_cmap(cmap, N=256, max_opacity=1):
+    data = np.zeros((N, 4), dtype=np.float32)
+    ramp = np.linspace(0, 1, N)
+    colors = cmap(ramp)
+    for i in range(3):
+        data[..., i] = [c[i] for c in colors]
+    data[..., 3] = ramp*max_opacity
+    return data
+
 
 data0 = [[[1, 2]] * 2] * 2
 
@@ -113,5 +122,9 @@ class IpyvolumeVolumeLayerArtist(LayerArtist):
             self.state.percentile = 100
 
     def _update_transfer_function(self):
-        self.transfer_function.rgba = _transfer_func_rgba(self.state.color,
-                                                          max_opacity=self.state.alpha)
+        if self.state.color_mode == "Fixed":
+            self.transfer_function.rgba = _transfer_func_rgba(self.state.color,
+                                                              max_opacity=self.state.alpha)
+        else:
+            self.transfer_function.rgba = _transfer_func_cmap(self.state.cmap,
+                                                              max_opacity=self.state.alpha)

--- a/glue_jupyter/ipyvolume/volume/layer_artist.py
+++ b/glue_jupyter/ipyvolume/volume/layer_artist.py
@@ -24,6 +24,7 @@ def _transfer_func_rgba(color, N=256, max_opacity=1, stretch=None):
     data[..., 3] = ramp*max_opacity
     return data
 
+
 def _transfer_func_cmap(cmap, N=256, max_opacity=1, stretch=None):
     data = np.zeros((N, 4), dtype=np.float32)
     ramp = np.linspace(0, 1, N)
@@ -74,7 +75,9 @@ class IpyvolumeVolumeLayerArtist(LayerArtist):
 
         link((self.state, 'opacity_scale'), (self.volume, 'opacity_scale'))
 
-        on_change([(self.state, 'color', 'alpha', 'color_mode', 'cmap', 'stretch', 'stretch_parameters')])(self._update_transfer_function)
+        on_change([(self.state, 'color', 'alpha', 'color_mode',
+                    'cmap', 'stretch', 'stretch_parameters'
+                    )])(self._update_transfer_function)
 
     def clear(self):
         pass
@@ -126,11 +129,13 @@ class IpyvolumeVolumeLayerArtist(LayerArtist):
             self.state.percentile = 100
 
     def _update_transfer_function(self):
+        def stretch(x):
+            return self.state.stretch_object(x, **self.state.stretch_parameters)
         if self.state.color_mode == "Fixed":
             self.transfer_function.rgba = _transfer_func_rgba(self.state.color,
                                                               max_opacity=self.state.alpha,
-                                                              stretch=lambda x: self.state.stretch_object(x, **self.state.stretch_parameters))
+                                                              stretch=stretch)
         else:
             self.transfer_function.rgba = _transfer_func_cmap(self.state.cmap,
                                                               max_opacity=self.state.alpha,
-                                                              stretch=lambda x: self.state.stretch_object(x, **self.state.stretch_parameters))
+                                                              stretch=stretch)

--- a/glue_jupyter/ipyvolume/volume/layer_artist.py
+++ b/glue_jupyter/ipyvolume/volume/layer_artist.py
@@ -70,7 +70,7 @@ class IpyvolumeVolumeLayerArtist(LayerArtist):
 
         link((self.state, 'opacity_scale'), (self.volume, 'opacity_scale'))
 
-        on_change([(self.state, 'color', 'alpha')])(self._update_transfer_function)
+        on_change([(self.state, 'color', 'alpha', 'color_mode', 'cmap')])(self._update_transfer_function)
 
     def clear(self):
         pass

--- a/glue_jupyter/ipyvolume/volume/layer_style_widget.py
+++ b/glue_jupyter/ipyvolume/volume/layer_style_widget.py
@@ -1,7 +1,7 @@
-from ipywidgets import (Checkbox, VBox, ColorPicker, Dropdown, FloatSlider,
+from ipywidgets import (Checkbox, VBox, Dropdown, FloatSlider,
                         FloatLogSlider)
 
-from glue.utils import color2hex
+from glue_jupyter.widgets import Color
 
 from ...link import link, dlink
 
@@ -53,8 +53,7 @@ class Volume3DLayerStateWidget(VBox):
         self.widget_clamp_max = Checkbox(description='clamp maximum', value=self.state.clamp_max)
         link((self.state, 'clamp_max'), (self.widget_clamp_max, 'value'))
 
-        self.widget_color = ColorPicker(value=color2hex(self.state.color), description='color')
-        link((self.state, 'color'), (self.widget_color, 'value'), color2hex)
+        self.widget_color = Color(state=self.state, cmap_mode_attr='color_mode', cmap_att=None)
 
         if self.state.alpha is None:
             self.state.alpha = 1

--- a/glue_jupyter/ipyvolume/volume/layer_style_widget.py
+++ b/glue_jupyter/ipyvolume/volume/layer_style_widget.py
@@ -1,5 +1,8 @@
-from ipywidgets import (Checkbox, VBox, Dropdown, FloatSlider,
+from ipywidgets import (Checkbox, VBox, ColorPicker, Dropdown, FloatSlider,
                         FloatLogSlider)
+
+from glue.core.subset import Subset
+from glue.utils import color2hex
 
 from glue_jupyter.widgets import Color
 from glue_jupyter.widgets.linked_dropdown import LinkedDropdown
@@ -54,7 +57,11 @@ class Volume3DLayerStateWidget(VBox):
         self.widget_clamp_max = Checkbox(description='clamp maximum', value=self.state.clamp_max)
         link((self.state, 'clamp_max'), (self.widget_clamp_max, 'value'))
 
-        self.widget_color = Color(state=self.state, cmap_mode_attr='color_mode', cmap_att=None)
+        if isinstance(layer_state.layer, Subset):
+            self.widget_color = ColorPicker(value=color2hex(self.state.color), description='color')
+            link((self.state, 'color'), (self.widget_color, 'value'), color2hex)
+        else:
+            self.widget_color = Color(state=self.state, cmap_mode_attr='color_mode', cmap_att=None)
 
         if self.state.alpha is None:
             self.state.alpha = 1

--- a/glue_jupyter/ipyvolume/volume/layer_style_widget.py
+++ b/glue_jupyter/ipyvolume/volume/layer_style_widget.py
@@ -2,6 +2,7 @@ from ipywidgets import (Checkbox, VBox, Dropdown, FloatSlider,
                         FloatLogSlider)
 
 from glue_jupyter.widgets import Color
+from glue_jupyter.widgets.linked_dropdown import LinkedDropdown
 
 from ...link import link, dlink
 
@@ -67,6 +68,10 @@ class Volume3DLayerStateWidget(VBox):
                                                    value=self.state.opacity_scale)
         link((self.state, 'opacity_scale'), (self.widget_opacity_scale, 'value'))
 
+        self.widget_stretch = LinkedDropdown(self.state, 'stretch',
+                                             ui_name='stretch',
+                                             label='stretch')
+
         # FIXME: this should be fixed
         # self.widget_reset_zoom = Button(description="Reset zoom")
         # self.widget_reset_zoom.on_click(self.state.viewer_state.reset_limits)
@@ -76,4 +81,4 @@ class Volume3DLayerStateWidget(VBox):
                           self.widget_clamp_min, self.widget_clamp_max,
                           self.widget_max_resolution,  # self.widget_reset_zoom,
                           self.widget_color, self.widget_opacity,
-                          self.widget_opacity_scale])
+                          self.widget_opacity_scale, self.widget_stretch])

--- a/glue_jupyter/widgets/color.py
+++ b/glue_jupyter/widgets/color.py
@@ -19,22 +19,27 @@ class Color(widgets.VBox):
         self.widget_color = widgets.ColorPicker(description='color')
         link((self.state, 'color'), (self.widget_color, 'value'), color2hex)
 
-        color_mode_options = getattr(type(self.state), self.color_mode_attr).get_choice_labels(self.state)
+        color_mode_options = getattr(type(self.state),
+                                    self.color_mode_attr).get_choice_labels(self.state)
         self.widget_color_mode = widgets.RadioButtons(options=color_mode_options,
                                                      description='cmap mode')
         link((self.state, self.color_mode_attr), (self.widget_color_mode, 'value'))
-        
+
         children = [self.widget_color_mode, self.widget_color]
         if self.cmap_att is not None:
-          self.widget_cmap_att = LinkedDropdown(self.state, 'cmap_att',
-                                                ui_name='color attribute',
-                                                label='color attribute')
-          self.widget_cmap_vmin = widgets.FloatText(description='color min')
-          self.widget_cmap_vmax = widgets.FloatText(description='color max')
-          self.widget_cmap_v = widgets.VBox([self.widget_cmap_vmin, self.widget_cmap_vmax])
-          link((self.state, 'cmap_vmin'), (self.widget_cmap_vmin, 'value'), lambda value: value or 0)
-          link((self.state, 'cmap_vmax'), (self.widget_cmap_vmax, 'value'), lambda value: value or 1)
-          children.extend((self.widget_cmap_att, self.widget_cmap_v))
+            self.widget_cmap_att = LinkedDropdown(self.state, 'cmap_att',
+                                                  ui_name='color attribute',
+                                                  label='color attribute')
+            self.widget_cmap_vmin = widgets.FloatText(description='color min')
+            self.widget_cmap_vmax = widgets.FloatText(description='color max')
+            self.widget_cmap_v = widgets.VBox([self.widget_cmap_vmin, self.widget_cmap_vmax])
+            link((self.state, 'cmap_vmin'),
+                 (self.widget_cmap_vmin, 'value'),
+                 lambda value: value or 0)
+            link((self.state, 'cmap_vmax'),
+                 (self.widget_cmap_vmax, 'value'),
+                 lambda value: value or 1)
+            children.extend((self.widget_cmap_att, self.widget_cmap_v))
 
         self.widget_cmap = widgets.Dropdown(options=colormaps, description='colormap')
         children.append(self.widget_cmap)

--- a/glue_jupyter/widgets/color.py
+++ b/glue_jupyter/widgets/color.py
@@ -47,12 +47,12 @@ class Color(widgets.VBox):
              lambda cmap: colormaps.name_from_cmap(cmap), lambda name: colormaps[name])
 
         dlink((self.widget_color_mode, 'value'), (self.widget_color.layout, 'display'),
-              lambda value: None if value == cmap_mode_options[0] else 'none')
+              lambda value: None if value == color_mode_options[0] else 'none')
         dlink((self.widget_color_mode, 'value'), (self.widget_cmap.layout, 'display'),
-              lambda value: None if value == cmap_mode_options[1] else 'none')
+              lambda value: None if value == color_mode_options[1] else 'none')
         if self.cmap_att is not None:
             dlink((self.widget_color_mode, 'value'), (self.widget_cmap_att.layout, 'display'),
-                  lambda value: None if value == cmap_mode_options[1] else 'none')
+                  lambda value: None if value == color_mode_options[1] else 'none')
             dlink((self.widget_color_mode, 'value'), (self.widget_cmap_v.layout, 'display'),
-                  lambda value: None if value == cmap_mode_options[1] else 'none')
+                  lambda value: None if value == color_mode_options[1] else 'none')
         self.children = tuple(children)

--- a/glue_jupyter/widgets/color.py
+++ b/glue_jupyter/widgets/color.py
@@ -13,36 +13,41 @@ class Color(widgets.VBox):
         super(Color, self).__init__(**kwargs)
         self.state = state
 
+        self.cmap_att = kwargs.get('cmap_att', 'cmap_att')
+        self.color_mode_attr = kwargs.get('color_mode_attr', 'color_mode')
+
         self.widget_color = widgets.ColorPicker(description='color')
         link((self.state, 'color'), (self.widget_color, 'value'), color2hex)
 
-        color_mode_options = type(self.state).color_mode.get_choice_labels(self.state)
+        color_mode_options = getattr(type(self.state), self.color_mode_attr).get_choice_labels(self.state)
         self.widget_color_mode = widgets.RadioButtons(options=color_mode_options,
                                                      description='cmap mode')
-        link((self.state, 'color_mode'), (self.widget_color_mode, 'value'))
-
-        self.widget_cmap_att = LinkedDropdown(self.state, 'cmap_att',
-                                              ui_name='color attribute',
-                                              label='color attribute')
-
-        self.widget_cmap_vmin = widgets.FloatText(description='color min')
-        self.widget_cmap_vmax = widgets.FloatText(description='color max')
-        self.widget_cmap_v = widgets.VBox([self.widget_cmap_vmin, self.widget_cmap_vmax])
-        link((self.state, 'cmap_vmin'), (self.widget_cmap_vmin, 'value'), lambda value: value or 0)
-        link((self.state, 'cmap_vmax'), (self.widget_cmap_vmax, 'value'), lambda value: value or 1)
+        link((self.state, self.color_mode_attr), (self.widget_color_mode, 'value'))
+        
+        children = [self.widget_color_mode, self.widget_color]
+        if self.cmap_att is not None:
+          self.widget_cmap_att = LinkedDropdown(self.state, 'cmap_att',
+                                                ui_name='color attribute',
+                                                label='color attribute')
+          self.widget_cmap_vmin = widgets.FloatText(description='color min')
+          self.widget_cmap_vmax = widgets.FloatText(description='color max')
+          self.widget_cmap_v = widgets.VBox([self.widget_cmap_vmin, self.widget_cmap_vmax])
+          link((self.state, 'cmap_vmin'), (self.widget_cmap_vmin, 'value'), lambda value: value or 0)
+          link((self.state, 'cmap_vmax'), (self.widget_cmap_vmax, 'value'), lambda value: value or 1)
+          children.extend((self.widget_cmap_att, self.widget_cmap_v))
 
         self.widget_cmap = widgets.Dropdown(options=colormaps, description='colormap')
+        children.append(self.widget_cmap)
         link((self.state, 'cmap'), (self.widget_cmap, 'label'),
              lambda cmap: colormaps.name_from_cmap(cmap), lambda name: colormaps[name])
 
         dlink((self.widget_color_mode, 'value'), (self.widget_color.layout, 'display'),
-              lambda value: None if value == color_mode_options[0] else 'none')
+              lambda value: None if value == cmap_mode_options[0] else 'none')
         dlink((self.widget_color_mode, 'value'), (self.widget_cmap.layout, 'display'),
-              lambda value: None if value == color_mode_options[1] else 'none')
-        dlink((self.widget_color_mode, 'value'), (self.widget_cmap_att.layout, 'display'),
-              lambda value: None if value == color_mode_options[1] else 'none')
-        dlink((self.widget_color_mode, 'value'), (self.widget_cmap_v.layout, 'display'),
-              lambda value: None if value == color_mode_options[1] else 'none')
-        self.children = (self.widget_color_mode, self.widget_color,
-                         self.widget_cmap_att, self.widget_cmap_v,
-                         self.widget_cmap)
+              lambda value: None if value == cmap_mode_options[1] else 'none')
+        if self.cmap_att is not None:
+            dlink((self.widget_color_mode, 'value'), (self.widget_cmap_att.layout, 'display'),
+                  lambda value: None if value == cmap_mode_options[1] else 'none')
+            dlink((self.widget_color_mode, 'value'), (self.widget_cmap_v.layout, 'display'),
+                  lambda value: None if value == cmap_mode_options[1] else 'none')
+        self.children = tuple(children)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Homepage = "https://glueviz.org"
 
 [project.optional-dependencies]
 recommended = [
-        "glue-vispy-viewers[jupyter]>=1.2.1",
+        "glue-vispy-viewers[jupyter]>=1.3.0",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
This PR is the equivalent of https://github.com/glue-viz/glue-vispy-viewers/pull/395 and https://github.com/glue-viz/glue-vispy-viewers/pull/396 for the ipyvolume viewer. FWIW, the colormaps look better in Max Intensity mode to me.

Along the way, I generalized our color widget to allow changing the name of the color mode attribute, as well as allowing the omission of the `cmap_att` sub-widgets, to allow reusing the mode/colormap pieces for volume layers.

As the ipyvolume volume layer state is a subclass of the vispy volume layer state, this PR builds off of the state updates from the two vispy viewer PRs. Thus I'm marking this as a draft until these updates land in a `glue-vispy-viewers` release, but this works nicely for me when used with the dev version of that package.