### PR TITLE
fix throttled-slider for vue3 support

### DIFF
--- a/glue_jupyter/widgets/glue_throttled_slider.vue
+++ b/glue_jupyter/widgets/glue_throttled_slider.vue
@@ -1,7 +1,7 @@
 <template>
     <v-slider
-            :value="value"
-            @input="throttledSetValue"
+            :model-value="value"
+            @update:modelValue="throttledSetValue"
             :max="max"
             :step="step"
             :hide-details="hideDetails" />


### PR DESCRIPTION
This PR fixed glue-throttled-slider to support vue3 (not sure if we need other logic to support _both_ vue2 and vue3 or if this should be part of a larger effort to migrate to vue3 entirely).
