### PR TITLE
Debug changing zorder in viewers with mixed layer states

### DIFF
--- a/glue_jupyter/bqplot/scatter/layer_artist.py
+++ b/glue_jupyter/bqplot/scatter/layer_artist.py
@@ -458,11 +458,12 @@ class BqplotScatterLayerArtist(LayerArtist):
 
     def _update_zorder(self, *args):
         sorted_layers = sorted(self.view.layers, key=lambda layer: layer.state.zorder)
+        marks = ['density_mark', 'scatter_mark', 'line_mark_gl', 'line_mark',
+                 'vector_mark', 'vector_lines']
         self.view.figure.marks = [
             item
             for layer in sorted_layers
-            for item in (layer.density_mark, layer.scatter_mark, layer.line_mark_gl,
-                         layer.line_mark, layer.vector_mark, layer.vector_lines)
+            for item in [getattr(layer, mark, None) for mark in marks] if item is not None
         ]
 
     def _build_line_vector_points(self, x, y, vx, vy):


### PR DESCRIPTION
I ran into a bug where changing zorder of the layers in a viewer with both image and scatter layers would error, because `BqplotImageLayerArtist` object has no attribute `density_mark`. This fixes the bug by only accessing each mark in `_update_zorder` if it actually exists on the layer.