### PR TITLE
Remove typos in histogram widget

### DIFF
--- a/glue_jupyter/common/state_widgets/viewer_histogram.vue
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.vue
@@ -7,10 +7,10 @@
             <v-text-field type="number" step="1" label="number of bins" v-model="glue_state.hist_n_bin" />
         </div>
         <div>
-            <glue-float-field label="x-min" :value.sync="glue_state.hist_x_min" />-->
+            <glue-float-field label="x-min" :value.sync="glue_state.hist_x_min" />
         </div>
         <div>
-            <glue-float-field label="x-max" :value.sync="glue_state.hist_x_max" />-->
+            <glue-float-field label="x-max" :value.sync="glue_state.hist_x_max" />
         </div>
         <div>
             <v-toolbar density="compact" >


### PR DESCRIPTION
While I was using the histogram viewer, I noticed that there are a couple typos in the histogram viewer widget - they look like stray ends of HTML comments. This PR removes them.