### PR TITLE
opt-in column rename/remove from table header UI

### DIFF
--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -56,8 +56,7 @@
         :class="['elevation-1', 'glue-data-table', scrollable && 'glue-data-table--scrollable']"
         :style="scrollable && height != null && `height: ${height}`"
       >
-      <template v-slot:header="props">
-        <thead>
+      <template v-slot:headers>
           <tr>
             <th :style="'padding: 0 10px; width: '+Math.max(1, Math.ceil(Math.log10(total_length)))*20+'px'">#</th>
             <th style="padding: 0 1px; width: 30px" v-if="selection_enabled">
@@ -70,28 +69,38 @@
             </th>
             <th v-for="header in headers"
                 :key="header.text"
-                @click="toggleSort(header.value)"
-                style="cursor: pointer; user-select: none;"
+                @click="onHeaderClick(header.value)"
+                @mouseenter="hoverHeader = header.value"
+                @mouseleave="hoverHeader = null"
+                style="cursor: pointer; user-select: none; padding: 0 8px; white-space: nowrap; position: relative;"
+                :style="editingHeader === header.value ? {minWidth: '240px'} : {}"
             >
               {{ header.text }}
               <v-icon v-if="options.sortBy && options.sortBy[0] === header.value">
                 {{ options.sortDesc && options.sortDesc[0] ? 'arrow_drop_down' : 'arrow_drop_up' }}
               </v-icon>
+              <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.renameable" @click.stop="enterHeaderRename(header.value)" style="cursor:pointer;margin-left:2px" title="Rename column">mdi-pencil</v-icon>
+              <v-icon size="x-small" v-if="hoverHeader === header.value && editingHeader !== header.value && header.removable" @click.stop="enterHeaderRemove(header.value)" style="cursor:pointer" title="Delete column">mdi-delete</v-icon>
+
+              <!-- Rename mode: fills the th (min-width ensures it fits) -->
+              <span v-if="editingHeader === header.value && headerMode === 'rename'" @click.stop style="position:absolute;top:0;left:0;right:0;bottom:0;display:inline-flex;align-items:center;gap:4px;background:white;padding:0 4px;z-index:1;"><input :data-header="header.value" v-model="headerEditValue" @keyup.enter.stop="acceptHeader(header.value)" @keyup.escape.stop="cancelHeader()" @click.stop class="glue-header-edit-input"/><v-icon size="x-small" @click.stop="cancelHeader()" style="cursor:pointer" title="Cancel (Esc)">mdi-close</v-icon><v-icon size="x-small" @click.stop="acceptHeader(header.value)" style="cursor:pointer" title="Accept (Enter)">mdi-check</v-icon></span>
+
+              <!-- Delete confirmation: fills the th (min-width ensures it fits) -->
+              <span v-if="editingHeader === header.value && headerMode === 'remove'" @click.stop style="position:absolute;top:0;left:0;right:0;bottom:0;display:inline-flex;align-items:center;gap:4px;background:#FFF3CD;border:1px solid #FFC107;padding:0 4px;z-index:1;font-size:11px;white-space:nowrap;"><v-icon size="x-small" style="color:#F57C00;">mdi-alert</v-icon><span>remove '{{ header.text }}'?</span><v-icon size="x-small" @click.stop="cancelHeader()" style="cursor:pointer" title="Cancel">mdi-close</v-icon><v-icon size="x-small" @click.stop="deleteHeader(header.value)" style="cursor:pointer" title="Confirm delete">mdi-delete</v-icon></span>
             </th>
           </tr>
-        </thead>
       </template>
       <template v-slot:item="props">
         <tr @click="on_row_clicked(props.item.__row__)" :class="{'highlightedRow': props.item.__row__ === highlighted}">
-          <td style="padding: 0 10px" class="text-xs-left">
+          <td style="padding: 0 10px" class="text-left">
             <i>{{ props.item.__row__ }}</i>
           </td>
-          <td style="padding: 0 1px" class="text-xs-left" v-if="selection_enabled">
+          <td style="padding: 0 1px" class="text-left" v-if="selection_enabled">
             <v-checkbox
               hide-details style="margin-top: 0; padding-top: 0"
-              :input-value="checked.indexOf(props.item.__row__) != -1"
+              :model-value="checked.indexOf(props.item.__row__) != -1"
               :key="props.item.__row__"
-              @change="(value) => select({checked: value, row: props.item.__row__})"
+              @update:modelValue="(value) => select({checked: value, row: props.item.__row__})"
             />
           </td>
           <td style="padding: 0 1px" :key="header.text" v-for="(header, index) in headers_selections">
@@ -122,10 +131,61 @@ module.exports = {
   data: function() {
     return {
       selectedCell: null,  // { row: number, column: string, editable: boolean }
-      editValue: ''
+      editValue: '',
+      hoverHeader: null,    // column value currently being hovered
+      editingHeader: null,  // column value currently in rename/remove mode
+      headerMode: null,     // 'rename' | 'remove' | null
+      headerEditValue: ''   // live text in the rename input
     };
   },
   methods: {
+    onOptionsUpdate(vuetifyOpts) {
+      // Propagate page/itemsPerPage changes to Python; sort is handled by sort_column
+      const newPage = vuetifyOpts.page;
+      const newIpp = vuetifyOpts.itemsPerPage;
+      if (newPage !== this.options.page || newIpp !== this.options.itemsPerPage) {
+        this.options = { ...this.options, page: newPage, itemsPerPage: newIpp };
+      }
+    },
+    // ---- header editing ----
+    onHeaderClick(column) {
+      if (this.editingHeader === null) { this.sort_column(column); }
+    },
+    enterHeaderRename(column) {
+      const header = this.headers.find(h => h.value === column);
+      this.headerEditValue = header ? header.text : column;
+      this.editingHeader = column;
+      this.headerMode = 'rename';
+      this.$nextTick(() => {
+        const input = this.$el.querySelector(`input[data-header="${column}"]`);
+        if (input) { input.focus(); input.select(); }
+      });
+    },
+    enterHeaderRemove(column) {
+      this.editingHeader = column;
+      this.headerMode = 'remove';
+    },
+    acceptHeader(column) {
+      const newName = this.headerEditValue.trim();
+      this.editingHeader = null;
+      this.headerMode = null;
+      this.headerEditValue = '';
+      if (newName && newName !== column) {
+        this.rename_column({ column, newName });
+      }
+    },
+    cancelHeader() {
+      this.editingHeader = null;
+      this.headerMode = null;
+      this.headerEditValue = '';
+    },
+    deleteHeader(column) {
+      this.editingHeader = null;
+      this.headerMode = null;
+      this.headerEditValue = '';
+      this.remove_column({ column });
+    },
+    // ---- cell editing ----
     toggleSort(column) {
       this.sort_column(column);
     },
@@ -300,5 +360,22 @@ module.exports = {
 .glue-cell-selected {
   background-color: #E3F2FD !important;
   box-shadow: inset 0 0 0 2px #1976D2;
+}
+
+/* ---- Column header rename / delete styles ---- */
+.glue-header-edit-input {
+  font-size: 12px;
+  border: 1px solid #90CAF9;
+  border-radius: 3px;
+  padding: 1px 5px;
+  width: 110px;
+  outline: none;
+  vertical-align: middle;
+  background: #fff;
+}
+
+.glue-header-edit-input:focus {
+  border-color: #1976D2;
+  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
 }
 </style>

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -57,6 +57,7 @@
         :style="scrollable && height != null && `height: ${height}`"
       >
       <template v-slot:headers>
+        <thead>
           <tr>
             <th :style="'padding: 0 10px; width: '+Math.max(1, Math.ceil(Math.log10(total_length)))*20+'px'">#</th>
             <th style="padding: 0 1px; width: 30px" v-if="selection_enabled">
@@ -89,6 +90,7 @@
               <span v-if="editingHeader === header.value && headerMode === 'remove'" @click.stop style="position:absolute;top:0;left:0;right:0;bottom:0;display:inline-flex;align-items:center;gap:4px;background:#FFF3CD;border:1px solid #FFC107;padding:0 4px;z-index:1;font-size:11px;white-space:nowrap;"><v-icon size="x-small" style="color:#F57C00;">mdi-alert</v-icon><span>remove '{{ header.text }}'?</span><v-icon size="x-small" @click.stop="cancelHeader()" style="cursor:pointer" title="Cancel">mdi-close</v-icon><v-icon size="x-small" @click.stop="deleteHeader(header.value)" style="cursor:pointer" title="Confirm delete">mdi-delete</v-icon></span>
             </th>
           </tr>
+        </thead>
       </template>
       <template v-slot:item="props">
         <tr @click="on_row_clicked(props.item.__row__)" :class="{'highlightedRow': props.item.__row__ === highlighted}">

--- a/glue_jupyter/table/table.vue
+++ b/glue_jupyter/table/table.vue
@@ -46,7 +46,6 @@
     <v-slide-x-transition appear>
       <v-data-table
         dense
-        hide-default-header
         :headers="[...headers]"
         :items="items"
         :footer-props="{'items-per-page-options': [10,20,50,100]}"

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -28,24 +28,15 @@ class TableState(ViewerState):
 
     def is_editable(self, component_id):
         """Check if a component is editable using identity comparison."""
-        for editable_cid in self.editable_components:
-            if component_id is editable_cid:
-                return True
-        return False
+        return component_id in self.editable_components
 
     def is_renameable(self, component_id):
         """Check if a component can be renamed."""
-        for cid in self.renameable_components:
-            if component_id is cid:
-                return True
-        return False
+        return component_id in self.renameable_components
 
     def is_removable(self, component_id):
         """Check if a component can be removed from the table."""
-        for cid in self.removable_components:
-            if component_id is cid:
-                return True
-        return False
+        return component_id in self.removable_components
 
 
 class TableBase(v.VuetifyTemplate):

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -23,11 +23,27 @@ ICONS_DIR = os.path.join(os.path.dirname(__file__), '..', 'icons')
 class TableState(ViewerState):
     hidden_components = ListCallbackProperty(docstring='Attributes to hide in the table display')
     editable_components = ListCallbackProperty(docstring='Attributes that can be edited in the table')
+    renameable_components = ListCallbackProperty(docstring='Attributes whose column can be renamed')
+    removable_components = ListCallbackProperty(docstring='Attributes whose column can be removed from the table')
 
     def is_editable(self, component_id):
         """Check if a component is editable using identity comparison."""
         for editable_cid in self.editable_components:
             if component_id is editable_cid:
+                return True
+        return False
+
+    def is_renameable(self, component_id):
+        """Check if a component can be renamed."""
+        for cid in self.renameable_components:
+            if component_id is cid:
+                return True
+        return False
+
+    def is_removable(self, component_id):
+        """Check if a component can be removed from the table."""
+        for cid in self.removable_components:
+            if component_id is cid:
                 return True
         return False
 
@@ -205,8 +221,13 @@ class TableGlue(TableBase):
             {
                 'text': str(k),
                 'value': str(k),
+                # Vuetify 3 renamed 'text' > 'title' and 'value' > 'key'
+                'title': str(k),
+                'key': str(k),
                 'sortable': True,
-                'editable': self.state is not None and self.state.is_editable(k)
+                'editable': self.state is not None and self.state.is_editable(k),
+                'renameable': self.state is not None and self.state.is_renameable(k),
+                'removable': self.state is not None and self.state.is_removable(k),
             }
             for k in components
         ]
@@ -346,6 +367,38 @@ class TableGlue(TableBase):
 
         # Refresh table
         self._update_items()
+
+    def vue_rename_column(self, data):
+        """User accepted a column rename in the header text-input.
+
+        Directly renames the component in the current glue Data object.
+        """
+        old_name = data.get('column', '')
+        new_name = data.get('newName', '').strip()
+        if not old_name or not new_name or old_name == new_name:
+            return
+        if self.data is not None and old_name in [c.label for c in self.data.main_components]:
+            self.data.id[old_name].label = new_name
+            self._update()
+
+    def vue_remove_column(self, data):
+        """User confirmed a column deletion via the remove-confirm badge."""
+        label = data.get('column', '')
+        if not label or self.data is None:
+            return
+        if label in [c.label for c in self.data.main_components]:
+            cid = self.data.id[label]
+            self.state.editable_components = [
+                c for c in self.state.editable_components if c is not cid
+            ]
+            self.state.renameable_components = [
+                c for c in self.state.renameable_components if c is not cid
+            ]
+            self.state.removable_components = [
+                c for c in self.state.removable_components if c is not cid
+            ]
+            self.data.remove_component(cid)
+            self._update()
 
 
 class TableLayerState(LayerState):
@@ -491,6 +544,8 @@ class TableViewer(IPyWidgetView):
         self.create_layout()
         self.state.add_callback('hidden_components', self._update_hidden)
         self.state.add_callback('editable_components', self._update_editable)
+        self.state.add_callback('renameable_components', self._update_renameable)
+        self.state.add_callback('removable_components', self._update_removable)
 
     def create_layout(self):
         # Override to pass viewer instead of just state
@@ -507,6 +562,12 @@ class TableViewer(IPyWidgetView):
         self.redraw()
 
     def _update_editable(self, *args):
+        self.widget_table._update_columns()
+
+    def _update_renameable(self, *args):
+        self.widget_table._update_columns()
+
+    def _update_removable(self, *args):
         self.widget_table._update_columns()
 
     def redraw(self):

--- a/glue_jupyter/table/viewer.py
+++ b/glue_jupyter/table/viewer.py
@@ -368,6 +368,12 @@ class TableGlue(TableBase):
         # Refresh table
         self._update_items()
 
+    def add_column_renamed_callback(self, fn):
+        """Register a callback invoked with (old_name, new_name) after a column rename."""
+        if not hasattr(self, '_column_renamed_callbacks'):
+            self._column_renamed_callbacks = []
+        self._column_renamed_callbacks.append(fn)
+
     def vue_rename_column(self, data):
         """User accepted a column rename in the header text-input.
 
@@ -379,7 +385,15 @@ class TableGlue(TableBase):
             return
         if self.data is not None and old_name in [c.label for c in self.data.main_components]:
             self.data.id[old_name].label = new_name
+            for fn in getattr(self, '_column_renamed_callbacks', []):
+                fn(old_name, new_name)
             self._update()
+
+    def add_column_removed_callback(self, fn):
+        """Register a callback invoked with (column_name,) after a column is removed."""
+        if not hasattr(self, '_column_removed_callbacks'):
+            self._column_removed_callbacks = []
+        self._column_removed_callbacks.append(fn)
 
     def vue_remove_column(self, data):
         """User confirmed a column deletion via the remove-confirm badge."""
@@ -399,6 +413,8 @@ class TableGlue(TableBase):
             ]
             self.data.remove_component(cid)
             self._update()
+        for fn in getattr(self, '_column_removed_callbacks', []):
+            fn(label)
 
 
 class TableLayerState(LayerState):


### PR DESCRIPTION
This PR implements icons in the table-viewer column headers to rename and remove columns from the data-collection entry for the corresponding table(s).  This functionality is opt-in using the same pattern as `editable_colums`.

https://github.com/user-attachments/assets/ea3102bd-fa4d-4319-b0bf-b7816aefa006

