### PR TITLE
Implement support for log axes in the histogram viewer

### DIFF
--- a/glue_jupyter/bqplot/histogram/layer_artist.py
+++ b/glue_jupyter/bqplot/histogram/layer_artist.py
@@ -22,13 +22,28 @@ class BqplotHistogramLayerArtist(LayerArtist):
 
         self.view = view
 
-        self.bars = bqplot.Bars(
-            scales=self.view.scales, x=[0, 1], y=[0, 1])
+        # Render the histogram as a single filled step polyline rather than
+        # bqplot.Bars. Bars derives each bar's width from the spacing of the
+        # `x` values it's given, so for non-uniform (e.g. log-spaced) bins
+        # the bars never quite line up with the bin edges and there are
+        # always little gaps. A Lines mark with `fill='bottom'` traces the
+        # top of the step shape and lets bqplot fill down to the axis
+        # floor, which matches matplotlib's per-rectangle hist rendering.
+        # We avoid `fill='inside'` + `close_path=True` because on log y
+        # axes the closing segment ends up at an unrenderably-low y value
+        # and bqplot draws a stray diagonal through the plot.
+        self.bars = bqplot.Lines(
+            scales=self.view.scales,
+            x=[], y=[],
+            fill='bottom',
+            stroke_width=0,
+        )
 
         self.view.figure.marks = list(self.view.figure.marks) + [self.bars]
 
         dlink((self.state, 'color'), (self.bars, 'colors'), lambda x: [color2hex(x)])
-        dlink((self.state, 'alpha'), (self.bars, 'opacities'), lambda x: [x])
+        dlink((self.state, 'color'), (self.bars, 'fill_colors'), lambda x: [color2hex(x)])
+        dlink((self.state, 'alpha'), (self.bars, 'fill_opacities'), lambda x: [x])
 
         self._viewer_state.add_global_callback(self._update_histogram)
         self.state.add_global_callback(self._update_histogram)
@@ -71,11 +86,26 @@ class BqplotHistogramLayerArtist(LayerArtist):
         elif self._viewer_state.normalize and self.hist.sum() > 0:
             self.hist /= (self.hist.sum() * dx)
 
-        # TODO this won't work for log ...
-        centers = (self.bins[:-1] + self.bins[1:]) / 2
-        assert len(centers) == len(self.hist)
-        self.bars.x = centers
-        self.bars.y = self.hist
+        # Build the step polyline that traces the TOP of the histogram:
+        #
+        #   (b0,h0) (b1,h0) (b1,h1) (b2,h1) ... (b_{N-1},h_{N-1}) (bN,h_{N-1})
+        #
+        # Together with `fill='bottom'` on the Lines mark this produces
+        # filled bars whose left/right edges sit exactly on the bin edges,
+        # so adjacent bins touch with no gaps regardless of bin spacing --
+        # including for log-spaced bins. bqplot handles the closure to the
+        # axis floor for us, so we don't have to push a baseline value to
+        # the path on log axes (which previously caused stray segments at
+        # extreme y).
+        edges = np.asarray(self.bins, dtype=float)
+        # Two points per bin (the bin's left and right edge at the bin's
+        # height), giving 2*N points in total.
+        x_path = np.empty(2 * len(self.hist))
+        x_path[0::2] = edges[:-1]
+        x_path[1::2] = edges[1:]
+        y_path = np.repeat(self.hist, 2)
+        self.bars.x = x_path
+        self.bars.y = y_path
 
         # We have to do the following to make sure that we reset the y_max as
         # needed. We can't simply reset based on the maximum for this layer

--- a/glue_jupyter/bqplot/histogram/tests/test_visual.py
+++ b/glue_jupyter/bqplot/histogram/tests/test_visual.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from glue_jupyter import jglue
+from glue_jupyter.tests.helpers import visual_widget_test
+
+
+@pytest.mark.parametrize(("x_log", "y_log"), [
+    (False, False),
+    (True, False),
+    (False, True),
+    (True, True),
+], ids=["linear", "xlog", "ylog", "xylog"])
+@visual_widget_test
+def test_visual_histogram1d_log(
+    tmp_path,
+    page_session,
+    solara_test,
+    x_log,
+    y_log,
+):
+
+    np.random.seed(12345)
+
+    x = np.random.lognormal(2, 0.7, 5000)
+
+    app = jglue()
+    data = app.add_data(a={"x": x})[0]
+    histogram = app.histogram1d(show=False, data=data)
+
+    app.data_collection.new_subset_group(
+        subset_state=data.id['x'] > np.median(x),
+        label='right half',
+    )
+
+    histogram.state.x_log = x_log
+    histogram.state.y_log = y_log
+
+    figure = histogram.figure_widget
+    figure.layout = {"width": "400px", "height": "250px"}
+    return figure

--- a/glue_jupyter/bqplot/histogram/viewer.py
+++ b/glue_jupyter/bqplot/histogram/viewer.py
@@ -31,8 +31,12 @@ class BqplotHistogramView(BqplotBaseView):
         super().__init__(*args, **kwargs)
         self.state.add_callback('x_att', self._update_axes)
         self.state.add_callback('x_log', self._update_axes)
+        self.state.add_callback('x_log', self._update_x_log)
+        self.state.add_callback('y_log', self._update_y_log)
         self.state.add_callback('normalize', self._update_axes)
         self._update_axes()
+        self._update_x_log()
+        self._update_y_log()
 
     def _update_axes(self, *args):
 
@@ -43,6 +47,18 @@ class BqplotHistogramView(BqplotBaseView):
             self.state.y_axislabel = 'Normalized number'
         else:
             self.state.y_axislabel = 'Number'
+
+    def _update_x_log(self, *args):
+        # When x_log toggles, the state's bins property switches between
+        # np.linspace and np.logspace automatically (see
+        # HistogramViewerState.bins), and the layer artist recomputes the
+        # histogram against the new bins via its x_log callback. All we have
+        # to do here is flip the LinLogScale mode so the bqplot axis renders
+        # logarithmically.
+        self._set_scale_mode('x')
+
+    def _update_y_log(self, *args):
+        self._set_scale_mode('y')
 
     def _roi_to_subset_state(self, roi):
         # TODO: copy paste from glue/viewers/histogram/qt/data_viewer.py

--- a/glue_jupyter/common/state_widgets/viewer_histogram.vue
+++ b/glue_jupyter/common/state_widgets/viewer_histogram.vue
@@ -19,6 +19,14 @@
             <v-switch v-model="cumulative" label="Cumulative" hide-details/>
         </div>
         <div>
+            <v-subheader class="pl-0 slider-label">log x axis</v-subheader>
+            <v-switch v-model="x_log" hide-details style="margin-top: 0"/>
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">log y axis</v-subheader>
+            <v-switch v-model="y_log" hide-details style="margin-top: 0"/>
+        </div>
+        <div>
             <v-btn variant="outlined" size="x-small" @click="bins_to_axis">
                 Fit Bins to Axes
             </v-btn>

--- a/glue_jupyter/tests/images/py311-test-visual-bqplot012.json
+++ b/glue_jupyter/tests/images/py311-test-visual-bqplot012.json
@@ -1,4 +1,5 @@
 {
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-linear]": "bbb2bccc0d8dd8ba16465db172b1db78dde61f9c6e3a32c75ec6e47e022c67f0",
   "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "3c03cfe2dd601d05d6bc488149eb603972196b93683edf71648df979d8407f23",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "54d966d08b4734f411abd32ff55e957f966b1fff5aa6c33b518aed48e2be0aaf",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "ecb62a88d636ea6df230a3540fb1bc166319d883b75bf5a0d118150da0d3e064",
@@ -9,9 +10,12 @@
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log_ellipse_subset[chromium]": "214281287630f557bead03ca5b46993d3c6117597459cda21debf82a7bf510e3",
   "glue_jupyter.tests.ui.test_selection.test_elliptical_selection[chromium]": "de3e144d9c57a972fc0ab29075ae1d39fb49326955b2c3af803c10c50847036d",
   "glue_jupyter.tests.ui.test_selection.test_rectangular_selection[chromium]": "14a2acd27fb61e0ae1f40ac285d9020858d63727848d39269b96aa46635cf7a5",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xlog]": "8c4a1db8d6b593b896ccc5818ba1413baceb5f944e2b56a3e8a803a4723e0844",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xlog]": "d494bd2c6ba618bf89c528c7d4865c6a1c26c9bea40723475c38e0c5e60ab812",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-ylog]": "ac8176821bdc5afff3defb508e88739ce8b7469573e1773b092070661c4e221b",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-ylog]": "be28acd2cccfa44acf7c3e4ca871d94fc70d482204d3036ed0b7e0299e8d1ee1",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-ylog]": "f4dc63374ac0e558839c078ce758aa8b8d126d77e3d0f42d3549783e2fbc9f4d",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-xylog]": "734ca7064775c5b4ad91e5f42c6aaba9073632694cef1db885f3cce19b6c6bf8",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xylog]": "980fe26d6133e7d70f8ec3be1f1ca48a653bf435354503a21e3073af95fef0db",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xylog]": "06a17b12b1d8a803dec71ff0b4d7c2aecd7f77f8b51373b8fcf40f844e194501"
 }

--- a/glue_jupyter/tests/images/py311-test-visual-dev.json
+++ b/glue_jupyter/tests/images/py311-test-visual-dev.json
@@ -1,4 +1,5 @@
 {
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-linear]": "bbb2bccc0d8dd8ba16465db172b1db78dde61f9c6e3a32c75ec6e47e022c67f0",
   "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "3c03cfe2dd601d05d6bc488149eb603972196b93683edf71648df979d8407f23",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "54d966d08b4734f411abd32ff55e957f966b1fff5aa6c33b518aed48e2be0aaf",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "ecb62a88d636ea6df230a3540fb1bc166319d883b75bf5a0d118150da0d3e064",
@@ -9,9 +10,12 @@
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log_ellipse_subset[chromium]": "214281287630f557bead03ca5b46993d3c6117597459cda21debf82a7bf510e3",
   "glue_jupyter.tests.ui.test_selection.test_elliptical_selection[chromium]": "de3e144d9c57a972fc0ab29075ae1d39fb49326955b2c3af803c10c50847036d",
   "glue_jupyter.tests.ui.test_selection.test_rectangular_selection[chromium]": "14a2acd27fb61e0ae1f40ac285d9020858d63727848d39269b96aa46635cf7a5",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xlog]": "8c4a1db8d6b593b896ccc5818ba1413baceb5f944e2b56a3e8a803a4723e0844",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xlog]": "d494bd2c6ba618bf89c528c7d4865c6a1c26c9bea40723475c38e0c5e60ab812",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-ylog]": "ac8176821bdc5afff3defb508e88739ce8b7469573e1773b092070661c4e221b",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-ylog]": "be28acd2cccfa44acf7c3e4ca871d94fc70d482204d3036ed0b7e0299e8d1ee1",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-ylog]": "f4dc63374ac0e558839c078ce758aa8b8d126d77e3d0f42d3549783e2fbc9f4d",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-xylog]": "734ca7064775c5b4ad91e5f42c6aaba9073632694cef1db885f3cce19b6c6bf8",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xylog]": "980fe26d6133e7d70f8ec3be1f1ca48a653bf435354503a21e3073af95fef0db",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xylog]": "06a17b12b1d8a803dec71ff0b4d7c2aecd7f77f8b51373b8fcf40f844e194501"
 }

--- a/glue_jupyter/tests/images/py311-test-visual.json
+++ b/glue_jupyter/tests/images/py311-test-visual.json
@@ -1,4 +1,5 @@
 {
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-linear]": "bbb2bccc0d8dd8ba16465db172b1db78dde61f9c6e3a32c75ec6e47e022c67f0",
   "glue_jupyter.bqplot.image.tests.test_visual.test_contour_units[chromium]": "3c03cfe2dd601d05d6bc488149eb603972196b93683edf71648df979d8407f23",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d[chromium]": "54d966d08b4734f411abd32ff55e957f966b1fff5aa6c33b518aed48e2be0aaf",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density[chromium]": "ecb62a88d636ea6df230a3540fb1bc166319d883b75bf5a0d118150da0d3e064",
@@ -9,9 +10,12 @@
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log_ellipse_subset[chromium]": "214281287630f557bead03ca5b46993d3c6117597459cda21debf82a7bf510e3",
   "glue_jupyter.tests.ui.test_selection.test_elliptical_selection[chromium]": "de3e144d9c57a972fc0ab29075ae1d39fb49326955b2c3af803c10c50847036d",
   "glue_jupyter.tests.ui.test_selection.test_rectangular_selection[chromium]": "14a2acd27fb61e0ae1f40ac285d9020858d63727848d39269b96aa46635cf7a5",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xlog]": "8c4a1db8d6b593b896ccc5818ba1413baceb5f944e2b56a3e8a803a4723e0844",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xlog]": "d494bd2c6ba618bf89c528c7d4865c6a1c26c9bea40723475c38e0c5e60ab812",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-ylog]": "ac8176821bdc5afff3defb508e88739ce8b7469573e1773b092070661c4e221b",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-ylog]": "be28acd2cccfa44acf7c3e4ca871d94fc70d482204d3036ed0b7e0299e8d1ee1",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-ylog]": "f4dc63374ac0e558839c078ce758aa8b8d126d77e3d0f42d3549783e2fbc9f4d",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_log[chromium-xylog]": "734ca7064775c5b4ad91e5f42c6aaba9073632694cef1db885f3cce19b6c6bf8",
+  "glue_jupyter.bqplot.histogram.tests.test_visual.test_visual_histogram1d_log[chromium-xylog]": "980fe26d6133e7d70f8ec3be1f1ca48a653bf435354503a21e3073af95fef0db",
   "glue_jupyter.bqplot.scatter.tests.test_visual.test_visual_scatter2d_density_alignment[chromium-xylog]": "06a17b12b1d8a803dec71ff0b4d7c2aecd7f77f8b51373b8fcf40f844e194501"
 }


### PR DESCRIPTION
<s>This is built on top of https://github.com/glue-viz/glue-jupyter/pull/528 and will need to be rebased once https://github.com/glue-viz/glue-jupyter/pull/528 is merged.</s> - done

<img width="1011" height="524" alt="Screenshot 2026-05-19 at 22 33 59" src="https://github.com/user-attachments/assets/5732d806-521e-490c-8e2c-9cd0688975ab" />
