### PR TITLE
[codex] document and test bqplot toolbar compatibility

### DIFF
--- a/glue_jupyter/bqplot/common/viewer.py
+++ b/glue_jupyter/bqplot/common/viewer.py
@@ -41,8 +41,13 @@ class BqplotBaseView(IPyWidgetView):
                              animation_duration=0,
                              axes=[self.axis_x, self.axis_y],
                              fig_margin={'left': 60, 'bottom': 60, 'top': 10, 'right': 10})
-        if hasattr(bqplot.Figure, 'display_toolbar'):
+
+        # bqplot 0.13 added an integrated Figure toolbar that is shown by
+        # default. Glue provides its own toolbar, and bqplot 0.12 does not know
+        # this trait, so gate on the trait API instead of the bqplot version.
+        if 'display_toolbar' in bqplot.Figure.class_traits():
             figure_kwargs['display_toolbar'] = False
+
         self.figure = bqplot.Figure(**figure_kwargs)
         self.figure.padding_y = 0
         self._fig_margin_default = self.figure.fig_margin

--- a/glue_jupyter/bqplot/tests/test_bqplot.py
+++ b/glue_jupyter/bqplot/tests/test_bqplot.py
@@ -3,13 +3,32 @@ import os
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from traitlets import Bool
 from glue.config import viewer_tool
 from glue.core import Data
 from glue.core.roi import CircularAnnulusROI, EllipticalROI
 from glue.core.subset import RoiSubsetState
+import glue_jupyter as gj
 from ..common.tools import TrueCircularROI
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def test_bqplot_integrated_toolbar_disabled_when_supported(dataxyz, monkeypatch):
+
+    from glue_jupyter.bqplot.common import viewer as common_viewer
+
+    # bqplot 0.13 adds this trait to Figure; keep the test independent from
+    # the bqplot version installed in the test environment.
+    class FigureWithIntegratedToolbar(common_viewer.bqplot.Figure):
+        display_toolbar = Bool(default_value=True).tag(sync=True)
+
+    monkeypatch.setattr(common_viewer.bqplot, 'Figure', FigureWithIntegratedToolbar)
+
+    app = gj.jglue(dataxyz=dataxyz)
+    viewer = app.scatter2d(x='x', y='y', data=dataxyz)
+
+    assert viewer.figure.display_toolbar is False
 
 
 def test_histogram1d(app, dataxyz):


### PR DESCRIPTION
## Summary

Current `main` already disables bqplot's integrated figure toolbar when `bqplot.Figure` exposes `display_toolbar`. This PR keeps that behavior and makes the compatibility path more explicit:

- check the trait API with `bqplot.Figure.class_traits()` instead of using `hasattr`
- add an inline comment explaining the bqplot 0.13 integrated toolbar change and why glue-jupyter disables it
- add a regression test that simulates a bqplot-0.13-style `Figure` where `display_toolbar` defaults to `True`

The behavior remains the same for users: bqplot 0.12 constructs figures without the unknown keyword, and bqplot 0.13 gets `display_toolbar=False` so glue-jupyter's own toolbar remains the only toolbar shown.

## Tests

- `/tmp/glue-jupyter-bqplot-toolbar-venv/bin/pytest glue_jupyter/bqplot/tests/test_bqplot.py -q` with bqplot 0.13.1: `19 passed, 1 deselected`
- `/tmp/glue-jupyter-bqplot-toolbar-venv012/bin/pytest glue_jupyter/bqplot/tests/test_bqplot.py -q` with bqplot 0.12.47: `19 passed, 1 deselected`

## Note

I attempted to create a signed commit, but this environment has no GPG secret key for `Maarten Breddels <maartenbreddels@gmail.com>`, so the commit in this PR is unsigned.