### PR TITLE
Fix subset deletion after reordering layers

### DIFF
--- a/glue_jupyter/bqplot/image/layer_artist.py
+++ b/glue_jupyter/bqplot/image/layer_artist.py
@@ -194,9 +194,10 @@ class BqplotImageSubsetLayerArtist(BaseImageLayerArtist):
         PIXEL_CACHE.pop(self.state.uuid, None)
         self.subset_array = None
         marks = self.view.figure.marks[:]
-        marks.remove(self.image_artist)
+        if self.image_artist in marks:
+            marks.remove(self.image_artist)
+            self.view.figure.marks = marks
         self.image_artist = None
-        self.view.figure.marks = marks
 
     def enable(self, redraw=True):
         if self.enabled:


### PR DESCRIPTION
This fixes an error I'm hitting in CI after implementing drag-and-drop layer reordering in Jdaviz. It appears that this may be triggered after the image_artist has already been removed due to the reordering, so I added a check that the image_artist is still in the marks before removing it.