### PR TITLE
Make use of echo.vue to autoconnect vue properties to glue state

### DIFF
--- a/glue_jupyter/bqplot/histogram/tests/test_ui.py
+++ b/glue_jupyter/bqplot/histogram/tests/test_ui.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+from glue.core import Data
+from IPython.display import display
+
+import glue_jupyter as gj
+from glue_jupyter.tests.helpers import HAS_VISUAL_TEST_DEPS
+
+pytestmark = pytest.mark.skipif(not HAS_VISUAL_TEST_DEPS, reason="requires solara, playwright")
+
+
+@pytest.fixture
+def viewer_and_page(solara_test, page_session):
+    data = Data(x=np.random.RandomState(42).uniform(0, 10, 1000), label="data")
+    app = gj.jglue(data=data)
+    viewer = app.histogram1d(x='x', show=False)
+    page_session.set_viewport_size({"width": 800, "height": 600})
+    return app, viewer, page_session
+
+
+def _click_switch(page, label):
+    switch = page.locator(f".v-input--switch:has(.v-label:text('{label}'))")
+    switch.click()
+    page.wait_for_timeout(300)
+
+
+def test_normalize_and_cumulative(viewer_and_page):
+    """Test that the normalize and cumulative switches update viewer state."""
+    _app, viewer, page = viewer_and_page
+
+    display(viewer.viewer_options)
+    page.wait_for_timeout(500)
+
+    assert not viewer.state.normalize
+    assert not viewer.state.cumulative
+
+    _click_switch(page, "Normalize")
+    assert viewer.state.normalize
+
+    _click_switch(page, "Cumulative")
+    assert viewer.state.cumulative
+
+    # Toggle them back off
+    _click_switch(page, "Normalize")
+    assert not viewer.state.normalize
+
+    _click_switch(page, "Cumulative")
+    assert not viewer.state.cumulative
+
+
+def test_fit_bins_to_axes(viewer_and_page):
+    """Test that updating x-min/x-max then clicking Fit Bins to Axes works."""
+    _app, viewer, page = viewer_and_page
+
+    display(viewer.viewer_options)
+    page.wait_for_timeout(500)
+
+    # Set non-default x range via the state and verify the UI will pick it up
+    viewer.state.x_min = 2.0
+    viewer.state.x_max = 8.0
+    page.wait_for_timeout(300)
+
+    original_hist_x_min = viewer.state.hist_x_min
+    original_hist_x_max = viewer.state.hist_x_max
+
+    # Click the "Fit Bins to Axes" button
+    page.locator("button:has-text('Fit Bins to Axes')").click()
+    page.wait_for_timeout(300)
+
+    assert viewer.state.hist_x_min == pytest.approx(2.0)
+    assert viewer.state.hist_x_max == pytest.approx(8.0)
+    assert viewer.state.hist_x_min != original_hist_x_min
+    assert viewer.state.hist_x_max != original_hist_x_max

--- a/glue_jupyter/bqplot/image/tests/test_ui.py
+++ b/glue_jupyter/bqplot/image/tests/test_ui.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+from glue.core import Data
+from IPython.display import display
+
+import glue_jupyter as gj
+from glue_jupyter.tests.helpers import HAS_VISUAL_TEST_DEPS
+
+pytestmark = pytest.mark.skipif(not HAS_VISUAL_TEST_DEPS, reason="requires solara, playwright")
+
+
+@pytest.fixture
+def viewer_and_page(solara_test, page_session):
+    data = Data(x=np.arange(1000).reshape((10, 10, 10)), label="cube")
+    app = gj.jglue(cube=data)
+    viewer = app.imshow(data=data, show=False)
+    page_session.set_viewport_size({"width": 800, "height": 600})
+    return app, viewer, page_session
+
+
+def test_slice_slider(viewer_and_page):
+    """Test that clicking the slice slider updates viewer state."""
+    _app, viewer, page = viewer_and_page
+
+    widget = viewer.viewer_options
+    assert len(widget.sliders) == 1
+    initial_slice = viewer.state.slices[0]
+
+    display(widget)
+    slider = page.locator(".glue-viewer-image .v-slider")
+    slider.wait_for()
+    page.wait_for_timeout(500)
+
+    # Click near the right end of the slider track
+    box = slider.bounding_box()
+    page.mouse.click(box["x"] + box["width"] * 0.9, box["y"] + box["height"] / 2)
+    page.wait_for_timeout(500)
+
+    assert viewer.state.slices[0] > initial_slice
+
+
+def test_colormap(viewer_and_page):
+    """Test that changing the colormap via the UI updates layer state."""
+    _app, viewer, page = viewer_and_page
+
+    layer_panel = viewer._layout_layer_options.layers[0]['layer_panel']
+    original_cmap = layer_panel.layer_state.cmap.name
+
+    display(layer_panel)
+    page.wait_for_timeout(500)
+
+    # Open the colormap dropdown and pick a different colormap
+    cmap_select = page.locator(".v-select").filter(has_text="colormap").first
+    cmap_select.click()
+    page.wait_for_timeout(300)
+
+    # Pick a colormap that isn't the current one
+    target = "viridis" if original_cmap != "viridis" else "plasma"
+    page.locator(f".v-list-item:has-text('{target}')").first.click()
+    page.wait_for_timeout(300)
+
+    assert layer_panel.layer_state.cmap.name == target
+    assert layer_panel.layer_state.cmap.name != original_cmap

--- a/glue_jupyter/bqplot/image/tests/test_viewer.py
+++ b/glue_jupyter/bqplot/image/tests/test_viewer.py
@@ -1,4 +1,3 @@
-import glue_jupyter.state_traitlets_helpers
 
 
 def test_non_hex_colors(app, data_image):
@@ -71,15 +70,10 @@ def test_contour_state(app, data_image):
     layer.state.c_min = 0
     layer.state.c_max = 10
     layer.state.n_levels = 3
-    glue_jupyter.state_traitlets_helpers.update_state_from_dict(
-        layer.state,
-        {'level_mode': 'Custom', 'levels': [1, 2]}
-    )
+    layer.state.level_mode = 'Custom'
+    layer.state.levels = [1, 2]
     assert layer.state.levels == [1, 2]
-    glue_jupyter.state_traitlets_helpers.update_state_from_dict(
-        layer.state,
-        {'level_mode': 'Linear', 'levels': [2, 3]}
-    )
+    layer.state.level_mode = 'Linear'
     # Without priority of levels, this gets set to [2, 3]
     assert layer.state.levels == [0, 5, 10]
 

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -376,12 +376,12 @@ def test_imshow_nonfloat(app):
 def test_show_axes(app, dataxyz):
     s = app.scatter2d(x='x', y='y', data=dataxyz)
     assert s.state.show_axes
-    assert s.viewer_options.glue_state.show_axes
+    assert s.viewer_options.show_axes
     margin_initial = s.figure.fig_margin
     s.state.show_axes = False
-    assert not s.viewer_options.glue_state.show_axes
+    assert not s.viewer_options.show_axes
     assert s.figure.fig_margin != margin_initial
-    s.viewer_options.glue_state.show_axes = True
+    s.viewer_options.show_axes = True
     assert s.state.show_axes
     assert s.figure.fig_margin == margin_initial
 

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -8,15 +8,13 @@ import traitlets
 
 from echo.vue import autoconnect_callbacks_to_vue
 
-from ...vuetify_helpers import cmap_extras, link_glue
+from ...vuetify_helpers import cmap_extras
 
 __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 
 
 class ImageLayerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'layer_image.vue')
-
-    color_mode = traitlets.Unicode().tag(sync=True)
 
     c_levels_txt = traitlets.Unicode().tag(sync=True)
     c_levels_txt_editing = False
@@ -39,8 +37,8 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
 
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
 
-        # color_mode comes from the viewer state, not the layer state
-        link_glue(self, 'color_mode', layer_state.viewer_state)
+        autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
+                                     only={'color_mode': 'text'})
 
         if self.has_contour:
             # Sync contour levels to editable text

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -1,5 +1,4 @@
 from ipywidgets import Checkbox, FloatSlider, ColorPicker, VBox
-from glue.config import colormaps
 from glue.utils import color2hex
 
 from ...link import link
@@ -9,7 +8,7 @@ import traitlets
 
 from echo.vue import autoconnect_callbacks_to_vue
 
-from ...vuetify_helpers import link_glue
+from ...vuetify_helpers import cmap_extras, link_glue
 
 __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 
@@ -17,8 +16,6 @@ __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 class ImageLayerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'layer_image.vue')
 
-    colormap_items = traitlets.List().tag(sync=True)
-    cmap_name = traitlets.Unicode().tag(sync=True)
     color_mode = traitlets.Unicode().tag(sync=True)
 
     c_levels_txt = traitlets.Unicode().tag(sync=True)
@@ -34,24 +31,13 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
 
         self.has_contour = hasattr(layer_state, "contour_visible")
 
-        extras = {}
+        extras = {'cmap': cmap_extras(self)}
         if self.has_contour:
             extras.update({'contour_visible': 'bool',
                            'bitmap_visible': 'bool',
                            'level_mode': 'text'})
 
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
-
-        self.colormap_items = [dict(
-            text=cmap[0],
-            value=cmap[1].name
-        ) for cmap in colormaps.members]
-
-        # Sync colormap name (Colormap objects can't be serialized directly)
-        def _sync_cmap_name(*args):
-            self.cmap_name = layer_state.cmap.name if layer_state.cmap is not None else ''
-        layer_state.add_callback('cmap', _sync_cmap_name)
-        _sync_cmap_name()
 
         # color_mode comes from the viewer state, not the layer state
         link_glue(self, 'color_mode', layer_state.viewer_state)
@@ -81,15 +67,6 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
             self.c_levels_error = ''
         finally:
             self.c_levels_txt_editing = False
-
-    def vue_set_colormap(self, data):
-        cmap = None
-        for member in colormaps.members:
-            if member[1].name == data:
-                cmap = member[1]
-                break
-
-        self.layer_state.cmap = cmap
 
 
 class ImageSubsetLayerStateWidget(VBox):

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -13,12 +13,16 @@ from ...vuetify_helpers import cmap_extras
 __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 
 
+def _levels_to_text(levels):
+    return ", ".join('%g' % level for level in levels)
+
+
+def _text_to_levels(text):
+    return [float(level.strip()) for level in text.split(',')]
+
+
 class ImageLayerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'layer_image.vue')
-
-    c_levels_txt = traitlets.Unicode().tag(sync=True)
-    c_levels_txt_editing = False
-    c_levels_error = traitlets.Unicode().tag(sync=True)
 
     has_contour = traitlets.Bool().tag(sync=True)
 
@@ -33,38 +37,13 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
         if self.has_contour:
             extras.update({'contour_visible': 'bool',
                            'bitmap_visible': 'bool',
-                           'level_mode': 'text'})
+                           'level_mode': 'text',
+                           'levels': ('text', _levels_to_text, _text_to_levels)})
 
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
 
         autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
                                      only={'color_mode': 'text'})
-
-        if self.has_contour:
-            # Sync contour levels to editable text
-            def levels_to_text(*_ignore):
-                if not self.c_levels_txt_editing:
-                    text = ", ".join('%g' % v for v in layer_state.levels)
-                    self.c_levels_txt = text
-
-            layer_state.add_callback('levels', levels_to_text)
-
-    @traitlets.observe('c_levels_txt')
-    def _on_change_c_levels_txt(self, change):
-        try:
-            self.c_levels_txt_editing = True
-            try:
-                parts = change['new'].split(',')
-                float_list_str = [float(v.strip()) for v in parts]
-            except Exception as e:
-                self.c_levels_error = str(e)
-                return
-
-            if self.layer_state.level_mode == "Custom":
-                self.layer_state.levels = float_list_str
-            self.c_levels_error = ''
-        finally:
-            self.c_levels_txt_editing = False
 
 
 class ImageSubsetLayerStateWidget(VBox):

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -8,7 +8,6 @@ import ipyvuetify as v
 import traitlets
 
 from echo.vue import autoconnect_callbacks_to_vue
-from echo.vue._connect import connect_bool, connect_text
 
 from ...vuetify_helpers import link_glue
 
@@ -35,7 +34,13 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
 
         self.has_contour = hasattr(layer_state, "contour_visible")
 
-        autoconnect_callbacks_to_vue(layer_state, self)
+        extras = {}
+        if self.has_contour:
+            extras.update({'contour_visible': 'bool',
+                           'bitmap_visible': 'bool',
+                           'level_mode': 'text'})
+
+        autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
 
         self.colormap_items = [dict(
             text=cmap[0],
@@ -52,11 +57,6 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
         link_glue(self, 'color_mode', layer_state.viewer_state)
 
         if self.has_contour:
-            # Properties only used in v-if/click handlers, not bound to components
-            connect_bool(layer_state, 'contour_visible', self)
-            connect_bool(layer_state, 'bitmap_visible', self)
-            connect_text(layer_state, 'level_mode', self)
-
             # Sync contour levels to editable text
             def levels_to_text(*_ignore):
                 if not self.c_levels_txt_editing:

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -13,16 +13,10 @@ from ...vuetify_helpers import cmap_extras
 __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 
 
-def _levels_to_text(levels):
-    return ", ".join('%g' % level for level in levels)
-
-
-def _text_to_levels(text):
-    return [float(level.strip()) for level in text.split(',')]
-
-
 class ImageLayerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'layer_image.vue')
+
+    c_levels_error = traitlets.Unicode().tag(sync=True)
 
     has_contour = traitlets.Bool().tag(sync=True)
 
@@ -38,12 +32,24 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
             extras.update({'contour_visible': 'bool',
                            'bitmap_visible': 'bool',
                            'level_mode': 'text',
-                           'levels': ('text', _levels_to_text, _text_to_levels)})
+                           'levels': ('text', self._levels_to_text, self._text_to_levels)})
 
         autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
 
         autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
                                      only={'color_mode': 'text'})
+
+    def _levels_to_text(self, levels):
+        return ", ".join('%g' % level for level in levels)
+
+
+    def _text_to_levels(self, text):
+        self.c_levels_error = ''
+        try:
+            return [float(level.strip()) for level in text.split(',')]
+        except Exception as e:
+            self.c_levels_error = str(e)
+            return []
 
 
 class ImageSubsetLayerStateWidget(VBox):

--- a/glue_jupyter/common/state_widgets/layer_image.py
+++ b/glue_jupyter/common/state_widgets/layer_image.py
@@ -6,8 +6,11 @@ from ...link import link
 
 import ipyvuetify as v
 import traitlets
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices, link_glue
+
+from echo.vue import autoconnect_callbacks_to_vue
+from echo.vue._connect import connect_bool, connect_text
+
+from ...vuetify_helpers import link_glue
 
 __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 
@@ -15,20 +18,8 @@ __all__ = ['ImageLayerStateWidget', 'ImageSubsetLayerStateWidget']
 class ImageLayerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'layer_image.vue')
 
-    glue_state = GlueState().tag(sync=True)
-
-    # TODO: expose toggle to turn on image and/or contour
-
-    attribute_items = traitlets.List().tag(sync=True)
-    attribute_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    stretch_items = traitlets.List().tag(sync=True)
-    stretch_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    percentile_items = traitlets.List().tag(sync=True)
-    percentile_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     colormap_items = traitlets.List().tag(sync=True)
+    cmap_name = traitlets.Unicode().tag(sync=True)
     color_mode = traitlets.Unicode().tag(sync=True)
 
     c_levels_txt = traitlets.Unicode().tag(sync=True)
@@ -41,30 +32,38 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
         super().__init__()
 
         self.layer_state = layer_state
-        self.glue_state = layer_state
 
         self.has_contour = hasattr(layer_state, "contour_visible")
 
-        link_glue_choices(self, layer_state, 'attribute')
-        link_glue_choices(self, layer_state, 'stretch')
-        link_glue_choices(self, layer_state, 'percentile')
+        autoconnect_callbacks_to_vue(layer_state, self)
 
         self.colormap_items = [dict(
             text=cmap[0],
             value=cmap[1].name
         ) for cmap in colormaps.members]
 
+        # Sync colormap name (Colormap objects can't be serialized directly)
+        def _sync_cmap_name(*args):
+            self.cmap_name = layer_state.cmap.name if layer_state.cmap is not None else ''
+        layer_state.add_callback('cmap', _sync_cmap_name)
+        _sync_cmap_name()
+
+        # color_mode comes from the viewer state, not the layer state
         link_glue(self, 'color_mode', layer_state.viewer_state)
 
-        # we only go from glue state to the text version of the level list
-        # the other way around is handled in _on_change_c_levels_txt
         if self.has_contour:
+            # Properties only used in v-if/click handlers, not bound to components
+            connect_bool(layer_state, 'contour_visible', self)
+            connect_bool(layer_state, 'bitmap_visible', self)
+            connect_text(layer_state, 'level_mode', self)
+
+            # Sync contour levels to editable text
             def levels_to_text(*_ignore):
                 if not self.c_levels_txt_editing:
-                    text = ", ".join('%g' % v for v in self.glue_state.levels)
+                    text = ", ".join('%g' % v for v in layer_state.levels)
                     self.c_levels_txt = text
 
-            self.glue_state.add_callback('levels', levels_to_text)
+            layer_state.add_callback('levels', levels_to_text)
 
     @traitlets.observe('c_levels_txt')
     def _on_change_c_levels_txt(self, change):
@@ -77,8 +76,8 @@ class ImageLayerStateWidget(v.VuetifyTemplate):
                 self.c_levels_error = str(e)
                 return
 
-            if self.glue_state.level_mode == "Custom":
-                self.glue_state.levels = float_list_str
+            if self.layer_state.level_mode == "Custom":
+                self.layer_state.levels = float_list_str
             self.c_levels_error = ''
         finally:
             self.c_levels_txt_editing = False

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -39,8 +39,7 @@
                         <glue-float-field label="contour max" :value.sync="c_max" echo-type="float" />
                         <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="float" />
                     </template>
-                    <v-text-field v-else label="contour levels" v-model="c_levels_txt" :rules="() => c_levels_error !== ''"
-                                  :error-messages="c_levels_error !== '' && [c_levels_error]"/>
+                    <v-text-field v-else label="contour levels" v-model="levels"/>
                 </div>
             </v-expand-transition>
             <v-divider class="mt-6"/>

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -7,13 +7,13 @@
             <v-divider class="mt-6"/>
             <div>
                 <strong>Contour</strong>
-                <v-btn icon @click.stop="glue_state.contour_visible = !glue_state.contour_visible">
-                    <v-icon>mdi-eye{{ glue_state.contour_visible ? '' : '-off' }}</v-icon>
+                <v-btn icon @click.stop="contour_visible = !contour_visible">
+                    <v-icon>mdi-eye{{ contour_visible ? '' : '-off' }}</v-icon>
                 </v-btn>
             </div>
             <v-expand-transition>
-                <div v-if="glue_state.contour_visible">
-                    <v-btn-toggle dense v-model="glue_state.level_mode" style="margin-right: 8px; margin-top: 8px">
+                <div v-if="contour_visible">
+                    <v-btn-toggle dense v-model="level_mode" echo-type="text" style="margin-right: 8px; margin-top: 8px">
 
                         <v-tooltip bottom>
                             <template v-slot:activator="{ on }">
@@ -34,10 +34,10 @@
                         </v-tooltip>
                     </v-btn-toggle>
 
-                    <template v-if="glue_state.level_mode == 'Linear'">
-                        <glue-float-field label="contour min" :value.sync="glue_state.c_min" />
-                        <glue-float-field label="contour max" :value.sync="glue_state.c_max" />
-                        <glue-float-field label="number of contour levels" :value.sync="glue_state.n_levels"/>
+                    <template v-if="level_mode == 'Linear'">
+                        <glue-float-field label="contour min" :value.sync="c_min" echo-type="value" />
+                        <glue-float-field label="contour max" :value.sync="c_max" echo-type="value" />
+                        <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="value" />
                     </template>
                     <v-text-field v-else label="contour levels" v-model="c_levels_txt" :rules="() => c_levels_error !== ''"
                                   :error-messages="c_levels_error !== '' && [c_levels_error]"/>
@@ -46,24 +46,24 @@
             <v-divider class="mt-6"/>
             <div>
                 <strong>Bitmap</strong>
-                <v-btn icon @click.stop="glue_state.bitmap_visible = !glue_state.bitmap_visible">
-                    <v-icon>mdi-eye{{ glue_state.bitmap_visible ? '' : '-off' }}</v-icon>
+                <v-btn icon @click.stop="bitmap_visible = !bitmap_visible">
+                    <v-icon>mdi-eye{{ bitmap_visible ? '' : '-off' }}</v-icon>
                 </v-btn>
             </div>
         </template>
         <v-expand-transition>
-            <div v-if="!has_contour || glue_state.bitmap_visible">
+            <div v-if="!has_contour || bitmap_visible">
                 <div>
                     <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="glue_state.contrast" hide-details />
+                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="contrast" echo-type="value" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">bias</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="glue_state.bias" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="bias" echo-type="value" hide-details />
                 </div>
                 <div>
                     <v-select label="stretch" :items="stretch_items" v-model="stretch_selected" hide-details />
@@ -72,13 +72,13 @@
                     <v-select label="percentile" :items="percentile_items" v-model="percentile_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="glue_state.v_min" />
+                    <glue-float-field label="min" :value.sync="v_min" echo-type="value" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="glue_state.v_max" />
+                    <glue-float-field label="max" :value.sync="v_max" echo-type="value" />
                 </div>
                 <div v-if="color_mode === 'Colormaps'">
-                    <v-select label="colormap" :items="colormap_items" :value="glue_state.cmap" @change="set_colormap" />
+                    <v-select label="colormap" :items="colormap_items" :value="cmap_name" @change="set_colormap" />
                 </div>
             </div>
         </v-expand-transition>
@@ -89,13 +89,13 @@
         methods: {
             /* TODO: use @change with debounce instead of @end */
             setAlpha(value) {
-                this.glue_state.alpha = value;
+                this.alpha = value;
             },
             setContrast(value) {
-                this.glue_state.contrast = value;
+                this.contrast = value;
             },
             setBias(value) {
-                this.glue_state.bias = value;
+                this.bias = value;
             },
         },
     }

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -35,9 +35,9 @@
                     </v-btn-toggle>
 
                     <template v-if="level_mode == 'Linear'">
-                        <glue-float-field label="contour min" :value.sync="c_min" echo-type="number" />
-                        <glue-float-field label="contour max" :value.sync="c_max" echo-type="number" />
-                        <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="number" />
+                        <glue-float-field label="contour min" :value.sync="c_min" echo-type="float" />
+                        <glue-float-field label="contour max" :value.sync="c_max" echo-type="float" />
+                        <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="float" />
                     </template>
                     <v-text-field v-else label="contour levels" v-model="c_levels_txt" :rules="() => c_levels_error !== ''"
                                   :error-messages="c_levels_error !== '' && [c_levels_error]"/>
@@ -55,15 +55,15 @@
             <div v-if="!has_contour || bitmap_visible">
                 <div>
                     <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="float" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="contrast" echo-type="number" hide-details />
+                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="contrast" echo-type="float" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">bias</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="bias" echo-type="number" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="bias" echo-type="float" hide-details />
                 </div>
                 <div>
                     <v-select label="stretch" :items="stretch_items" v-model="stretch_selected" hide-details />
@@ -72,10 +72,10 @@
                     <v-select label="percentile" :items="percentile_items" v-model="percentile_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="v_min" echo-type="number" />
+                    <glue-float-field label="min" :value.sync="v_min" echo-type="float" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="v_max" echo-type="number" />
+                    <glue-float-field label="max" :value.sync="v_max" echo-type="float" />
                 </div>
                 <div v-if="color_mode === 'Colormaps'">
                     <v-select label="colormap" :items="cmap_items" v-model="cmap" />

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -78,27 +78,13 @@
                     <glue-float-field label="max" :value.sync="v_max" echo-type="value" />
                 </div>
                 <div v-if="color_mode === 'Colormaps'">
-                    <v-select label="colormap" :items="colormap_items" :value="cmap_name" @change="set_colormap" />
+                    <v-select label="colormap" :items="cmap_items" v-model="cmap" />
                 </div>
             </div>
         </v-expand-transition>
     </div>
 </template>
 <script>
-    modules.export = {
-        methods: {
-            /* TODO: use @change with debounce instead of @end */
-            setAlpha(value) {
-                this.alpha = value;
-            },
-            setContrast(value) {
-                this.contrast = value;
-            },
-            setBias(value) {
-                this.bias = value;
-            },
-        },
-    }
 </script>
 <style id="layer_image">
     .v-subheader.slider-label {

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -35,9 +35,9 @@
                     </v-btn-toggle>
 
                     <template v-if="level_mode == 'Linear'">
-                        <glue-float-field label="contour min" :value.sync="c_min" echo-type="value" />
-                        <glue-float-field label="contour max" :value.sync="c_max" echo-type="value" />
-                        <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="value" />
+                        <glue-float-field label="contour min" :value.sync="c_min" echo-type="number" />
+                        <glue-float-field label="contour max" :value.sync="c_max" echo-type="number" />
+                        <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="number" />
                     </template>
                     <v-text-field v-else label="contour levels" v-model="c_levels_txt" :rules="() => c_levels_error !== ''"
                                   :error-messages="c_levels_error !== '' && [c_levels_error]"/>
@@ -55,15 +55,15 @@
             <div v-if="!has_contour || bitmap_visible">
                 <div>
                     <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="contrast" echo-type="value" hide-details />
+                    <glue-throttled-slider wait="300" max="4" step="0.01" :value.sync="contrast" echo-type="number" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">bias</v-subheader>
-                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="bias" echo-type="value" hide-details />
+                    <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="bias" echo-type="number" hide-details />
                 </div>
                 <div>
                     <v-select label="stretch" :items="stretch_items" v-model="stretch_selected" hide-details />
@@ -72,10 +72,10 @@
                     <v-select label="percentile" :items="percentile_items" v-model="percentile_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="v_min" echo-type="value" />
+                    <glue-float-field label="min" :value.sync="v_min" echo-type="number" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="v_max" echo-type="value" />
+                    <glue-float-field label="max" :value.sync="v_max" echo-type="number" />
                 </div>
                 <div v-if="color_mode === 'Colormaps'">
                     <v-select label="colormap" :items="cmap_items" v-model="cmap" />

--- a/glue_jupyter/common/state_widgets/layer_image.vue
+++ b/glue_jupyter/common/state_widgets/layer_image.vue
@@ -39,7 +39,8 @@
                         <glue-float-field label="contour max" :value.sync="c_max" echo-type="float" />
                         <glue-float-field label="number of contour levels" :value.sync="n_levels" echo-type="float" />
                     </template>
-                    <v-text-field v-else label="contour levels" v-model="levels"/>
+                    <v-text-field v-else label="contour levels" v-model="levels" :rules="() => c_levels_error !== ''"
+                                  :error-messages="c_levels_error !== '' && [c_levels_error]"/>
                 </div>
             </v-expand-transition>
             <v-divider class="mt-6"/>

--- a/glue_jupyter/common/state_widgets/layer_profile.py
+++ b/glue_jupyter/common/state_widgets/layer_profile.py
@@ -1,7 +1,6 @@
 from ipyvuetify import VuetifyTemplate
-import traitlets
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices, link_glue
+
+from echo.vue import autoconnect_callbacks_to_vue
 
 __all__ = ['ProfileLayerStateWidget']
 
@@ -9,16 +8,9 @@ __all__ = ['ProfileLayerStateWidget']
 class ProfileLayerStateWidget(VuetifyTemplate):
     template_file = (__file__, 'layer_profile.vue')
 
-    glue_state = GlueState().tag(sync=True)
-
-    attribute_items = traitlets.List().tag(sync=True)
-    attribute_selected = traitlets.Int().tag(sync=True)
-    as_steps = traitlets.Bool(False).tag(sync=True)
-
     def __init__(self, layer_state):
         super().__init__()
 
-        self.glue_state = layer_state
+        self.layer_state = layer_state
 
-        link_glue_choices(self, layer_state, 'attribute')
-        link_glue(self, 'as_steps', layer_state)
+        autoconnect_callbacks_to_vue(layer_state, self)

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <div>
-            <glue-float-field label="line width" suffix="px" :value.sync="linewidth" echo-type="number" />
+            <glue-float-field label="line width" suffix="px" :value.sync="linewidth" echo-type="float" />
         </div>
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="float" hide-details />
         </div>
         <div>
             <v-switch label="Plot as steps" v-model="as_steps" />

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <div>
-            <glue-float-field label="line width" suffix="px" :value.sync="glue_state.linewidth" />
+            <glue-float-field label="line width" suffix="px" :value.sync="linewidth" echo-type="value" />
         </div>
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
         </div>
         <div>
             <v-switch label="Plot as steps" v-model="as_steps" />

--- a/glue_jupyter/common/state_widgets/layer_profile.vue
+++ b/glue_jupyter/common/state_widgets/layer_profile.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <div>
-            <glue-float-field label="line width" suffix="px" :value.sync="linewidth" echo-type="value" />
+            <glue-float-field label="line width" suffix="px" :value.sync="linewidth" echo-type="number" />
         </div>
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details />
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
         </div>
         <div>
             <v-switch label="Plot as steps" v-model="as_steps" />

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -1,11 +1,9 @@
 import ipyvuetify as v
 import traitlets
 
-from glue.config import colormaps
-
 from echo.vue import autoconnect_callbacks_to_vue
 
-from ...vuetify_helpers import link_glue
+from ...vuetify_helpers import cmap_extras, link_glue
 
 __all__ = ["ScatterLayerStateWidget"]
 
@@ -13,9 +11,6 @@ __all__ = ["ScatterLayerStateWidget"]
 class ScatterLayerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "layer_scatter.vue")
-
-    cmap_items = traitlets.List().tag(sync=True)
-    cmap_name = traitlets.Unicode().tag(sync=True)
 
     dpi = traitlets.Float().tag(sync=True)
 
@@ -25,25 +20,8 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
         self.layer_state = layer_state
 
         autoconnect_callbacks_to_vue(layer_state, self,
-                                     extras={'density_map': 'bool'})
-
-        self.cmap_items = [
-            {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
-        ]
-
-        # Sync colormap name (Colormap objects can't be serialized directly)
-        def _sync_cmap_name(*args):
-            self.cmap_name = layer_state.cmap.name if layer_state.cmap is not None else ''
-        layer_state.add_callback('cmap', _sync_cmap_name)
-        _sync_cmap_name()
+                                     extras={'density_map': 'bool',
+                                             'cmap': cmap_extras(self)})
 
         # dpi comes from the viewer state, not the layer state
         link_glue(self, "dpi", layer_state.viewer_state)
-
-    def vue_set_colormap(self, data):
-        cmap = None
-        for member in colormaps.members:
-            if member[1].name == data:
-                cmap = member[1]
-                break
-        self.layer_state.cmap = cmap

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -3,8 +3,10 @@ import traitlets
 
 from glue.config import colormaps
 
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue, link_glue_choices
+from echo.vue import autoconnect_callbacks_to_vue
+from echo.vue._connect import connect_bool
+
+from ...vuetify_helpers import link_glue
 
 __all__ = ["ScatterLayerStateWidget"]
 
@@ -13,83 +15,33 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "layer_scatter.vue")
 
-    glue_state = GlueState().tag(sync=True)
-
-    # Color
-
-    cmap_mode_items = traitlets.List().tag(sync=True)
-    cmap_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    cmap_att_items = traitlets.List().tag(sync=True)
-    cmap_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     cmap_items = traitlets.List().tag(sync=True)
-
-    # Points
-
-    points_mode_items = traitlets.List().tag(sync=True)
-    points_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    size_mode_items = traitlets.List().tag(sync=True)
-    size_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    size_att_items = traitlets.List().tag(sync=True)
-    size_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
+    cmap_name = traitlets.Unicode().tag(sync=True)
 
     dpi = traitlets.Float().tag(sync=True)
-
-    # Line
-
-    linestyle_items = traitlets.List().tag(sync=True)
-    linestyle_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    # Vectors
-
-    vx_att_items = traitlets.List().tag(sync=True)
-    vx_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    vy_att_items = traitlets.List().tag(sync=True)
-    vy_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    vector_origin_items = traitlets.List().tag(sync=True)
-    vector_origin_selected = traitlets.Int(allow_none=True).tag(sync=True)
 
     def __init__(self, layer_state):
         super().__init__()
 
         self.layer_state = layer_state
-        self.glue_state = layer_state
 
-        # Color
-
-        link_glue_choices(self, layer_state, "cmap_mode")
-        link_glue_choices(self, layer_state, "cmap_att")
+        autoconnect_callbacks_to_vue(layer_state, self)
 
         self.cmap_items = [
             {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
         ]
 
-        # Points
+        # density_map is only used in v-if, not bound to a component
+        connect_bool(layer_state, 'density_map', self)
 
-        link_glue_choices(self, layer_state, "points_mode")
-        link_glue_choices(self, layer_state, "size_mode")
-        link_glue_choices(self, layer_state, "size_att")
+        # Sync colormap name (Colormap objects can't be serialized directly)
+        def _sync_cmap_name(*args):
+            self.cmap_name = layer_state.cmap.name if layer_state.cmap is not None else ''
+        layer_state.add_callback('cmap', _sync_cmap_name)
+        _sync_cmap_name()
 
+        # dpi comes from the viewer state, not the layer state
         link_glue(self, "dpi", layer_state.viewer_state)
-
-        # TODO: make sliders for dpi and size scaling logarithmic
-
-        # FIXME: moving any sliders causes a change in the colormap
-
-        # Line
-
-        link_glue_choices(self, layer_state, "linestyle")
-
-        # Vectors
-
-        link_glue_choices(self, layer_state, "vx_att")
-        link_glue_choices(self, layer_state, "vy_att")
-        link_glue_choices(self, layer_state, "vector_origin")
 
     def vue_set_colormap(self, data):
         cmap = None

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -1,9 +1,8 @@
 import ipyvuetify as v
-import traitlets
 
 from echo.vue import autoconnect_callbacks_to_vue
 
-from ...vuetify_helpers import cmap_extras, link_glue
+from ...vuetify_helpers import cmap_extras
 
 __all__ = ["ScatterLayerStateWidget"]
 
@@ -11,8 +10,6 @@ __all__ = ["ScatterLayerStateWidget"]
 class ScatterLayerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "layer_scatter.vue")
-
-    dpi = traitlets.Float().tag(sync=True)
 
     def __init__(self, layer_state):
         super().__init__()
@@ -23,5 +20,5 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
                                      extras={'density_map': 'bool',
                                              'cmap': cmap_extras(self)})
 
-        # dpi comes from the viewer state, not the layer state
-        link_glue(self, "dpi", layer_state.viewer_state)
+        autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
+                                     only={'dpi': 'value'})

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -22,4 +22,4 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
                                      skip={'dpi'})
 
         autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
-                                     only={'dpi': 'number'})
+                                     only={'dpi': 'float'})

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -21,4 +21,4 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
                                              'cmap': cmap_extras(self)})
 
         autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
-                                     only={'dpi': 'value'})
+                                     only={'dpi': 'number'})

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -18,7 +18,8 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
 
         autoconnect_callbacks_to_vue(layer_state, self,
                                      extras={'density_map': 'bool',
-                                             'cmap': cmap_extras(self)})
+                                             'cmap': cmap_extras(self)},
+                                     skip={'dpi'})
 
         autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
                                      only={'dpi': 'number'})

--- a/glue_jupyter/common/state_widgets/layer_scatter.py
+++ b/glue_jupyter/common/state_widgets/layer_scatter.py
@@ -4,7 +4,6 @@ import traitlets
 from glue.config import colormaps
 
 from echo.vue import autoconnect_callbacks_to_vue
-from echo.vue._connect import connect_bool
 
 from ...vuetify_helpers import link_glue
 
@@ -25,14 +24,12 @@ class ScatterLayerStateWidget(v.VuetifyTemplate):
 
         self.layer_state = layer_state
 
-        autoconnect_callbacks_to_vue(layer_state, self)
+        autoconnect_callbacks_to_vue(layer_state, self,
+                                     extras={'density_map': 'bool'})
 
         self.cmap_items = [
             {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
         ]
-
-        # density_map is only used in v-if, not bound to a component
-        connect_bool(layer_state, 'density_map', self)
 
         # Sync colormap name (Colormap objects can't be serialized directly)
         def _sync_cmap_name(*args):

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -9,10 +9,10 @@
                 <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
             <div>
-                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="number" />
+                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="float" />
             </div>
             <div>
-                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="number" />
+                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="float" />
             </div>
             <div>
                 <v-select label="colormap" :items="cmap_items" v-model="cmap" hide-details/>
@@ -20,7 +20,7 @@
         </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="float" hide-details />
         </div>
         <div class="text-subtitle-2 font-weight-bold">Points</div>
         <div>
@@ -39,20 +39,20 @@
                     <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="size_vmin" echo-type="number" />
+                    <glue-float-field label="min" :value.sync="size_vmin" echo-type="float" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="size_vmax" echo-type="number" />
+                    <glue-float-field label="max" :value.sync="size_vmax" echo-type="float" />
                 </div>
             </template>
             <template v-if="density_map">
                 <div>
                     <v-subheader class="pl-0 slider-label">dpi</v-subheader>
-                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" echo-type="number" hide-details />
+                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" echo-type="float" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="density_contrast" echo-type="number"
+                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="density_contrast" echo-type="float"
                                          hide-details />
                 </div>
             </template>
@@ -63,7 +63,7 @@
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
-                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="number"
+                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="float"
                         hide-details />
                 </div>
             </template>
@@ -76,7 +76,7 @@
         <template v-if="line_visible">
             <div>
                 <v-subheader class="pl-0 slider-label">width</v-subheader>
-                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="linewidth" echo-type="number" hide-details />
+                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="linewidth" echo-type="float" hide-details />
             </div>
             <div>
                 <v-select label="linestyle" :items="linestyle_items" v-model="linestyle_selected" hide-details />
@@ -99,7 +99,7 @@
             </div>
             <div>
                 <v-subheader class="pl-0 slider-label">vector size</v-subheader>
-                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="vector_scaling" echo-type="number"
+                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="vector_scaling" echo-type="float"
                     hide-details />
             </div>
         </template>

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -4,7 +4,7 @@
         <div>
             <v-select label="color" :items="cmap_mode_items" v-model="cmap_mode_selected" hide-details />
         </div>
-        <template v-if="cmap_mode_text === 'Linear'">
+        <template v-if="(cmap_mode_items[cmap_mode_selected] || {}).text === 'Linear'">
             <div>
                 <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
@@ -34,7 +34,7 @@
             <div v-if="density_map === false">
                 <v-select label="size" :items="size_mode_items" v-model="size_mode_selected" hide-details />
             </div>
-            <template v-if="size_mode_text === 'Linear'">
+            <template v-if="(size_mode_items[size_mode_selected] || {}).text === 'Linear'">
                 <div>
                     <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
@@ -106,18 +106,6 @@
     </div>
 </template>
 <script>
-    module.exports = {
-        computed: {
-            cmap_mode_text() {
-                var item = this.cmap_mode_items && this.cmap_mode_items[this.cmap_mode_selected];
-                return item ? item.text : '';
-            },
-            size_mode_text() {
-                var item = this.size_mode_items && this.size_mode_items[this.size_mode_selected];
-                return item ? item.text : '';
-            }
-        }
-    }
 </script>
 <style id="layer_scatter">
 .glue-layer-scatter .v-subheader.slider-label {

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -15,7 +15,7 @@
                 <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="value" />
             </div>
             <div>
-                <v-select label="colormap" :items="cmap_items" :value="cmap_name" @change="set_colormap" hide-details/>
+                <v-select label="colormap" :items="cmap_items" v-model="cmap" hide-details/>
             </div>
         </template>
         <div>

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -9,10 +9,10 @@
                 <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
             <div>
-                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="value" />
+                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="number" />
             </div>
             <div>
-                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="value" />
+                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="number" />
             </div>
             <div>
                 <v-select label="colormap" :items="cmap_items" v-model="cmap" hide-details/>
@@ -20,7 +20,7 @@
         </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="number" hide-details />
         </div>
         <div class="text-subtitle-2 font-weight-bold">Points</div>
         <div>
@@ -39,20 +39,20 @@
                     <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="size_vmin" echo-type="value" />
+                    <glue-float-field label="min" :value.sync="size_vmin" echo-type="number" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="size_vmax" echo-type="value" />
+                    <glue-float-field label="max" :value.sync="size_vmax" echo-type="number" />
                 </div>
             </template>
             <template v-if="density_map">
                 <div>
                     <v-subheader class="pl-0 slider-label">dpi</v-subheader>
-                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" echo-type="value" hide-details />
+                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="density_contrast" echo-type="value"
+                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="density_contrast" echo-type="number"
                                          hide-details />
                 </div>
             </template>
@@ -63,7 +63,7 @@
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
-                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="value"
+                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="number"
                         hide-details />
                 </div>
             </template>
@@ -76,7 +76,7 @@
         <template v-if="line_visible">
             <div>
                 <v-subheader class="pl-0 slider-label">width</v-subheader>
-                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="linewidth" echo-type="value" hide-details />
+                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="linewidth" echo-type="number" hide-details />
             </div>
             <div>
                 <v-select label="linestyle" :items="linestyle_items" v-model="linestyle_selected" hide-details />
@@ -99,7 +99,7 @@
             </div>
             <div>
                 <v-subheader class="pl-0 slider-label">vector size</v-subheader>
-                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="vector_scaling" echo-type="value"
+                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="vector_scaling" echo-type="number"
                     hide-details />
             </div>
         </template>

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -48,7 +48,7 @@
             <template v-if="density_map">
                 <div>
                     <v-subheader class="pl-0 slider-label">dpi</v-subheader>
-                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" hide-details />
+                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" echo-type="number" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>

--- a/glue_jupyter/common/state_widgets/layer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/layer_scatter.vue
@@ -4,90 +4,90 @@
         <div>
             <v-select label="color" :items="cmap_mode_items" v-model="cmap_mode_selected" hide-details />
         </div>
-        <template v-if="glue_state.cmap_mode === 'Linear'">
+        <template v-if="cmap_mode_text === 'Linear'">
             <div>
                 <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
             </div>
             <div>
-                <glue-float-field label="min" :value.sync="glue_state.cmap_vmin" />
+                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="value" />
             </div>
             <div>
-                <glue-float-field label="max" :value.sync="glue_state.cmap_vmax" />
+                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="value" />
             </div>
             <div>
-                <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
+                <v-select label="colormap" :items="cmap_items" :value="cmap_name" @change="set_colormap" hide-details/>
             </div>
         </template>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="value" hide-details />
         </div>
         <div class="text-subtitle-2 font-weight-bold">Points</div>
         <div>
             <v-subheader class="pl-0 slider-label">show points</v-subheader>
-            <v-switch v-model="glue_state.markers_visible" hide-details style="margin-top: 0" />
+            <v-switch v-model="markers_visible" hide-details style="margin-top: 0" />
         </div>
-        <template v-if="glue_state.markers_visible">
+        <template v-if="markers_visible">
             <div>
                 <v-select label="type" :items="points_mode_items" v-model="points_mode_selected" hide-details />
             </div>
-            <div v-if="glue_state.density_map === false">
+            <div v-if="density_map === false">
                 <v-select label="size" :items="size_mode_items" v-model="size_mode_selected" hide-details />
             </div>
-            <template v-if="glue_state.size_mode === 'Linear'">
+            <template v-if="size_mode_text === 'Linear'">
                 <div>
                     <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
                 </div>
                 <div>
-                    <glue-float-field label="min" :value.sync="glue_state.size_vmin" />
+                    <glue-float-field label="min" :value.sync="size_vmin" echo-type="value" />
                 </div>
                 <div>
-                    <glue-float-field label="max" :value.sync="glue_state.size_vmax" />
+                    <glue-float-field label="max" :value.sync="size_vmax" echo-type="value" />
                 </div>
             </template>
-            <template v-if="glue_state.density_map">
+            <template v-if="density_map">
                 <div>
                     <v-subheader class="pl-0 slider-label">dpi</v-subheader>
-                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" hide-details />
+                    <glue-throttled-slider wait="300" min="12" max="144" step="1" :value.sync="dpi" echo-type="value" hide-details />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">contrast</v-subheader>
-                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="glue_state.density_contrast"
+                    <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="density_contrast" echo-type="value"
                                          hide-details />
                 </div>
             </template>
             <template v-else>
                 <div>
                     <v-subheader class="pl-0 slider-label">fill markers</v-subheader>
-                    <v-switch v-model="glue_state.fill" hide-details style="margin-top: 0" />
+                    <v-switch v-model="fill" hide-details style="margin-top: 0" />
                 </div>
                 <div>
                     <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
-                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="glue_state.size_scaling"
+                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="value"
                         hide-details />
                 </div>
             </template>
         </template>
-        <div class="text-subtitle-2 font-weight-bold" :style="glue_state.markers_visible ? {} : {marginTop: '6px'}">Line</div>
+        <div class="text-subtitle-2 font-weight-bold" :style="markers_visible ? {} : {marginTop: '6px'}">Line</div>
         <div>
             <v-subheader class="pl-0 slider-label">show line</v-subheader>
-            <v-switch v-model="glue_state.line_visible" hide-details style="margin-top: 0"/>
+            <v-switch v-model="line_visible" hide-details style="margin-top: 0"/>
         </div>
-        <template v-if="glue_state.line_visible">
+        <template v-if="line_visible">
             <div>
                 <v-subheader class="pl-0 slider-label">width</v-subheader>
-                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="glue_state.linewidth" hide-details />
+                <glue-throttled-slider wait="300" min="1" max="20" step="1" :value.sync="linewidth" echo-type="value" hide-details />
             </div>
             <div>
                 <v-select label="linestyle" :items="linestyle_items" v-model="linestyle_selected" hide-details />
             </div>
         </template>
-        <div class="text-subtitle-2 font-weight-bold" :style="glue_state.markers_visible ? {} : {marginTop: '6px'}">Vectors</div>
+        <div class="text-subtitle-2 font-weight-bold" :style="markers_visible ? {} : {marginTop: '6px'}">Vectors</div>
         <div>
             <v-subheader class="pl-0 slider-label">show vectors</v-subheader>
-            <v-switch v-model="glue_state.vector_visible" hide-details style="margin-top: 0"/>
+            <v-switch v-model="vector_visible" hide-details style="margin-top: 0"/>
         </div>
-        <template v-if="glue_state.vector_visible">
+        <template v-if="vector_visible">
             <div>
                 <v-select label="vx" :items="vx_att_items" v-model="vx_att_selected" hide-details />
             </div>
@@ -99,13 +99,25 @@
             </div>
             <div>
                 <v-subheader class="pl-0 slider-label">vector size</v-subheader>
-                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="glue_state.vector_scaling"
+                <glue-throttled-slider wait="300" min="0.01" max="1" step="0.01" :value.sync="vector_scaling" echo-type="value"
                     hide-details />
             </div>
         </template>
     </div>
 </template>
 <script>
+    module.exports = {
+        computed: {
+            cmap_mode_text() {
+                var item = this.cmap_mode_items && this.cmap_mode_items[this.cmap_mode_selected];
+                return item ? item.text : '';
+            },
+            size_mode_text() {
+                var item = this.size_mode_items && this.size_mode_items[this.size_mode_selected];
+                return item ? item.text : '';
+            }
+        }
+    }
 </script>
 <style id="layer_scatter">
 .glue-layer-scatter .v-subheader.slider-label {

--- a/glue_jupyter/common/state_widgets/tests/test_viewer_image.py
+++ b/glue_jupyter/common/state_widgets/tests/test_viewer_image.py
@@ -4,12 +4,12 @@ def test_contour_levels(app, data_image):
     layer_state = widget_state.layer_state
     layer_state.level_mode = "Custom"
 
-    widget_state.c_levels_txt = '1e2, 1e3, 0.1, .1'
+    widget_state.levels = '1e2, 1e3, 0.1, .1'
     assert layer_state.levels == [100, 1000, 0.1, 0.1]
-    assert widget_state.c_levels_txt == '1e2, 1e3, 0.1, .1'
+    assert widget_state.levels == '1e2, 1e3, 0.1, .1'
 
     layer_state.levels = [10, 100]
-    assert widget_state.c_levels_txt == '10, 100'
+    assert widget_state.levels == '10, 100'
 
 
 def test_no_slider_if_flat(app, data_flat):

--- a/glue_jupyter/common/state_widgets/viewer_histogram.py
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.py
@@ -1,7 +1,6 @@
 import ipyvuetify as v
 
 from echo.vue import autoconnect_callbacks_to_vue
-from echo.vue._connect import connect_bool
 
 __all__ = ['HistogramViewerStateWidget']
 
@@ -14,11 +13,9 @@ class HistogramViewerStateWidget(v.VuetifyTemplate):
 
         self.viewer_state = viewer_state
 
-        autoconnect_callbacks_to_vue(viewer_state, self)
-
-        # Properties only used in JS, not bound to a Vue component
-        connect_bool(viewer_state, 'normalize', self)
-        connect_bool(viewer_state, 'cumulative', self)
+        autoconnect_callbacks_to_vue(viewer_state, self,
+                                     extras={'normalize': 'bool',
+                                             'cumulative': 'bool'})
 
     def vue_bins_to_axis(self, *args):
         self.viewer_state.update_bins_to_view()

--- a/glue_jupyter/common/state_widgets/viewer_histogram.py
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.py
@@ -13,9 +13,7 @@ class HistogramViewerStateWidget(v.VuetifyTemplate):
 
         self.viewer_state = viewer_state
 
-        autoconnect_callbacks_to_vue(viewer_state, self,
-                                     extras={'normalize': 'bool',
-                                             'cumulative': 'bool'})
+        autoconnect_callbacks_to_vue(viewer_state, self)
 
     def vue_bins_to_axis(self, *args):
         self.viewer_state.update_bins_to_view()

--- a/glue_jupyter/common/state_widgets/viewer_histogram.py
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.py
@@ -1,24 +1,24 @@
 import ipyvuetify as v
-import traitlets
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices
 
+from echo.vue import autoconnect_callbacks_to_vue
+from echo.vue._connect import connect_bool
 
 __all__ = ['HistogramViewerStateWidget']
 
 
 class HistogramViewerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'viewer_histogram.vue')
-    x_att_items = traitlets.List().tag(sync=True)
-    x_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-    glue_state = GlueState().tag(sync=True)
 
     def __init__(self, viewer_state):
         super().__init__()
 
-        self.glue_state = viewer_state
+        self.viewer_state = viewer_state
 
-        link_glue_choices(self, viewer_state, 'x_att')
+        autoconnect_callbacks_to_vue(viewer_state, self)
+
+        # Properties only used in JS, not bound to a Vue component
+        connect_bool(viewer_state, 'normalize', self)
+        connect_bool(viewer_state, 'cumulative', self)
 
     def vue_bins_to_axis(self, *args):
-        self.glue_state.update_bins_to_view()
+        self.viewer_state.update_bins_to_view()

--- a/glue_jupyter/common/state_widgets/viewer_histogram.vue
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.vue
@@ -4,13 +4,13 @@
             <v-select :items="x_att_items" label="x axis" v-model="x_att_selected"/>
         </div>
         <div>
-            <v-text-field type="number" step="1" label="number of bins" v-model="glue_state.hist_n_bin" />
+            <v-text-field type="number" step="1" label="number of bins" v-model="hist_n_bin" />
         </div>
         <div>
-            <glue-float-field label="x-min" :value.sync="glue_state.hist_x_min" />
+            <glue-float-field label="x-min" :value.sync="hist_x_min" echo-type="value" />
         </div>
         <div>
-            <glue-float-field label="x-max" :value.sync="glue_state.hist_x_max" />
+            <glue-float-field label="x-max" :value.sync="hist_x_max" echo-type="value" />
         </div>
         <div>
             <v-toolbar density="compact" >
@@ -36,20 +36,20 @@
                   </v-btn>
             </v-toolbar>
         </div>
-        <v-switch v-model="glue_state.show_axes" label="Show axes" hide-details/>
+        <v-switch v-model="show_axes" label="Show axes" hide-details/>
     </div>
 </template>
 <script>
     module.exports = {
         computed: {
             modeSet() {
-                return [this.glue_state.normalize && 'normalize', this.glue_state.cumulative && 'cumulative']
+                return [this.normalize && 'normalize', this.cumulative && 'cumulative']
             }
         },
         methods: {
             modeSetChange(v) {
-                this.glue_state.normalize = v.includes('normalize');
-                this.glue_state.cumulative = v.includes('cumulative');
+                this.normalize = v.includes('normalize');
+                this.cumulative = v.includes('cumulative');
             }
         }
     }

--- a/glue_jupyter/common/state_widgets/viewer_histogram.vue
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.vue
@@ -4,53 +4,25 @@
             <v-select :items="x_att_items" label="x axis" v-model="x_att_selected"/>
         </div>
         <div>
-            <v-text-field type="number" step="1" label="number of bins" v-model="hist_n_bin" />
+            <v-text-field type="number" step="1" label="number of bins" v-model.number="hist_n_bin" />
         </div>
         <div>
-            <glue-float-field label="x-min" :value.sync="hist_x_min" echo-type="number" />
+            <glue-float-field label="x-min" :value.sync="hist_x_min" echo-type="float" />
         </div>
         <div>
-            <glue-float-field label="x-max" :value.sync="hist_x_max" echo-type="number" />
+            <glue-float-field label="x-max" :value.sync="hist_x_max" echo-type="float" />
         </div>
         <div>
-            <v-toolbar density="compact" >
-                  <v-tooltip>
-                    <template v-slot:activator="{ on }">
-                         <v-btn v-on="on" size="x-small" value="normalize">
-                             <v-icon>unfold_more</v-icon>
-                         </v-btn>
-                     </template>
-                    <span>normalize</span>
-                  </v-tooltip>
-                  <v-tooltip bottom>
-                    <template v-slot:activator="{ on }">
-                        <v-btn v-on="on" size="x-small" value="cumulative">
-                            <v-icon>trending_up</v-icon>
-                        </v-btn>
-                    </template>
-                    <span>cumulative</span>
-                  </v-tooltip>
-
-                  <v-btn variant="outlined" size="x-small" @click="bins_to_axes">
-                      Fit Bins to Axes
-                  </v-btn>
-            </v-toolbar>
+            <v-switch v-model="normalize" label="Normalize" hide-details/>
+        </div>
+        <div>
+            <v-switch v-model="cumulative" label="Cumulative" hide-details/>
+        </div>
+        <div>
+            <v-btn variant="outlined" size="x-small" @click="bins_to_axis">
+                Fit Bins to Axes
+            </v-btn>
         </div>
         <v-switch v-model="show_axes" label="Show axes" hide-details/>
     </div>
 </template>
-<script>
-    module.exports = {
-        computed: {
-            modeSet() {
-                return [this.normalize && 'normalize', this.cumulative && 'cumulative']
-            }
-        },
-        methods: {
-            modeSetChange(v) {
-                this.normalize = v.includes('normalize');
-                this.cumulative = v.includes('cumulative');
-            }
-        }
-    }
-</script>

--- a/glue_jupyter/common/state_widgets/viewer_histogram.vue
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.vue
@@ -7,10 +7,10 @@
             <v-text-field type="number" step="1" label="number of bins" v-model="hist_n_bin" />
         </div>
         <div>
-            <glue-float-field label="x-min" :value.sync="hist_x_min" echo-type="value" />
+            <glue-float-field label="x-min" :value.sync="hist_x_min" echo-type="number" />
         </div>
         <div>
-            <glue-float-field label="x-max" :value.sync="hist_x_max" echo-type="value" />
+            <glue-float-field label="x-max" :value.sync="hist_x_max" echo-type="number" />
         </div>
         <div>
             <v-toolbar density="compact" >

--- a/glue_jupyter/common/state_widgets/viewer_image.py
+++ b/glue_jupyter/common/state_widgets/viewer_image.py
@@ -4,7 +4,6 @@ import ipyvuetify as v
 import traitlets
 
 from echo.vue import autoconnect_callbacks_to_vue
-from echo.vue._connect import connect_text
 
 __all__ = ['ImageViewerStateWidget']
 
@@ -21,10 +20,8 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
         self.viewer_state = viewer_state
         self._updating_slices = False
 
-        autoconnect_callbacks_to_vue(viewer_state, self)
-
-        # aspect is only used in JS expressions, not bound to a known component
-        connect_text(viewer_state, 'aspect', self)
+        autoconnect_callbacks_to_vue(viewer_state, self,
+                                     extras={'aspect': 'text'})
 
         # Set up sliders for remaining dimensions
 

--- a/glue_jupyter/common/state_widgets/viewer_image.py
+++ b/glue_jupyter/common/state_widgets/viewer_image.py
@@ -12,13 +12,19 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'viewer_image.vue')
 
     sliders = traitlets.List().tag(sync=True)
+
+    # The slices property on the viewer state is a tuple with one entry per
+    # data dimension (e.g. (0, 0, 50, 100)).  The template binds each extra-
+    # dimension slider to a single element of this list.  Because autoconnect
+    # maps one property to one traitlet, it cannot handle this element-level
+    # binding, so we sync the full list manually.  Equality checks in both
+    # directions prevent infinite update cycles.
     slices = traitlets.List().tag(sync=True)
 
     def __init__(self, viewer_state):
         super().__init__()
 
         self.viewer_state = viewer_state
-        self._updating_slices = False
 
         autoconnect_callbacks_to_vue(viewer_state, self,
                                      extras={'aspect': 'text'})
@@ -48,11 +54,8 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
                 new_slices.append(self.viewer_state.slices[i])
         self.viewer_state.slices = tuple(new_slices)
 
-        self._updating_slices = True
-        try:
+        if list(self.viewer_state.slices) != self.slices:
             self.slices = list(self.viewer_state.slices)
-        finally:
-            self._updating_slices = False
 
         self.sliders = [{
             'index': i,
@@ -71,10 +74,6 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
 
     @traitlets.observe('slices')
     def _on_slices_change(self, change):
-        if self._updating_slices:
-            return
-        self._updating_slices = True
-        try:
-            self.viewer_state.slices = tuple(change['new'])
-        finally:
-            self._updating_slices = False
+        new_slices = tuple(change['new'])
+        if new_slices != self.viewer_state.slices:
+            self.viewer_state.slices = new_slices

--- a/glue_jupyter/common/state_widgets/viewer_image.py
+++ b/glue_jupyter/common/state_widgets/viewer_image.py
@@ -2,9 +2,9 @@ from glue.viewers.image.state import AggregateSlice
 from glue.core.coordinate_helpers import world_axis
 import ipyvuetify as v
 import traitlets
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices
 
+from echo.vue import autoconnect_callbacks_to_vue
+from echo.vue._connect import connect_text
 
 __all__ = ['ImageViewerStateWidget']
 
@@ -12,40 +12,19 @@ __all__ = ['ImageViewerStateWidget']
 class ImageViewerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'viewer_image.vue')
 
-    glue_state = GlueState().tag(sync=True)
-
-    color_mode_items = traitlets.List().tag(sync=True)
-    color_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    reference_data_items = traitlets.List().tag(sync=True)
-    reference_data_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    x_att_world_items = traitlets.List().tag(sync=True)
-    x_att_world_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    y_att_world_items = traitlets.List().tag(sync=True)
-    y_att_world_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     sliders = traitlets.List().tag(sync=True)
+    slices = traitlets.List().tag(sync=True)
 
     def __init__(self, viewer_state):
         super().__init__()
 
         self.viewer_state = viewer_state
-        self.glue_state = viewer_state
+        self._updating_slices = False
 
-        # Set up dropdown for color mode
+        autoconnect_callbacks_to_vue(viewer_state, self)
 
-        link_glue_choices(self, viewer_state, 'color_mode')
-
-        # Set up dropdown for reference data
-
-        link_glue_choices(self, viewer_state, 'reference_data')
-
-        # Set up dropdowns for main attributes
-
-        link_glue_choices(self, viewer_state, 'x_att_world')
-        link_glue_choices(self, viewer_state, 'y_att_world')
+        # aspect is only used in JS expressions, not bound to a known component
+        connect_text(viewer_state, 'aspect', self)
 
         # Set up sliders for remaining dimensions
 
@@ -72,6 +51,12 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
                 new_slices.append(self.viewer_state.slices[i])
         self.viewer_state.slices = tuple(new_slices)
 
+        self._updating_slices = True
+        try:
+            self.slices = list(self.viewer_state.slices)
+        finally:
+            self._updating_slices = False
+
         self.sliders = [{
             'index': i,
             'label': (data.world_component_ids[i].label if data.coords
@@ -83,6 +68,16 @@ class ImageViewerStateWidget(v.VuetifyTemplate):
                                                  data,
                                                  pixel_axis=data.ndim - 1 - i,
                                                  world_axis=data.ndim - 1 - i
-                                                 )[self.glue_state.slices[i]] if data.coords
+                                                 )[self.viewer_state.slices[i]] if data.coords
                             else '')
         } for i in range(data.ndim) if (not used_on_axis(i) and data.shape[i] > 1)]
+
+    @traitlets.observe('slices')
+    def _on_slices_change(self, change):
+        if self._updating_slices:
+            return
+        self._updating_slices = True
+        try:
+            self.viewer_state.slices = tuple(change['new'])
+        finally:
+            self._updating_slices = False

--- a/glue_jupyter/common/state_widgets/viewer_image.vue
+++ b/glue_jupyter/common/state_widgets/viewer_image.vue
@@ -9,11 +9,11 @@
         <div class="glue-viewer-image-switches">
             <div>
                 <v-subheader class="pl-0 slider-label">equal aspect ratio</v-subheader>
-                <v-switch input-value="glue_state.aspect === EQUAL" @change="setEqualAspect" hide-details style="margin-top: 0" />
+                <v-switch :input-value="aspect === 'equal'" @change="setEqualAspect" hide-details style="margin-top: 0" />
             </div>
             <div>
                 <v-subheader class="pl-0 slider-label">show axes</v-subheader>
-                <v-switch v-model="glue_state.show_axes" hide-details style="margin-top: 0"/>
+                <v-switch v-model="show_axes" hide-details style="margin-top: 0"/>
             </div>
         </div>
         <div>
@@ -23,22 +23,23 @@
             <v-select label="y axis" :items="y_att_world_items" v-model="y_att_world_selected" hide-details style="margin-bottom: 16px" />
         </div>
         <div v-for="slider of sliders">
-            <v-subheader class="pl-0 slider-label">{{ slider.label }}: {{ glue_state.slices[slider.index] }} ({{  slider.world_value  }} {{ slider.unit }})</v-subheader>
+            <v-subheader class="pl-0 slider-label">{{ slider.label }}: {{ slices[slider.index] }} ({{  slider.world_value  }} {{ slider.unit }})</v-subheader>
             <glue-throttled-slider
-                v-if="glue_state.slices && glue_state.slices.length > 0"
-                wait="300" :max="slider.max" :value.sync="glue_state.slices[slider.index]" hide-details />
+                v-if="slices && slices.length > 0"
+                wait="300" :max="slider.max" :value="slices[slider.index]" @update:value="updateSlice(slider.index, $event)" hide-details />
         </div>
     </div>
 </template>
 <script>
     modules.export = {
-        created() {
-            this.EQUAL = 'equal';
-            this.AUTO = 'auto';
-        },
         methods: {
             setEqualAspect(value) {
-                this.glue_state.aspect = value ? this.EQUAL : this.AUTO;
+                this.aspect = value ? 'equal' : 'auto';
+            },
+            updateSlice(index, value) {
+                var newSlices = this.slices.slice();
+                newSlices[index] = value;
+                this.slices = newSlices;
             },
         }
     }

--- a/glue_jupyter/common/state_widgets/viewer_profile.py
+++ b/glue_jupyter/common/state_widgets/viewer_profile.py
@@ -1,7 +1,6 @@
 import ipyvuetify as v
 
 from echo.vue import autoconnect_callbacks_to_vue
-from echo.vue._connect import connect_bool
 
 __all__ = ['ProfileViewerStateWidget']
 
@@ -14,7 +13,5 @@ class ProfileViewerStateWidget(v.VuetifyTemplate):
 
         self.viewer_state = viewer_state
 
-        autoconnect_callbacks_to_vue(viewer_state, self)
-
-        # Property only used in JS, not bound to a Vue component
-        connect_bool(viewer_state, 'normalize', self)
+        autoconnect_callbacks_to_vue(viewer_state, self,
+                                     extras={'normalize': 'bool'})

--- a/glue_jupyter/common/state_widgets/viewer_profile.py
+++ b/glue_jupyter/common/state_widgets/viewer_profile.py
@@ -1,7 +1,7 @@
 import ipyvuetify as v
-import traitlets
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices
+
+from echo.vue import autoconnect_callbacks_to_vue
+from echo.vue._connect import connect_bool
 
 __all__ = ['ProfileViewerStateWidget']
 
@@ -9,30 +9,12 @@ __all__ = ['ProfileViewerStateWidget']
 class ProfileViewerStateWidget(v.VuetifyTemplate):
     template_file = (__file__, 'viewer_profile.vue')
 
-    glue_state = GlueState().tag(sync=True)
-
-    reference_data_items = traitlets.List().tag(sync=True)
-    reference_data_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    x_att_items = traitlets.List().tag(sync=True)
-    x_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    function_items = traitlets.List().tag(sync=True)
-    function_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    x_display_unit_items = traitlets.List().tag(sync=True)
-    x_display_unit_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    y_display_unit_items = traitlets.List().tag(sync=True)
-    y_display_unit_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     def __init__(self, viewer_state):
         super().__init__()
 
-        self.glue_state = viewer_state
+        self.viewer_state = viewer_state
 
-        link_glue_choices(self, viewer_state, 'reference_data')
-        link_glue_choices(self, viewer_state, 'x_att')
-        link_glue_choices(self, viewer_state, 'function')
-        link_glue_choices(self, viewer_state, 'x_display_unit')
-        link_glue_choices(self, viewer_state, 'y_display_unit')
+        autoconnect_callbacks_to_vue(viewer_state, self)
+
+        # Property only used in JS, not bound to a Vue component
+        connect_bool(viewer_state, 'normalize', self)

--- a/glue_jupyter/common/state_widgets/viewer_profile.vue
+++ b/glue_jupyter/common/state_widgets/viewer_profile.vue
@@ -30,7 +30,7 @@
 
             </v-btn-toggle>
 
-            <v-switch v-model="glue_state.show_axes" label="Show axes" hide-details style="margin-top: 0"/>
+            <v-switch v-model="show_axes" label="Show axes" hide-details style="margin-top: 0"/>
         </div>
     </div>
 </template>
@@ -39,12 +39,12 @@
     module.exports = {
         computed: {
             modeSet() {
-                return [this.glue_state.normalize && 'normalize']
+                return [this.normalize && 'normalize']
             }
         },
         methods: {
             modeSetChange(v) {
-                this.glue_state.normalize = v.includes('normalize');
+                this.normalize = v.includes('normalize');
             }
         }
     }

--- a/glue_jupyter/common/state_widgets/viewer_scatter.py
+++ b/glue_jupyter/common/state_widgets/viewer_scatter.py
@@ -1,8 +1,6 @@
 import ipyvuetify as v
-import traitlets
 
-from ...state_traitlets_helpers import GlueState
-from ...vuetify_helpers import link_glue_choices
+from echo.vue import autoconnect_callbacks_to_vue
 
 __all__ = ["ScatterViewerStateWidget"]
 
@@ -11,20 +9,10 @@ class ScatterViewerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "viewer_scatter.vue")
 
-    glue_state = GlueState().tag(sync=True)
-
-    x_att_items = traitlets.List().tag(sync=True)
-    x_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    y_att_items = traitlets.List().tag(sync=True)
-    y_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     def __init__(self, viewer_state):
 
         super().__init__()
 
         self.viewer_state = viewer_state
-        self.glue_state = viewer_state
 
-        link_glue_choices(self, viewer_state, "x_att")
-        link_glue_choices(self, viewer_state, "y_att")
+        autoconnect_callbacks_to_vue(viewer_state, self)

--- a/glue_jupyter/common/state_widgets/viewer_scatter.vue
+++ b/glue_jupyter/common/state_widgets/viewer_scatter.vue
@@ -8,7 +8,7 @@
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">show axes</v-subheader>
-            <v-switch v-model="glue_state.show_axes" hide-details style="margin-top: 0"/>
+            <v-switch v-model="show_axes" hide-details style="margin-top: 0"/>
         </div>
     </div>
 </template>

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -7,7 +7,5 @@
   "glue_jupyter.tests.ui.test_selection.test_elliptical_selection[chromium]": "de3e144d9c57a972fc0ab29075ae1d39fb49326955b2c3af803c10c50847036d",
   "glue_jupyter.tests.ui.test_selection.test_elliptical_selection_rotate[chromium]": "7c47211f5150ef19db0171a72f9af8ec25a66ded53cf86320776c0dbe9471bed",
   "glue_jupyter.tests.ui.test_selection.test_rectangular_selection[chromium]": "14a2acd27fb61e0ae1f40ac285d9020858d63727848d39269b96aa46635cf7a5",
-  "glue_jupyter.tests.ui.test_selection.test_rectangular_selection_rotate[chromium]": "a7c5bfda37992da1b8ecc5cf40bd836793a212b95d7bbca67871eeb495048c05",
-  "glue_jupyter.tests.ui.test_selection_handles.test_elliptical_selection_handles_rotate[chromium]": "51baba2a6134b8fda922a473cb61b768031f2bb5097e5bac558d3671309beb6d",
-  "glue_jupyter.tests.ui.test_selection_handles.test_rectangular_selection_handles_rotate[chromium]": "0f95d0c9e32937449fbe769fb97e85fda1a670fa868282d608a10169639cb248"
+  "glue_jupyter.tests.ui.test_selection.test_rectangular_selection_rotate[chromium]": "a7c5bfda37992da1b8ecc5cf40bd836793a212b95d7bbca67871eeb495048c05"
 }

--- a/glue_jupyter/tests/test_vuetify_helpers.py
+++ b/glue_jupyter/tests/test_vuetify_helpers.py
@@ -1,0 +1,76 @@
+import traitlets
+
+from glue.config import colormaps
+from glue.core.state_objects import State, CallbackProperty
+from echo import SelectionCallbackProperty
+
+from glue_jupyter.vuetify_helpers import _name_to_cmap, link_glue, link_glue_choices
+
+
+def test_name_to_cmap():
+    # Check that a known colormap can be found by name
+    _, expected_cmap = colormaps.members[0]
+    assert _name_to_cmap(expected_cmap.name) is expected_cmap
+    # Check that an unknown name returns None
+    assert _name_to_cmap('not_a_real_colormap_name') is None
+
+
+class SimpleWidget(traitlets.HasTraits):
+    value = traitlets.Float(0)
+
+
+class SimpleState(State):
+    value = CallbackProperty(0)
+
+
+def test_link_glue():
+    widget = SimpleWidget()
+    state = SimpleState()
+    state.value = 5.0
+
+    link_glue(widget, 'value', state)
+
+    # Initial sync from state to widget
+    assert widget.value == 5.0
+
+    # State -> widget
+    state.value = 10.0
+    assert widget.value == 10.0
+
+    # Widget -> state
+    widget.value = 20.0
+    assert state.value == 20.0
+
+
+class ChoiceState(State):
+    x = SelectionCallbackProperty(default_index=0)
+
+
+class ChoiceWidget(traitlets.HasTraits):
+    x_items = traitlets.List()
+    x_selected = traitlets.Any()
+
+
+def test_link_glue_choices():
+    state = ChoiceState()
+    ChoiceState.x.set_choices(state, ['a', 'b', 'c'])
+    ChoiceState.x.set_display_func(state, lambda x: x.upper())
+
+    widget = ChoiceWidget()
+    link_glue_choices(widget, state, 'x')
+
+    # Items should be populated with display labels
+    assert len(widget.x_items) == 3
+    assert widget.x_items[0] == {'text': 'A', 'value': 0}
+    assert widget.x_items[2] == {'text': 'C', 'value': 2}
+
+    # Selected should reflect current state (index 0)
+    assert widget.x_selected == 0
+
+    # Changing state selection should update widget
+    state.x = 'b'
+    assert widget.x_selected == 1
+
+    # Changing widget selection should update state
+    widget.x_selected = 2
+    assert state.x == 'c'

--- a/glue_jupyter/tests/ui/test_selection.py
+++ b/glue_jupyter/tests/ui/test_selection.py
@@ -35,7 +35,7 @@ def test_elliptical_selection(solara_test, page_session):
     return plot.screenshot()
 
 
-@visual_ui_test(tolerance=1)
+@visual_ui_test(tolerance=1, skip_hash=True)
 def test_elliptical_selection_rotate(solara_test, page_session):
     app, viewer, plot = create_viewer(page_session)
 
@@ -88,7 +88,7 @@ def test_rectangular_selection(solara_test, page_session):
     return plot.screenshot()
 
 
-@visual_ui_test(tolerance=1)
+@visual_ui_test(tolerance=1, skip_hash=True)
 def test_rectangular_selection_rotate(solara_test, page_session):
     app, viewer, plot = create_viewer(page_session)
 

--- a/glue_jupyter/tests/ui/test_selection.py
+++ b/glue_jupyter/tests/ui/test_selection.py
@@ -18,19 +18,19 @@ def test_elliptical_selection(solara_test, page_session):
     page_session.mouse.move(240, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x, center_y)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
     page_session.pause()
     return plot.screenshot()
 
@@ -43,22 +43,22 @@ def test_elliptical_selection_rotate(solara_test, page_session):
     page_session.mouse.move(240, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x, center_y)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     rotate(45, app, viewer)
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -71,19 +71,19 @@ def test_rectangular_selection(solara_test, page_session):
     page_session.mouse.move(135, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x - selection_width / 2, center_y - selection_height / 2)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -96,22 +96,22 @@ def test_rectangular_selection_rotate(solara_test, page_session):
     page_session.mouse.move(135, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x - selection_width / 2, center_y - selection_height / 2)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     rotate(45, app, viewer)
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -142,7 +142,7 @@ def create_viewer(page_session):
 
     plot = page_session.locator(".jp-OutputArea-output")
     plot.wait_for()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
     return app, viewer, plot
 
 

--- a/glue_jupyter/tests/ui/test_selection_handles.py
+++ b/glue_jupyter/tests/ui/test_selection_handles.py
@@ -46,7 +46,7 @@ def test_elliptical_selection_handles(solara_test, page_session):
     return plot.screenshot()
 
 
-@visual_ui_test(tolerance=1)
+@visual_ui_test(tolerance=1, skip_hash=True)
 def test_elliptical_selection_handles_rotate(solara_test, page_session):
     app, viewer, plot = create_viewer(page_session)
 
@@ -99,7 +99,7 @@ def test_rectangular_selection_handles(solara_test, page_session):
     return plot.screenshot()
 
 
-@visual_ui_test(tolerance=1)
+@visual_ui_test(tolerance=1, skip_hash=True)
 def test_rectangular_selection_handles_rotate(solara_test, page_session):
     app, viewer, plot = create_viewer(page_session)
 

--- a/glue_jupyter/tests/ui/test_selection_handles.py
+++ b/glue_jupyter/tests/ui/test_selection_handles.py
@@ -29,19 +29,19 @@ def test_elliptical_selection_handles(solara_test, page_session):
     page_session.mouse.move(240, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x, center_y)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
     page_session.pause()
     return plot.screenshot()
 
@@ -54,22 +54,22 @@ def test_elliptical_selection_handles_rotate(solara_test, page_session):
     page_session.mouse.move(240, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x, center_y)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     rotate(45, app, viewer)
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -82,19 +82,19 @@ def test_rectangular_selection_handles(solara_test, page_session):
     page_session.mouse.move(135, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x - selection_width / 2, center_y - selection_height / 2)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -107,22 +107,22 @@ def test_rectangular_selection_handles_rotate(solara_test, page_session):
     page_session.mouse.move(135, 31)
     page_session.mouse.down()
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     center_x, center_y = center_of_element(page_session, ".bqplot")
 
     # mouse down on center of plot
     page_session.mouse.move(center_x - selection_width / 2, center_y - selection_height / 2)
     page_session.mouse.down()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     # move right and down and release mouse
     page_session.mouse.move(center_x + selection_width / 2, center_y + selection_height / 2)
     page_session.mouse.up()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     rotate(45, app, viewer)
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
 
     return plot.screenshot()
 
@@ -153,7 +153,7 @@ def create_viewer(page_session):
 
     plot = page_session.locator(".jp-OutputArea-output")
     plot.wait_for()
-    page_session.wait_for_timeout(100)
+    page_session.wait_for_timeout(500)
     return app, viewer, plot
 
 

--- a/glue_jupyter/vuetify_helpers.py
+++ b/glue_jupyter/vuetify_helpers.py
@@ -1,3 +1,7 @@
+import traitlets
+
+from glue.config import colormaps
+
 from .widgets.linked_dropdown import get_choices
 
 
@@ -46,6 +50,30 @@ def link_glue_choices(widget, state, prop):
     link_glue(widget, f'{prop}_selected', state, prop,
               from_glue_fn=choice_to_index,
               to_glue_fn=index_to_choice)
+
+
+def _cmap_to_name(cmap):
+    return cmap.name if cmap is not None else ''
+
+
+def _name_to_cmap(name):
+    for _, member_cmap in colormaps.members:
+        if member_cmap.name == name:
+            return member_cmap
+    return None
+
+
+def cmap_extras(widget):
+    """
+    Set up colormap items on ``widget`` and return an extras tuple
+    suitable for ``autoconnect_callbacks_to_vue``.
+    """
+    if not widget.has_trait('cmap_items'):
+        widget.add_traits(cmap_items=traitlets.List().tag(sync=True))
+    widget.cmap_items = [
+        {'text': name, 'value': cmap.name} for name, cmap in colormaps.members
+    ]
+    return ('text', _cmap_to_name, _name_to_cmap)
 
 
 class WidgetCache():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ filterwarnings = [
     "ignore:Image.Image.getdata is deprecated and will be removed in Pillow 14 .2027-10.*:DeprecationWarning:pixelmatch.*:",
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
     "ignore:remove second argument of ws_handler:DeprecationWarning",
-    "ignore:.*Sentinel is not a public part of the traitlets API.*:DeprecationWarning:",
+    "ignore:((.|\n)*)Sentinel is not a public part of the traitlets API((.|\n)*)",
     "ignore:.*metadata.*was set from the constructor.*:DeprecationWarning:",
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,12 @@ namespaces = false
 [tool.setuptools_scm]
 version_file = "glue_jupyter/_version.py"
 
+[tool.coverage.run]
+omit = [
+    "*/tests/*",
+    "*/test_*",
+]
+
 [tool.pytest.ini_options]
 addopts = "-m 'not notebook'"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ version_file = "glue_jupyter/_version.py"
 addopts = "-m 'not notebook'"
 markers = [
     "notebook: marks tests as notebook tests (deselected by default, run with '-m notebook')",
+    "mpl_image_compare",
 ]
 filterwarnings = [
     "error:::echo.*:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ markers = [
     "notebook: marks tests as notebook tests (deselected by default, run with '-m notebook')",
 ]
 filterwarnings = [
+    "error:::echo.*:",
     "error::DeprecationWarning",
     "ignore:`BqplotScatterLayerState` is deprecated and will be removed in a future version.*:DeprecationWarning:glue_jupyter.bqplot.*:",
     "ignore:metadata .* was set from the constructor:DeprecationWarning:bqscales.*:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ authors = [
 ]
 
 dependencies = [
+    "echo>=0.14.0",
     "glue-core>=1.25.0",
     "ipympl>=0.3.0",
     "ipyvolume>=0.6.0",


### PR DESCRIPTION
This is a pretty major change internally though it should hopefully not have any impact on user-space.

Currently whenever a callback property changes in glue on a viewer or layer state, we sync the whole viewer or layer state to the frontend, and vice versa.

The idea is to replace this with atomic connections between vue properties and glue state properties. To enable this, I've worked on glue-viz/echo#56 which provides a similar interface to what we use in Qt - an autoconnect function that can take an ipyvuetify widget connected to a template and parse the template to figure out what the properties are and then create traits on the widget automatically and connect these to glue callback properties. To give an example of a change, since the diffs are a bit hard to read:

**Scatter layer before**

```python
import ipyvuetify as v
import traitlets

from glue.config import colormaps

from ...state_traitlets_helpers import GlueState
from ...vuetify_helpers import link_glue, link_glue_choices

__all__ = ["ScatterLayerStateWidget"]


class ScatterLayerStateWidget(v.VuetifyTemplate):

    template_file = (__file__, "layer_scatter.vue")

    glue_state = GlueState().tag(sync=True)

    # Color

    cmap_mode_items = traitlets.List().tag(sync=True)
    cmap_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)

    cmap_att_items = traitlets.List().tag(sync=True)
    cmap_att_selected = traitlets.Int(allow_none=True).tag(sync=True)

    cmap_items = traitlets.List().tag(sync=True)

    # Points

    points_mode_items = traitlets.List().tag(sync=True)
    points_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)

    size_mode_items = traitlets.List().tag(sync=True)
    size_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)

    size_att_items = traitlets.List().tag(sync=True)
    size_att_selected = traitlets.Int(allow_none=True).tag(sync=True)

    dpi = traitlets.Float().tag(sync=True)

    # Line

    linestyle_items = traitlets.List().tag(sync=True)
    linestyle_selected = traitlets.Int(allow_none=True).tag(sync=True)

    # Vectors

    vx_att_items = traitlets.List().tag(sync=True)
    vx_att_selected = traitlets.Int(allow_none=True).tag(sync=True)

    vy_att_items = traitlets.List().tag(sync=True)
    vy_att_selected = traitlets.Int(allow_none=True).tag(sync=True)

    vector_origin_items = traitlets.List().tag(sync=True)
    vector_origin_selected = traitlets.Int(allow_none=True).tag(sync=True)

    def __init__(self, layer_state):
        super().__init__()

        self.layer_state = layer_state
        self.glue_state = layer_state

        # Color

        link_glue_choices(self, layer_state, "cmap_mode")
        link_glue_choices(self, layer_state, "cmap_att")

        self.cmap_items = [
            {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
        ]

        # Points

        link_glue_choices(self, layer_state, "points_mode")
        link_glue_choices(self, layer_state, "size_mode")
        link_glue_choices(self, layer_state, "size_att")

        link_glue(self, "dpi", layer_state.viewer_state)

        # Line

        link_glue_choices(self, layer_state, "linestyle")

        # Vectors

        link_glue_choices(self, layer_state, "vx_att")
        link_glue_choices(self, layer_state, "vy_att")
        link_glue_choices(self, layer_state, "vector_origin")

    def vue_set_colormap(self, data):
        cmap = None
        for member in colormaps.members:
            if member[1].name == data:
                cmap = member[1]
                break
        self.layer_state.cmap = cmap
```

**Scatter layer after**

```python
import ipyvuetify as v

from echo.vue import autoconnect_callbacks_to_vue

from ...vuetify_helpers import cmap_extras

__all__ = ["ScatterLayerStateWidget"]


class ScatterLayerStateWidget(v.VuetifyTemplate):

    template_file = (__file__, "layer_scatter.vue")

    def __init__(self, layer_state):
        super().__init__()

        self.layer_state = layer_state

        autoconnect_callbacks_to_vue(layer_state, self,
                                     extras={'density_map': 'bool',
                                             'cmap': cmap_extras(self)},
                                     skip={'dpi'})

        autoconnect_callbacks_to_vue(layer_state.viewer_state, self,
                                     only={'dpi': 'float'})
```

We avoid a lot of boilerplate code!

By doing this, we will avoid issues that have come up as part of https://github.com/glue-viz/glue-jupyter/pull/528 and https://github.com/glue-viz/glue-jupyter/pulls whereby there were issues if we received an update to e.g. ``x_log`` from the front-end, which triggered a change in ``x_min``/``x_max`` glue-side which then got overwritten by the ``x_min``/``x_max`` coming from the frontend even though the only front-end change was ``x_log``. So with the changes here, we should avoid this - properties are synced individually to/from glue.

We could also deprecate the whole ``GlueState`` infrastructure now in principle. However, I think this is best done in a separate PR and I think we should first make sure e.g. jdaviz can use the new approach first (since jdaviz uses GlueState at least in one place).