### PR TITLE
Enable keyboard navigation from the table edit cell

### DIFF
--- a/glue_jupyter/conftest.py
+++ b/glue_jupyter/conftest.py
@@ -11,6 +11,11 @@ def dataxyz():
 
 
 @pytest.fixture
+def datamix():
+    return Data(x=[1, 2, 3], y=[2.3, 3.14, 4], z=['a', 'b', 'c'], label="mixed type data")
+
+
+@pytest.fixture
 def datacat():
     return Data(a=['a', 'b', 'c'], b=['d', 'e', 'f'], label="categorical data")
 

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -15,10 +15,11 @@
           hide-details
           single-line
           outlined
-          :readonly="!selectedCell || !selectedCell.editable"
           :placeholder="selectedCell ? '' : 'Select a cell...'"
-          @keyup.enter="commitEdit"
+          @keyup.enter="selectedCell.editable ? commitEdit() : advanceRow(1)"
           @keyup.escape="cancelEdit"
+          @keyup.up="advanceRow(-1)"
+          @keyup.down="advanceRow(1)"
         ></v-text-field>
       </div>
       <div class="edit-bar-actions" v-if="selectedCell && selectedCell.editable">
@@ -149,16 +150,23 @@ module.exports = {
       if (this.selectedCell && this.selectedCell.editable) {
         const currentColumn = this.selectedCell.column;
         const currentRow = this.selectedCell.row;
-        const isEditable = this.selectedCell.editable;
         // Commit the edit
         this.cell_edited({
           row: currentRow,
           column: currentColumn,
           value: this.editValue
         });
-        // Move to the next row in the same column
-        const nextRow = currentRow + 1;
-        if (nextRow < this.total_length) {
+        this.advanceRow(1);
+      }
+    },
+    advanceRow(step) {
+      // Advance <step> rows in the same column
+      if (this.selectedCell) {
+        const currentColumn = this.selectedCell.column;
+        const currentRow = this.selectedCell.row;
+        const isEditable = this.selectedCell.editable;
+        const nextRow = currentRow + step;
+        if ((nextRow >= 0) && (nextRow < this.total_length)) {
           // Find the current value for the next cell
           const nextItem = this.items.find(item => item.__row__ === nextRow);
           if (nextItem) {

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -133,14 +133,12 @@ module.exports = {
     selectCell(row, column, currentValue, editable) {
       this.selectedCell = { row: row, column: column, editable: editable };
       this.editValue = currentValue !== null && currentValue !== undefined ? String(currentValue) : '';
-      // Focus the edit input after Vue updates the DOM (only if editable)
-      if (editable) {
-        this.$nextTick(() => {
-          if (this.$refs.editInput) {
-            this.$refs.editInput.focus();
-          }
-        });
-      }
+      // Focus the edit input after Vue updates the DOM (to support editable mode, or keyboard navigation)
+      this.$nextTick(() => {
+        if (this.$refs.editInput) {
+          this.$refs.editInput.focus();
+        }
+      });
     },
     cancelEdit() {
       this.selectedCell = null;

--- a/glue_jupyter/table/tests/test_table.py
+++ b/glue_jupyter/table/tests/test_table.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from glue.core import Data
 
 from glue_jupyter.table import TableViewer
@@ -292,28 +293,32 @@ def test_table_editable_components(app, dataxyz):
     assert y_header['editable'] is True
     assert z_header['editable'] is False
 
-
-def test_table_cell_edit(app, dataxyz):
+@pytest.mark.parametrize('new_value', [999, 1.4e-12, np.inf, np.nan])
+def test_table_cell_edit(app, datamix, new_value):
     """Test that cell editing updates the underlying data."""
-    table = app.table(data=dataxyz)
+    app.add_data(datamix)
+    table = app.table(data=datamix)
 
-    # Enable editing for column 'x'
-    table.state.editable_components = [dataxyz.id['x']]
+    # Enable editing for float column
+    column = 'y'
+    table.state.editable_components = [datamix.id[column]]
 
     # Get original value
-    original_value = dataxyz['x'][0]
+    original_value = datamix[column][0]
 
     # Simulate cell edit
-    new_value = 999
     table.widget_table.vue_cell_edited({
         'row': 0,
-        'column': 'x',
+        'column': column,
         'value': str(new_value)
     })
 
     # Verify data was updated
-    assert dataxyz['x'][0] == new_value
-    assert dataxyz['x'][0] != original_value
+    if np.isnan(new_value):
+        assert np.isnan(datamix[column][0])
+    else:
+        assert datamix[column][0] == new_value
+    assert datamix[column][0] != original_value
 
 
 def test_table_cell_edit_type_conversion(app, dataxyz):


### PR DESCRIPTION
## Description
#525 – this is adding support for the up/down keys to move forward or back a row.
I did not restrict the movement to editable cells, so the actions will be
1. `Escape`: leave cell
2. `Enter`: if `editable`, commit changes, otherwise just move to next row
3. `Up`/`Down`: move to previous/next row

My js coding is extremely limited, I just used Up and Down without modifiers here – this will intercept the navigation between notebook cells, but only when the edit cell is in focus – is this acceptable?
Will return from the cell upon reaching bottom or top of a page, but that is consistent with the behaviour from #515.

In principle this might even be extended to navigating between columns, but the left/right keys are already in demand for in-cell movement. With modifiers like alt-left, this could become usable.

Also added some more edit tests for different inputs.