### PR TITLE
Provide a way to edit cells in table viewer

### DIFF
--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -1,47 +1,47 @@
 <template>
   <div class="glue-table-container">
-    <!-- Edit bar (Excel-style formula bar) -->
-    <v-slide-y-transition>
-      <div v-if="editingCell" class="glue-edit-bar elevation-1">
-        <div class="edit-bar-cell-ref">
-          <v-icon small class="mr-1">mdi-table-edit</v-icon>
-          <span class="edit-bar-label">{{ editingCell.column }} [{{ editingCell.row }}]</span>
-        </div>
-        <div class="edit-bar-input-container">
-          <v-text-field
-            ref="editInput"
-            v-model="editValue"
-            class="edit-bar-input"
-            dense
-            hide-details
-            single-line
-            outlined
-            @keyup.enter="commitEdit"
-            @keyup.escape="cancelEdit"
-          ></v-text-field>
-        </div>
-        <div class="edit-bar-actions">
-          <v-btn
-            icon
-            small
-            color="success"
-            @click="commitEdit"
-            title="Confirm and move to next row (Enter)"
-          >
-            <v-icon small>mdi-check</v-icon>
-          </v-btn>
-          <v-btn
-            icon
-            small
-            color="error"
-            @click="cancelEdit"
-            title="Cancel (Escape)"
-          >
-            <v-icon small>mdi-close</v-icon>
-          </v-btn>
-        </div>
+    <!-- Cell display/edit bar (always visible) -->
+    <div class="glue-edit-bar elevation-1">
+      <div class="edit-bar-cell-ref">
+        <v-icon small class="mr-1">{{ selectedCell ? (selectedCell.editable ? 'mdi-table-edit' : 'mdi-table-eye') : 'mdi-table' }}</v-icon>
+        <span class="edit-bar-label">{{ selectedCell ? selectedCell.column + ' [' + selectedCell.row + ']' : 'Click a cell to view' }}</span>
       </div>
-    </v-slide-y-transition>
+      <div class="edit-bar-input-container">
+        <v-text-field
+          ref="editInput"
+          v-model="editValue"
+          class="edit-bar-input"
+          dense
+          hide-details
+          single-line
+          outlined
+          :readonly="!selectedCell || !selectedCell.editable"
+          :placeholder="selectedCell ? '' : 'Select a cell...'"
+          @keyup.enter="commitEdit"
+          @keyup.escape="cancelEdit"
+        ></v-text-field>
+      </div>
+      <div class="edit-bar-actions" v-if="selectedCell && selectedCell.editable">
+        <v-btn
+          icon
+          small
+          color="success"
+          @click="commitEdit"
+          title="Confirm and move to next row (Enter)"
+        >
+          <v-icon small>mdi-check</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          small
+          color="error"
+          @click="cancelEdit"
+          title="Cancel (Escape)"
+        >
+          <v-icon small>mdi-close</v-icon>
+        </v-btn>
+      </div>
+    </div>
 
     <v-slide-x-transition appear>
       <v-data-table
@@ -105,19 +105,12 @@
           </td>
           <td v-for="header in headers"
               :key="header.text"
-              class="text-truncate text-no-wrap glue-editable-cell"
-              :class="{'glue-cell-editing': isEditing(props.item.__row__, header.value)}"
+              class="text-truncate text-no-wrap glue-selectable-cell"
+              :class="{'glue-cell-selected': isSelected(props.item.__row__, header.value)}"
               :title="props.item[header.value]"
+              @click.stop="selectCell(props.item.__row__, header.value, props.item[header.value], header.editable)"
           >
-              <span class="cell-content">
-                {{ props.item[header.value] }}
-                <v-icon
-                  v-if="header.editable"
-                  x-small
-                  class="edit-icon"
-                  @click.stop="startEdit(props.item.__row__, header.value, props.item[header.value])"
-                >mdi-pencil</v-icon>
-              </span>
+              <span class="cell-content">{{ props.item[header.value] }}</span>
           </td>
         </tr>
       </template>
@@ -130,7 +123,7 @@
 module.exports = {
   data: function() {
     return {
-      editingCell: null,  // { row: number, column: string }
+      selectedCell: null,  // { row: number, column: string, editable: boolean }
       editValue: ''
     };
   },
@@ -138,24 +131,27 @@ module.exports = {
     toggleSort(column) {
       this.sort_column(column);
     },
-    startEdit(row, column, currentValue) {
-      this.editingCell = { row: row, column: column };
+    selectCell(row, column, currentValue, editable) {
+      this.selectedCell = { row: row, column: column, editable: editable };
       this.editValue = currentValue !== null && currentValue !== undefined ? String(currentValue) : '';
-      // Focus the edit input after Vue updates the DOM
-      this.$nextTick(() => {
-        if (this.$refs.editInput) {
-          this.$refs.editInput.focus();
-        }
-      });
+      // Focus the edit input after Vue updates the DOM (only if editable)
+      if (editable) {
+        this.$nextTick(() => {
+          if (this.$refs.editInput) {
+            this.$refs.editInput.focus();
+          }
+        });
+      }
     },
     cancelEdit() {
-      this.editingCell = null;
+      this.selectedCell = null;
       this.editValue = '';
     },
     commitEdit() {
-      if (this.editingCell) {
-        const currentColumn = this.editingCell.column;
-        const currentRow = this.editingCell.row;
+      if (this.selectedCell && this.selectedCell.editable) {
+        const currentColumn = this.selectedCell.column;
+        const currentRow = this.selectedCell.row;
+        const isEditable = this.selectedCell.editable;
         // Commit the edit
         this.cell_edited({
           row: currentRow,
@@ -168,23 +164,23 @@ module.exports = {
           // Find the current value for the next cell
           const nextItem = this.items.find(item => item.__row__ === nextRow);
           if (nextItem) {
-            this.startEdit(nextRow, currentColumn, nextItem[currentColumn]);
+            this.selectCell(nextRow, currentColumn, nextItem[currentColumn], isEditable);
           } else {
-            // Next row might not be in current page, just close editing
-            this.editingCell = null;
+            // Next row might not be in current page, just clear selection
+            this.selectedCell = null;
             this.editValue = '';
           }
         } else {
-          // No more rows, close editing
-          this.editingCell = null;
+          // No more rows, clear selection
+          this.selectedCell = null;
           this.editValue = '';
         }
       }
     },
-    isEditing(row, column) {
-      return this.editingCell !== null &&
-             this.editingCell.row === row &&
-             this.editingCell.column === column;
+    isSelected(row, column) {
+      return this.selectedCell !== null &&
+             this.selectedCell.row === row &&
+             this.selectedCell.column === column;
     }
   }
 }
@@ -289,29 +285,17 @@ module.exports = {
   z-index: 1;
 }
 
-/* Editable cell styles */
-.glue-editable-cell .cell-content {
-  display: inline-flex;
-  align-items: center;
-}
-
-.glue-editable-cell .edit-icon {
-  opacity: 0;
-  transition: opacity 0.2s;
-  margin-left: 4px;
+/* Selectable cell styles */
+.glue-selectable-cell {
   cursor: pointer;
 }
 
-.glue-editable-cell:hover .edit-icon {
-  opacity: 0.5;
+.glue-selectable-cell:hover {
+  background-color: #f5f5f5;
 }
 
-.glue-editable-cell .edit-icon:hover {
-  opacity: 1;
-}
-
-/* Visual cue for cell being edited */
-.glue-cell-editing {
+/* Visual cue for selected cell */
+.glue-cell-selected {
   background-color: #E3F2FD !important;
   box-shadow: inset 0 0 0 2px #1976D2;
 }

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -1,17 +1,61 @@
 <template>
-  <v-slide-x-transition appear>
-    <v-data-table
-      dense
-      hide-default-header
-      :headers="[...headers]"
-      :items="items"
-      :footer-props="{'items-per-page-options': [10,20,50,100]}"
-      :options.sync="options"
-      :items_per_page.sync="items_per_page"
-      :server-items-length="total_length"
-      :class="['elevation-1', 'glue-data-table', scrollable && 'glue-data-table--scrollable']"
-      :style="scrollable && height != null && `height: ${height}`"
-    >
+  <div class="glue-table-container">
+    <!-- Edit bar (Excel-style formula bar) -->
+    <v-slide-y-transition>
+      <div v-if="editingCell" class="glue-edit-bar elevation-1">
+        <div class="edit-bar-cell-ref">
+          <v-icon small class="mr-1">mdi-table-edit</v-icon>
+          <span class="edit-bar-label">{{ editingCell.column }} [{{ editingCell.row }}]</span>
+        </div>
+        <div class="edit-bar-input-container">
+          <v-text-field
+            ref="editInput"
+            v-model="editValue"
+            class="edit-bar-input"
+            dense
+            hide-details
+            single-line
+            outlined
+            @keyup.enter="commitEdit"
+            @keyup.escape="cancelEdit"
+          ></v-text-field>
+        </div>
+        <div class="edit-bar-actions">
+          <v-btn
+            icon
+            small
+            color="success"
+            @click="commitEdit"
+            title="Confirm and move to next row (Enter)"
+          >
+            <v-icon small>mdi-check</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            small
+            color="error"
+            @click="cancelEdit"
+            title="Cancel (Escape)"
+          >
+            <v-icon small>mdi-close</v-icon>
+          </v-btn>
+        </div>
+      </div>
+    </v-slide-y-transition>
+
+    <v-slide-x-transition appear>
+      <v-data-table
+        dense
+        hide-default-header
+        :headers="[...headers]"
+        :items="items"
+        :footer-props="{'items-per-page-options': [10,20,50,100]}"
+        :options.sync="options"
+        :items_per_page.sync="items_per_page"
+        :server-items-length="total_length"
+        :class="['elevation-1', 'glue-data-table', scrollable && 'glue-data-table--scrollable']"
+        :style="scrollable && height != null && `height: ${height}`"
+      >
       <template v-slot:header="props">
         <thead>
           <tr>
@@ -62,40 +106,10 @@
           <td v-for="header in headers"
               :key="header.text"
               class="text-truncate text-no-wrap glue-editable-cell"
+              :class="{'glue-cell-editing': isEditing(props.item.__row__, header.value)}"
               :title="props.item[header.value]"
-              @dblclick="header.editable && startEdit(props.item.__row__, header.value, props.item[header.value])"
           >
-              <div v-if="isEditing(props.item.__row__, header.value)" class="cell-edit-container">
-                <v-text-field
-                  v-model="editValue"
-                  class="cell-edit-input"
-                  dense
-                  hide-details
-                  single-line
-                  autofocus
-                  @focus="onEditFocus"
-                  @keyup.enter="commitEdit"
-                  @keyup.escape="cancelEdit"
-                  @click.stop
-                ></v-text-field>
-                <div class="cell-edit-icons">
-                  <v-icon
-                    small
-                    class="cell-edit-confirm"
-                    color="success"
-                    @click.native.stop="commitEdit"
-                    title="Confirm (Enter)"
-                  >mdi-check</v-icon>
-                  <v-icon
-                    small
-                    class="cell-edit-cancel"
-                    color="error"
-                    @click.native.stop="cancelEdit"
-                    title="Cancel (Escape)"
-                  >mdi-close</v-icon>
-                </div>
-              </div>
-              <span v-else class="cell-content">
+              <span class="cell-content">
                 {{ props.item[header.value] }}
                 <v-icon
                   v-if="header.editable"
@@ -107,8 +121,9 @@
           </td>
         </tr>
       </template>
-    </v-data-table>
-  </v-slide-x-transition>
+      </v-data-table>
+    </v-slide-x-transition>
+  </div>
 </template>
 
 <script>
@@ -126,6 +141,12 @@ module.exports = {
     startEdit(row, column, currentValue) {
       this.editingCell = { row: row, column: column };
       this.editValue = currentValue !== null && currentValue !== undefined ? String(currentValue) : '';
+      // Focus the edit input after Vue updates the DOM
+      this.$nextTick(() => {
+        if (this.$refs.editInput) {
+          this.$refs.editInput.focus();
+        }
+      });
     },
     cancelEdit() {
       this.editingCell = null;
@@ -133,34 +154,97 @@ module.exports = {
     },
     commitEdit() {
       if (this.editingCell) {
+        const currentColumn = this.editingCell.column;
+        const currentRow = this.editingCell.row;
+        // Commit the edit
         this.cell_edited({
-          row: this.editingCell.row,
-          column: this.editingCell.column,
+          row: currentRow,
+          column: currentColumn,
           value: this.editValue
         });
-        this.editingCell = null;
-        this.editValue = '';
+        // Move to the next row in the same column
+        const nextRow = currentRow + 1;
+        if (nextRow < this.total_length) {
+          // Find the current value for the next cell
+          const nextItem = this.items.find(item => item.__row__ === nextRow);
+          if (nextItem) {
+            this.startEdit(nextRow, currentColumn, nextItem[currentColumn]);
+          } else {
+            // Next row might not be in current page, just close editing
+            this.editingCell = null;
+            this.editValue = '';
+          }
+        } else {
+          // No more rows, close editing
+          this.editingCell = null;
+          this.editValue = '';
+        }
       }
     },
     isEditing(row, column) {
       return this.editingCell !== null &&
              this.editingCell.row === row &&
              this.editingCell.column === column;
-    },
-    onEditFocus(event) {
-      // Move cursor to start so text isn't truncated at the beginning
-      this.$nextTick(() => {
-        const input = event.target;
-        if (input && input.setSelectionRange) {
-          input.setSelectionRange(0, 0);
-        }
-      });
     }
   }
 }
 </script>
 
 <style id="glue_table">
+/* Table container */
+.glue-table-container {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Edit bar (Excel-style formula bar) */
+.glue-edit-bar {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  gap: 8px;
+}
+
+.edit-bar-cell-ref {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  min-width: 120px;
+  font-size: 12px;
+  color: #666;
+}
+
+.edit-bar-label {
+  font-family: monospace;
+  font-weight: 500;
+}
+
+.edit-bar-input-container {
+  flex: 1;
+}
+
+.edit-bar-input {
+  margin: 0;
+  padding: 0;
+}
+
+.edit-bar-input .v-input__slot {
+  min-height: 32px !important;
+  background-color: #fff !important;
+}
+
+.edit-bar-actions {
+  display: flex;
+  gap: 4px;
+}
+
 .highlightedRow {
     background-color: #E3F2FD;
 }
@@ -226,42 +310,9 @@ module.exports = {
   opacity: 1;
 }
 
-.cell-edit-container {
-  display: inline-flex;
-  align-items: center;
-}
-
-.cell-edit-icons {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: 4px;
-}
-
-.cell-edit-input {
-  margin: 0;
-  padding: 0;
-  flex: 1;
-  font-size: inherit;
-}
-
-.cell-edit-input input {
-  font-size: inherit;
-}
-
-.cell-edit-input .v-input__slot {
-  min-height: unset !important;
-}
-
-.cell-edit-confirm,
-.cell-edit-cancel {
-  cursor: pointer;
-  opacity: 0.7;
-  transition: opacity 0.2s;
-}
-
-.cell-edit-confirm:hover,
-.cell-edit-cancel:hover {
-  opacity: 1;
+/* Visual cue for cell being edited */
+.glue-cell-editing {
+  background-color: #E3F2FD !important;
+  box-shadow: inset 0 0 0 2px #1976D2;
 }
 </style>

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -109,9 +109,7 @@
               :class="{'glue-cell-selected': isSelected(props.item.__row__, header.value)}"
               :title="props.item[header.value]"
               @click.stop="selectCell(props.item.__row__, header.value, props.item[header.value], header.editable)"
-          >
-              <span class="cell-content">{{ props.item[header.value] }}</span>
-          </td>
+          >{{ props.item[header.value] }}</td>
         </tr>
       </template>
       </v-data-table>


### PR DESCRIPTION
To use this, one needs to set ``editable_components`` on the viewer state:

```
table.state.editable_components = [points.id['x']]
```

and when hovering over values a little pen will appear - clicking on it will allow the cell to be edited (see x column):

<img width="392" height="62" alt="Screenshot 2026-02-14 at 22 54 03" src="https://github.com/user-attachments/assets/57bdbb31-7f9a-4db4-900e-c63e54b62a11" />


Changes are currently automatically synced to the ``Data`` object, which is not great performance-wise so we should think whether we want to have a way to only sync on request


Open questions:

* Do we want editing a cell to actually bring up a modal dialog? This might be better if the content to type is long? The current UI has some advantages though.
* Do we want edits to be synced straight away to the rest of glue? This might be slow for datasets with millions of rows, so it just depends what kind of datasets we will use this with