### PR TITLE
ci: fix error in ui-tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ version_file = "glue_jupyter/_version.py"
 
 [tool.pytest.ini_options]
 filterwarnings = [
+    "error::DeprecationWarning",
     "ignore:`BqplotScatterLayerState` is deprecated and will be removed in a future version.*:DeprecationWarning:glue_jupyter.bqplot.*:",
     "ignore:metadata .* was set from the constructor:DeprecationWarning:bqscales.*:",
     "ignore:Passing unrecognized arguments to super:DeprecationWarning:traitlets.*:",
@@ -106,7 +107,6 @@ filterwarnings = [
     "ignore:.*Sentinel is not a public part of the traitlets API.*:DeprecationWarning:",
     "ignore:.*metadata.*was set from the constructor.*:DeprecationWarning:",
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning:",
-    "error::DeprecationWarning",
 ]
 
 [tool.gilesbot]


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes uitest error caused by a precedence issue, error::DeprecationWarning is overriding ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning introduced in #510